### PR TITLE
feat: add silent startup script and auto shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# App Testeo Ecom
+
+Aplicación para investigación de productos.
+
+## Arranque silencioso en Windows
+
+Doble clic en `run_silent.vbs` para lanzar el servidor sin ventana y abrir el navegador automáticamente.
+
+Alternativa de empaquetado:
+
+```
+pyinstaller --noconfirm --onefile --windowed server.py
+```

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -1153,5 +1153,10 @@ document.getElementById('trendsBtn').onclick = async () => {
 };
 </script>
 <script src="/static/js/filters.js"></script>
+<script>
+  window.addEventListener('beforeunload', () => {
+    navigator.sendBeacon('/shutdown');
+  });
+</script>
 </body>
 </html>

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -435,6 +435,11 @@ class RequestHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         parsed = urlparse(self.path)
         path = parsed.path
+        if path == "/shutdown":
+            self._set_json()
+            self.wfile.write(json.dumps({"ok": True}).encode("utf-8"))
+            threading.Thread(target=self.server.shutdown, daemon=True).start()
+            return
         if path == "/upload":
             self.handle_upload()
             return

--- a/run_silent.vbs
+++ b/run_silent.vbs
@@ -1,0 +1,4 @@
+Set shell = CreateObject("Wscript.Shell")
+shell.Run "pythonw.exe -m product_research_app.web_app", 0, False
+WScript.Sleep 2000
+shell.Run "http://127.0.0.1:8000", 1, False


### PR DESCRIPTION
## Summary
- add `run_silent.vbs` for silent Windows startup
- document silent start in README
- auto-stop server via `/shutdown` when browser tab closes
- launch browser automatically when using `run_silent.vbs`

## Testing
- `python -m product_research_app.web_app`
- `curl -s -o /tmp/index.html http://127.0.0.1:8000/`
- `curl -s -X POST http://127.0.0.1:8000/shutdown`
- `curl -s http://127.0.0.1:8000/ || echo "server down"`


------
https://chatgpt.com/codex/tasks/task_e_68ba274b72b08328b056c5837bdaaad9