### PR TITLE
Fix light mode styling for readability

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -1,32 +1,156 @@
-.table-toolbar { position: sticky; top: var(--header-h, 60px); z-index: 20; display: grid; grid-template-columns: 1fr auto 1fr; align-items:center; gap:12px; padding:8px 12px; background:#131A2E; border-bottom:1px solid #243150; }
+/* Global page styling */
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+  background: linear-gradient(to bottom, #f8fbff, #e9f0ff);
+  color: #222;
+}
 
-.table-toolbar > :first-child { justify-self: start; } .table-toolbar > :nth-child(2){ justify-self:center;} .table-toolbar > :last-child { justify-self: end; display:flex; gap:8px; }
+body.dark {
+  background: #1a1b2e;
+  color: #eaeaea;
+}
 
-.sticky-thead { position: sticky; top: calc(var(--header-h,60px) + 44px); background:#131A2E; z-index: 15; }
+.table-toolbar {
+  position: sticky;
+  top: var(--header-h, 60px);
+  z-index: 20;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  background: #f8fbff;
+  border-bottom: 1px solid #ccc;
+  color: #222;
+}
+body.dark .table-toolbar {
+  background: #131A2E;
+  border-bottom: 1px solid #243150;
+  color: #E5EAF5;
+}
 
-.drawer.right{ position: fixed; right:0; top:0; bottom:0; width:360px; background:#0F1424; border-left:1px solid #243150; box-shadow: -8px 0 16px rgba(0,0,0,.2); padding:16px; z-index:100; }
-.hidden{ display:none; }
+.table-toolbar > :first-child { justify-self: start; }
+.table-toolbar > :nth-child(2) { justify-self: center; }
+.table-toolbar > :last-child { justify-self: end; display: flex; gap: 8px; }
 
-.legend-btn{ position:fixed; left:16px; bottom:16px; background:#1F2A44; border:1px solid #34456B; border-radius:8px; padding:4px 8px; z-index:900; }
+.sticky-thead {
+  position: sticky;
+  top: calc(var(--header-h, 60px) + 44px);
+  background: #f8fbff;
+  z-index: 15;
+}
+body.dark .sticky-thead {
+  background: #131A2E;
+}
 
-.popover{ position:fixed; left:16px; bottom:56px; background:#0F1424; border:1px solid #34456B; padding:10px 12px; border-radius:8px; box-shadow:0 8px 16px rgba(0,0,0,.3); z-index:900; }
+.drawer.right {
+  position: fixed;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 360px;
+  background: #fff;
+  border-left: 1px solid #ccc;
+  box-shadow: -8px 0 16px rgba(0,0,0,.2);
+  padding: 16px;
+  z-index: 100;
+}
+body.dark .drawer.right {
+  background: #0F1424;
+  border-left: 1px solid #243150;
+}
 
-.selected .fires{ filter: grayscale(1); opacity:.6; }
+.hidden { display: none; }
 
-.chip{ display:inline-flex; align-items:center; gap:6px; padding:4px 8px; border:1px solid #34456B; border-radius:999px; background:#1F2A44; color:#E5EAF5; margin:0 6px 6px 0; font-size:12px }
-.chip button{background:none;border:0;color:#A9B4D0;cursor:pointer}
+.legend-btn {
+  position: fixed;
+  left: 16px;
+  bottom: 16px;
+  background: #e0f0ff;
+  border: 1px solid #0077cc;
+  border-radius: 8px;
+  padding: 4px 8px;
+  z-index: 900;
+}
+body.dark .legend-btn {
+  background: #1F2A44;
+  border: 1px solid #34456B;
+}
 
-#topBar{ position:sticky; top:0; z-index:40; }
-#searchRow{ background:#f8fbff; }
-body.dark #searchRow{ background:#1a1b2e; }
+.popover {
+  position: fixed;
+  left: 16px;
+  bottom: 56px;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 10px 12px;
+  border-radius: 8px;
+  box-shadow: 0 8px 16px rgba(0,0,0,.3);
+  z-index: 900;
+}
+body.dark .popover {
+  background: #0F1424;
+  border: 1px solid #34456B;
+}
 
-.table tr{ height:52px; }
-.table td, .table th{ padding:8px 12px; }
-.table tbody tr:nth-child(odd){ background:#11192B; }
+.selected .fires { filter: grayscale(1); opacity: .6; }
 
-.badge{ border-radius:10px; padding:2px 8px; font-weight:600; }
-.score-green{ background:#183B2D; color:#44C48C }
-.score-amber{ background:#3A3119; color:#F1B44C }
-.score-red{ background:#3A1E1E; color:#F16969 }
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid #0077cc;
+  border-radius: 999px;
+  background: #e0f0ff;
+  color: #0077cc;
+  margin: 0 6px 6px 0;
+  font-size: 12px;
+}
+body.dark .chip {
+  border: 1px solid #34456B;
+  background: #1F2A44;
+  color: #E5EAF5;
+}
+.chip button {
+  background: none;
+  border: 0;
+  color: #005fa3;
+  cursor: pointer;
+}
+body.dark .chip button { color: #A9B4D0; }
 
-.bottombar{ position:sticky; bottom:0; left:0; right:0; background:#0F1424; border-top:1px solid #243150; display:flex; justify-content:space-between; align-items:center; padding:8px 12px; z-index:25 }
+#topBar { position: sticky; top: 0; z-index: 40; }
+#searchRow { background: #f8fbff; }
+body.dark #searchRow { background: #1a1b2e; }
+
+.table tr { height: 52px; }
+.table td, .table th { padding: 8px 12px; }
+body.dark .table tbody tr:nth-child(odd) { background: #11192B; }
+
+.badge { border-radius: 10px; padding: 2px 8px; font-weight: 600; }
+.score-green { background: #183B2D; color: #44C48C; }
+.score-amber { background: #3A3119; color: #F1B44C; }
+.score-red { background: #3A1E1E; color: #F16969; }
+
+.bottombar {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #f8fbff;
+  border-top: 1px solid #ccc;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  z-index: 25;
+  color: #222;
+}
+body.dark .bottombar {
+  background: #0F1424;
+  border-top: 1px solid #243150;
+  color: #E5EAF5;
+}


### PR DESCRIPTION
## Summary
- Add global body styles to establish light and dark backgrounds and text colors
- Ensure page renders content instead of blank screen when app first loads

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ba19caf0ac8328baf0e8c68cd59f93