### PR TITLE
Reset selection on filter/group change and move info button

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -67,8 +67,8 @@ body.dark .drawer.right {
 
 .legend-btn {
   position: fixed;
-  left: 16px;
-  bottom: 16px;
+  right: 16px;
+  top: calc(var(--header-h, 60px) + 16px);
   background: #e0f0ff;
   border: 1px solid #0077cc;
   border-radius: 8px;
@@ -82,8 +82,8 @@ body.dark .legend-btn {
 
 .popover {
   position: fixed;
-  left: 16px;
-  bottom: 56px;
+  right: 16px;
+  top: calc(var(--header-h, 60px) + 56px);
   background: #fff;
   border: 1px solid #ccc;
   padding: 10px 12px;

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -338,6 +338,7 @@ async function fetchProducts() {
   products = [...allProducts];
   window.allProducts = allProducts;
   window.products = products;
+  selection.clear();
   renderTable();
 }
 
@@ -882,6 +883,7 @@ async function loadList(id){
     products = [...allProducts];
     window.allProducts = allProducts;
     window.products = products;
+    selection.clear();
     renderTable();
     // refresh lists to highlight active group
     loadLists();

--- a/product_research_app/static/js/filters.js
+++ b/product_research_app/static/js/filters.js
@@ -62,6 +62,7 @@ function applyFiltersFromState() {
   window.products = products;
   buildActiveChips(filtersState);
   if (typeof startProgress === 'function') startProgress();
+  selection.clear();
   renderTable();
 }
 


### PR DESCRIPTION
## Summary
- Clear selected products when filters are applied or groups/lists are changed
- Reposition legend info button and popover to the top-right so it no longer covers selected items

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68baf2d9aed08328a2648645dda4d0e1