### PR TITLE
feat: add product detail modal

### DIFF
--- a/product_research_app/static/js/title_analyzer.js
+++ b/product_research_app/static/js/title_analyzer.js
@@ -6,6 +6,20 @@ const table = document.getElementById('taTable');
 const tbody = table.querySelector('tbody');
 const summaryDiv = document.getElementById('taSummary');
 
+let detailDialog = document.getElementById('taDetailDialog');
+if (!detailDialog) {
+  detailDialog = document.createElement('dialog');
+  detailDialog.id = 'taDetailDialog';
+  const pre = document.createElement('pre');
+  pre.id = 'taDetailText';
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Cerrar';
+  closeBtn.addEventListener('click', () => detailDialog.close());
+  detailDialog.appendChild(pre);
+  detailDialog.appendChild(closeBtn);
+  document.body.appendChild(detailDialog);
+}
+
 analyzeBtn?.addEventListener('click', async () => {
   const file = fileInput.files[0];
   if (!file) {
@@ -103,12 +117,14 @@ function renderTable(items) {
     btnDetail.title = 'Ver análisis detallado';
     btnDetail.addEventListener('click', async () => {
       try {
-        const resp = await fetchJson('/api/analyze/title_detail', {
+        const resp = await fetchJson('/api/analyze/product_detail', {
           method: 'POST',
           body: JSON.stringify(item),
           headers: { 'Content-Type': 'application/json' }
         });
-        alert(resp.detail);
+        const pre = document.getElementById('taDetailText');
+        if (pre) pre.textContent = resp.detail || '';
+        detailDialog.showModal();
       } catch (err) {
         if (window.toast) toast.error('No se pudo obtener el detalle');
       }

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -444,6 +444,9 @@ class RequestHandler(BaseHTTPRequestHandler):
         if path == "/api/analyze/title_detail":
             self.handle_title_detail()
             return
+        if path == "/api/analyze/product_detail":
+            self.handle_product_detail()
+            return
         if path == "/upload":
             self.handle_upload()
             return
@@ -1183,6 +1186,43 @@ class RequestHandler(BaseHTTPRequestHandler):
             return
         try:
             product = {"title": data.get("title"), "price": data.get("price")}
+            detail = gpt.generate_detailed_summary(api_key, model, product, data)
+            self._set_json()
+            self.wfile.write(json.dumps({"detail": detail}).encode('utf-8'))
+        except Exception as exc:
+            self._set_json(500)
+            self.wfile.write(json.dumps({"error": str(exc)}).encode('utf-8'))
+
+    def handle_product_detail(self):
+        """Return a detailed analysis for a single product.
+
+        The request body must be JSON containing at least ``title`` and
+        ``signals`` fields, typically produced by ``analyze_titles``.  The
+        handler forwards the information to ``generate_detailed_summary`` and
+        returns the resulting text.
+        """
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length).decode('utf-8')
+        try:
+            data = json.loads(body)
+        except Exception:
+            self._set_json(400)
+            self.wfile.write(json.dumps({"error": "Invalid JSON"}).encode('utf-8'))
+            return
+        if not isinstance(data, dict) or 'title' not in data or 'signals' not in data:
+            self._set_json(400)
+            self.wfile.write(json.dumps({"error": "Missing required fields"}).encode('utf-8'))
+            return
+        api_key = config.get_api_key() or os.environ.get('OPENAI_API_KEY')
+        model = config.get_model()
+        if not api_key:
+            self._set_json(400)
+            self.wfile.write(json.dumps({"error": "No API key configured"}).encode('utf-8'))
+            return
+        try:
+            product = {'title': data.get('title')}
+            if data.get('price') is not None:
+                product['price'] = data.get('price')
             detail = gpt.generate_detailed_summary(api_key, model, product, data)
             self._set_json()
             self.wfile.write(json.dumps({"detail": detail}).encode('utf-8'))


### PR DESCRIPTION
## Summary
- add modal dialog to show product analysis details
- fetch product detail from backend and handle errors gracefully
- implement product detail endpoint with OpenAI integration and validation

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bae7edfbb483288d41b6f1e243041e