### PR TITLE
feat: add product detail modal

### DIFF
--- a/product_research_app/static/js/title_analyzer.js
+++ b/product_research_app/static/js/title_analyzer.js
@@ -6,6 +6,20 @@ const table = document.getElementById('taTable');
 const tbody = table.querySelector('tbody');
 const summaryDiv = document.getElementById('taSummary');
 
+let detailDialog = document.getElementById('taDetailDialog');
+if (!detailDialog) {
+  detailDialog = document.createElement('dialog');
+  detailDialog.id = 'taDetailDialog';
+  const pre = document.createElement('pre');
+  pre.id = 'taDetailText';
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Cerrar';
+  closeBtn.addEventListener('click', () => detailDialog.close());
+  detailDialog.appendChild(pre);
+  detailDialog.appendChild(closeBtn);
+  document.body.appendChild(detailDialog);
+}
+
 analyzeBtn?.addEventListener('click', async () => {
   const file = fileInput.files[0];
   if (!file) {
@@ -103,12 +117,14 @@ function renderTable(items) {
     btnDetail.title = 'Ver análisis detallado';
     btnDetail.addEventListener('click', async () => {
       try {
-        const resp = await fetchJson('/api/analyze/title_detail', {
+        const resp = await fetchJson('/api/analyze/product_detail', {
           method: 'POST',
           body: JSON.stringify(item),
           headers: { 'Content-Type': 'application/json' }
         });
-        alert(resp.detail);
+        const pre = document.getElementById('taDetailText');
+        if (pre) pre.textContent = resp.detail || '';
+        detailDialog.showModal();
       } catch (err) {
         if (window.toast) toast.error('No se pudo obtener el detalle');
       }


### PR DESCRIPTION
## Summary
- add modal dialog to show product analysis details
- fetch product detail from backend and handle errors gracefully

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bae7edfbb483288d41b6f1e243041e