### PR TITLE
Fix analyze API endpoint and allow auto shutdown

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -183,20 +183,7 @@ body.dark #scoreInfo { background:#262a51; }
 <!-- Analysis drawer with tabbed content -->
 <div id="analysisDrawer" class="drawer right hidden">
   <div style="text-align:right;"><button id="closeAnalysis" style="background:none;border:none;font-size:20px;cursor:pointer;">✖</button></div>
-  <div id="analysisTabs" style="display:flex; gap:6px; margin-bottom:8px;">
-    <button data-tab="resumen" class="active">Resumen</button>
-    <button data-tab="fuentes">Fuentes</button>
-    <button data-tab="economia">Economía</button>
-    <button data-tab="riesgos">Riesgos</button>
-    <button data-tab="creatividad">Creatividad</button>
-  </div>
-  <div id="analysisContent">
-    <pre id="tab-resumen" class="tab-section"></pre>
-    <pre id="tab-fuentes" class="tab-section hidden"></pre>
-    <pre id="tab-economia" class="tab-section hidden"></pre>
-    <pre id="tab-riesgos" class="tab-section hidden"></pre>
-    <pre id="tab-creatividad" class="tab-section hidden"></pre>
-  </div>
+  <div id="analysisContent" style="white-space:pre-wrap; overflow-y:auto; max-height:80vh;"></div>
   <button id="analysisExport">Exportar</button>
 </div>
 <div id="table-toolbar" class="table-toolbar">
@@ -268,6 +255,7 @@ body.dark #scoreInfo { background:#262a51; }
 <script type="module">
 import { fetchJson } from "/static/js/net.js";
 import { openAnalysis } from "/static/js/analyze.js";
+window.addEventListener('beforeunload', () => navigator.sendBeacon('/shutdown'));
 // Global arrays to hold all products and the current filtered list
 let allProducts = [];
 let products = [];

--- a/product_research_app/static/js/analyze.js
+++ b/product_research_app/static/js/analyze.js
@@ -1,80 +1,33 @@
 import { fetchJson } from '/static/js/net.js';
 
 const drawer = document.getElementById('analysisDrawer');
-const tabs = document.getElementById('analysisTabs');
-const sections = {
-  resumen: document.getElementById('tab-resumen'),
-  fuentes: document.getElementById('tab-fuentes'),
-  economia: document.getElementById('tab-economia'),
-  riesgos: document.getElementById('tab-riesgos'),
-  creatividad: document.getElementById('tab-creatividad')
-};
-let currentData = null;
-
-function switchTab(name){
-  if(!tabs) return;
-  [...tabs.querySelectorAll('button')].forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.tab===name);
-  });
-  Object.keys(sections).forEach(key => {
-    sections[key].classList.toggle('hidden', key!==name);
-  });
-}
-
-if(tabs){
-  tabs.addEventListener('click', e => {
-    if(e.target.tagName === 'BUTTON'){
-      switchTab(e.target.dataset.tab);
-    }
-  });
-}
+const content = document.getElementById('analysisContent');
+let currentText = '';
 
 const closeBtn = document.getElementById('closeAnalysis');
-if(closeBtn){
+if (closeBtn) {
   closeBtn.addEventListener('click', () => drawer.classList.add('hidden'));
 }
 
 const exportBtn = document.getElementById('analysisExport');
-if(exportBtn){
+if (exportBtn) {
   exportBtn.addEventListener('click', () => {
-    if(!currentData) return;
-    const json = JSON.stringify(currentData, null, 2);
-    const blobJson = new Blob([json], {type:'application/json'});
-    const aJson = document.createElement('a');
-    aJson.href = URL.createObjectURL(blobJson);
-    aJson.download = 'analysis.json';
-    aJson.click();
-    const md = '```json\n' + json + '\n```';
-    const blobMd = new Blob([md], {type:'text/markdown'});
-    const aMd = document.createElement('a');
-    aMd.href = URL.createObjectURL(blobMd);
-    aMd.download = 'analysis.md';
-    aMd.click();
+    if (!currentText) return;
+    const blob = new Blob([currentText], { type: 'text/plain' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'analysis.txt';
+    a.click();
   });
 }
 
-export async function openAnalysis(product){
-  try{
-    const res = await fetchJson('/api/analyze', {method:'POST', body: JSON.stringify(product)});
-    currentData = res.result || {};
-    sections.resumen.textContent = JSON.stringify({
-      producto: currentData.producto,
-      demanda_y_tendencia: currentData.demanda_y_tendencia,
-      competencia: currentData.competencia,
-      pros: currentData.pros,
-      contras: currentData.contras,
-      veredicto: currentData.veredicto
-    }, null, 2);
-    sections.fuentes.textContent = JSON.stringify({
-      social_proof: currentData.social_proof,
-      fuentes: currentData.fuentes
-    }, null, 2);
-    sections.economia.textContent = JSON.stringify(currentData.unit_economics, null, 2);
-    sections.riesgos.textContent = JSON.stringify(currentData.logistica_y_riesgos, null, 2);
-    sections.creatividad.textContent = JSON.stringify(currentData.insights_creativos, null, 2);
-    switchTab('resumen');
+export async function openAnalysis(product) {
+  try {
+    const res = await fetchJson('/analysis', { method: 'POST', body: JSON.stringify(product) });
+    currentText = res.analysis || '';
+    content.textContent = currentText;
     drawer.classList.remove('hidden');
-  }catch(err){
+  } catch (err) {
     console.error(err);
   }
 }


### PR DESCRIPTION
## Summary
- Return plain-text product analysis with sections like Pros, Fuentes and Economía
- Simplify analysis drawer to show wrapped text and support text export
- Provide fallback heuristic text when OpenAI API is absent

## Testing
- `python -m py_compile product_research_app/web_app.py`
- `node --check product_research_app/static/js/analyze.js`


------
https://chatgpt.com/codex/tasks/task_e_68bace49280883288fbcc3ee22861318