### PR TITLE
Add Windows silent startup script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# App-Testeo-Ecom
+
+## Arranque silencioso en Windows
+
+Doble clic en `run_silent.vbs` para iniciar la aplicación sin ventana de consola.
+Tras unos segundos se abrirá el navegador en `http://127.0.0.1:8000`.
+
+Alternativa de empaquetado:
+
+```bash
+pyinstaller --noconfirm --onefile --windowed product_research_app/web_app.py
+```

--- a/run_silent.vbs
+++ b/run_silent.vbs
@@ -1,0 +1,6 @@
+Set shell = CreateObject("WScript.Shell")
+Set fso = CreateObject("Scripting.FileSystemObject")
+shell.CurrentDirectory = fso.GetParentFolderName(WScript.ScriptFullName)
+shell.Run "pythonw.exe -m product_research_app.web_app", 0, False
+WScript.Sleep 2000
+shell.Run "http://127.0.0.1:8000", 0, False


### PR DESCRIPTION
## Summary
- launch full web app from silent Windows VBScript and auto-open browser
- clarify README with instructions and correct PyInstaller command

## Testing
- `pytest`
- `python -m product_research_app.web_app --help` *(fails: No module named 'cgi')*


------
https://chatgpt.com/codex/tasks/task_e_68ba1d98461c83289da621e0e4597703