### PR TITLE
Add popover legend and inline trending fires

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -7,6 +7,12 @@
 .drawer.right{ position: fixed; right:0; top:0; bottom:0; width:360px; background:#0F1424; border-left:1px solid #243150; box-shadow: -8px 0 16px rgba(0,0,0,.2); padding:16px; z-index:100; }
 .hidden{ display:none; }
 
+.legend-btn{ position: sticky; left:0; bottom:0; margin:8px; background:#1F2A44; border:1px solid #34456B; border-radius:8px; padding:4px 8px; }
+
+.popover{ position:absolute; left:12px; bottom:40px; background:#0F1424; border:1px solid #34456B; padding:10px 12px; border-radius:8px; box-shadow:0 8px 16px rgba(0,0,0,.3); }
+
+.selected .fires{ filter: grayscale(1); opacity:.6; }
+
 .chip{ display:inline-flex; align-items:center; gap:6px; padding:4px 8px; border:1px solid #34456B; border-radius:999px; background:#1F2A44; color:#E5EAF5; margin:0 6px 6px 0; font-size:12px }
 .chip button{background:none;border:0;color:#A9B4D0;cursor:pointer}
 

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -179,9 +179,6 @@ body.dark #scoreInfo { background:#262a51; }
 
 <!-- Analysis panel for individual products (drawer) -->
 <div id="analysisCard" class="card" style="display:none; position:fixed; top:80px; right:0; width:350px; max-width:90%; height:calc(100% - 100px); overflow:auto; z-index:1500; box-shadow:-2px 0 8px rgba(0,0,0,0.3);"></div>
-<!-- Legend icon -->
-<div id="legendIcon" style="margin-top:5px; font-size:18px; cursor:help; color:#0077cc;" title="Fila roja: producto duplicado\n🔥 1–5: más tendencia">ℹ️</div>
-
 <div id="table-toolbar" class="table-toolbar">
   <div style="display:flex; align-items:center; gap:8px;">
     <input type="checkbox" id="selectAll">
@@ -205,8 +202,11 @@ body.dark #scoreInfo { background:#262a51; }
   </thead>
   <tbody></tbody>
 </table>
-<!-- Legend explaining row highlights and emojis -->
-<!-- Legend card will be inserted above the product table -->
+<button id="legendBtn" class="legend-btn">ℹ️</button>
+<div id="legendPop" class="popover hidden">
+  <div>• Fila roja: duplicado</div>
+  <div>• 🔥 x1–x5: tendencia en el nombre</div>
+</div>
 
 <!-- Overlay for viewing images in larger size -->
 <div id="imgOverlay" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.8); justify-content:center; align-items:center; z-index:1000;">
@@ -354,8 +354,10 @@ function renderTable() {
     cb.classList.add('rowCheck');
     cb.dataset.id = item.id;
     cb.checked = selection.has(item.id);
+    tr.classList.toggle('selected', cb.checked);
     cb.addEventListener('change', () => {
       if (cb.checked) selection.add(item.id); else selection.delete(item.id);
+      tr.classList.toggle('selected', cb.checked);
       updateMasterState();
     });
     tdSel.appendChild(cb);
@@ -404,20 +406,15 @@ function renderTable() {
         };
         td.appendChild(img);
       } else if (key === 'name' && value) {
-        // Show name text
-        const span = document.createElement('span');
-        span.textContent = value;
-        td.appendChild(span);
-        // Append trending emojis to name
-        let tCount = 0;
-        if (value) {
-          const words = value.toLowerCase().split(/[^a-z0-9áéíóúüñ]+/);
-          tCount = words.filter(w => trendingWords.includes(w)).length;
-        }
-        if (tCount > 0) {
-          const emo = document.createElement('span');
-          emo.textContent = ' ' + '🔥'.repeat(Math.min(5, tCount));
-          td.appendChild(emo);
+        const fireText = firesFor(item.trendingScore);
+        const nameSpan = document.createElement('span');
+        nameSpan.textContent = value + (fireText ? ' ' : '');
+        td.appendChild(nameSpan);
+        if (fireText) {
+          const fireSpan = document.createElement('span');
+          fireSpan.className = 'fires';
+          fireSpan.textContent = fireText;
+          td.appendChild(fireSpan);
         }
         // If Kalodata URL exists, add copy link button
         const kal = item.extras && item.extras['KalodataUrl'];

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -14,3 +14,15 @@ master.addEventListener('change', ()=>{
   renderTable();
   updateMasterState();
 });
+
+function firesFor(score0to5){
+  const n = Math.max(0, Math.min(5, Math.round(score0to5 || 0)));
+  return '🔥'.repeat(n);
+}
+
+const legendBtn = document.getElementById('legendBtn');
+const legendPop = document.getElementById('legendPop');
+if(legendBtn && legendPop){
+  legendBtn.addEventListener('click', ()=>legendPop.classList.toggle('hidden'));
+  document.addEventListener('click',(e)=>{ if(!legendPop.contains(e.target) && e.target!==legendBtn) legendPop.classList.add('hidden'); });
+}


### PR DESCRIPTION
## Summary
- Replace legend strip with sticky ℹ️ button that opens explanatory popover
- Append fire emojis to product names according to `trendingScore`
- Grey out fires on selected rows and style popover/button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba0e31ed648328be099c3e06488c53