### PR TITLE
Fix analyze API endpoint and allow auto shutdown

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -268,6 +268,7 @@ body.dark #scoreInfo { background:#262a51; }
 <script type="module">
 import { fetchJson } from "/static/js/net.js";
 import { openAnalysis } from "/static/js/analyze.js";
+window.addEventListener('beforeunload', () => navigator.sendBeacon('/shutdown'));
 // Global arrays to hold all products and the current filtered list
 let allProducts = [];
 let products = [];

--- a/product_research_app/static/js/analyze.js
+++ b/product_research_app/static/js/analyze.js
@@ -55,8 +55,8 @@ if(exportBtn){
 
 export async function openAnalysis(product){
   try{
-    const res = await fetchJson('/api/analyze', {method:'POST', body: JSON.stringify(product)});
-    currentData = res.result || {};
+    const res = await fetchJson('/analysis', {method:'POST', body: JSON.stringify(product)});
+    currentData = res.result || res || {};
     sections.resumen.textContent = JSON.stringify({
       producto: currentData.producto,
       demanda_y_tendencia: currentData.demanda_y_tendencia,

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -468,6 +468,9 @@ class RequestHandler(BaseHTTPRequestHandler):
         if path == "/analysis":
             self.handle_analysis()
             return
+        if path == "/shutdown":
+            self.handle_shutdown()
+            return
         self.send_error(404)
 
     def handle_upload(self):
@@ -1199,6 +1202,12 @@ class RequestHandler(BaseHTTPRequestHandler):
             analysis = self.simple_analysis(p)
         self._set_json()
         self.wfile.write(json.dumps(analysis, ensure_ascii=False).encode('utf-8'))
+
+    def handle_shutdown(self):
+        """Shutdown the HTTP server."""
+        self._set_json()
+        self.wfile.write(json.dumps({"ok": True}).encode('utf-8'))
+        threading.Thread(target=self.server.shutdown, daemon=True).start()
 
     def handle_delete(self):
         """Delete one or more products specified in the request body.


### PR DESCRIPTION
## Summary
- Correct product analysis JS to call existing `/analysis` endpoint and handle response
- Add client-side unload hook to request server shutdown
- Implement `/shutdown` route to gracefully stop the HTTP server

## Testing
- `python -m py_compile product_research_app/web_app.py`
- `node --check product_research_app/static/js/analyze.js`


------
https://chatgpt.com/codex/tasks/task_e_68bace49280883288fbcc3ee22861318