### PR TITLE
feat: add column visibility controls

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -63,6 +63,7 @@ body.dark .drawer.right {
 }
 
 .hidden { display: none; }
+.col-hidden{ display:none; }
 
 .legend-btn {
   position: fixed;
@@ -93,6 +94,12 @@ body.dark .legend-btn {
 body.dark .popover {
   background: #0F1424;
   border: 1px solid #34456B;
+}
+
+#columnsPanel {
+  position: absolute;
+  left: auto;
+  bottom: auto;
 }
 
 .selected .fires { filter: grayscale(1); opacity: .6; }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -188,8 +188,9 @@ body.dark #scoreInfo { background:#262a51; }
       <button id="btnAddToGroup">Añadir</button>
     </div>
   </div>
-  <div id="listMeta">0 resultados • Vista: Tabla ▾</div>
+  <div id="listMeta">0 resultados • Vista: Tabla ▾ (Tarjetas)</div>
   <div>
+    <button id="btnColumns">Columnas</button>
     <button id="btnDelete" disabled>Eliminar</button>
     <button id="btnExport" disabled>Exportar</button>
   </div>
@@ -206,6 +207,7 @@ body.dark #scoreInfo { background:#262a51; }
   <div>• Fila roja: duplicado</div>
   <div>• 🔥 x1–x5: tendencia en el nombre</div>
 </div>
+<div id="columnsPanel" class="popover hidden"></div>
 
 <!-- Overlay for viewing images in larger size -->
 <div id="imgOverlay" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.8); justify-content:center; align-items:center; z-index:1000;">
@@ -244,6 +246,7 @@ body.dark #scoreInfo { background:#262a51; }
 </style>
 <script src="/static/js/toast.js"></script>
 <script src="/static/js/table.js"></script>
+<script src="/static/js/columns.js"></script>
 <script type="module">
 import { fetchJson } from "/static/js/net.js";
 window.addEventListener('beforeunload', () => navigator.sendBeacon('/shutdown'));
@@ -356,6 +359,7 @@ function renderTable() {
     columns.forEach(col => {
       const td = document.createElement('td');
       const key = col.key;
+      td.setAttribute('data-key', key);
       let value = '';
       if (['id','name','category','price','image_url','score'].includes(key)) {
         value = item[key];
@@ -441,7 +445,9 @@ function renderTable() {
     tbody.appendChild(tr);
   });
   currentPageIds = products.map(p => p.id);
-  document.getElementById('listMeta').textContent = `${currentPageIds.length} resultados • Vista: Tabla ▾`;
+  document.getElementById('listMeta').textContent = `${currentPageIds.length} resultados • Vista: Tabla ▾ (Tarjetas)`; // TODO: implementar vista Tarjetas
+  if (window.refreshColumns) window.refreshColumns();
+  if (window.applyColumnVisibility) window.applyColumnVisibility();
   updateMasterState();
 }
 

--- a/product_research_app/static/js/columns.js
+++ b/product_research_app/static/js/columns.js
@@ -1,0 +1,79 @@
+// Column visibility manager
+(function(){
+  const btn = document.getElementById('btnColumns');
+  const panel = document.getElementById('columnsPanel');
+  if(!btn || !panel) return;
+
+  function loadState(){
+    try{ return JSON.parse(localStorage.columnsVisibility || '{}'); }catch(e){ return {}; }
+  }
+  function saveState(state){
+    localStorage.columnsVisibility = JSON.stringify(state);
+  }
+
+  function apply(){
+    const state = loadState();
+    document.querySelectorAll('th[data-key], td[data-key]').forEach(el => {
+      const key = el.dataset.key;
+      const visible = state[key] !== false;
+      el.classList.toggle('col-hidden', !visible);
+    });
+    panel.querySelectorAll('input[type="checkbox"][data-key]').forEach(cb => {
+      const key = cb.dataset.key;
+      cb.checked = state[key] !== false;
+    });
+  }
+
+  function build(){
+    panel.innerHTML = '';
+    const state = loadState();
+    document.querySelectorAll('th[data-key]').forEach(th => {
+      const key = th.dataset.key;
+      const id = 'col-vis-' + key;
+      const div = document.createElement('div');
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.id = id;
+      cb.dataset.key = key;
+      cb.checked = state[key] !== false;
+      const label = document.createElement('label');
+      label.htmlFor = id;
+      label.textContent = th.textContent || key;
+      cb.addEventListener('change', () => {
+        const s = loadState();
+        s[key] = cb.checked;
+        saveState(s);
+        document.querySelectorAll(`[data-key="${key}"]`).forEach(cell => {
+          cell.classList.toggle('col-hidden', !cb.checked);
+        });
+      });
+      div.appendChild(cb);
+      div.appendChild(label);
+      panel.appendChild(div);
+    });
+    apply();
+  }
+
+  btn.addEventListener('click', () => {
+    if(panel.classList.contains('hidden')){
+      const rect = btn.getBoundingClientRect();
+      panel.style.top = `${rect.bottom + window.scrollY}px`;
+      panel.style.left = `${rect.left + window.scrollX}px`;
+      panel.classList.remove('hidden');
+    } else {
+      panel.classList.add('hidden');
+    }
+  });
+
+  document.addEventListener('click', e => {
+    if(!panel.contains(e.target) && e.target !== btn){
+      panel.classList.add('hidden');
+    }
+  });
+
+  window.refreshColumns = build;
+  window.applyColumnVisibility = apply;
+
+  // initial attempt (will populate once table is rendered)
+  build();
+})();


### PR DESCRIPTION
## Summary
- add Columns popover to toggle table columns
- persist column visibility in localStorage
- stub text for future card view

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68baec1c76d48328beb362775fd6d547