### PR TITLE
Reset selection counter on context change and fix deselection decrement

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -66,24 +66,21 @@ body.dark .drawer.right {
 .col-hidden{ display:none; }
 
 .legend-btn {
-  position: fixed;
-  left: 16px;
-  bottom: 16px;
-  background: #e0f0ff;
-  border: 1px solid #0077cc;
-  border-radius: 8px;
-  padding: 4px 8px;
-  z-index: 900;
+    background: #e0f0ff;
+    border: 1px solid #0077cc;
+    border-radius: 8px;
+    padding: 4px 8px;
+    cursor: pointer;
 }
 body.dark .legend-btn {
-  background: #1F2A44;
-  border: 1px solid #34456B;
+    background: #1F2A44;
+    border: 1px solid #34456B;
 }
 
 .popover {
   position: fixed;
-  left: 16px;
-  bottom: 56px;
+  right: 16px;
+  top: calc(var(--header-h, 60px) + 56px);
   background: #fff;
   border: 1px solid #ccc;
   padding: 10px 12px;
@@ -94,6 +91,12 @@ body.dark .legend-btn {
 body.dark .popover {
   background: #0F1424;
   border: 1px solid #34456B;
+}
+#legendPop {
+  left: 16px;
+  bottom: 56px;
+  right: auto;
+  top: auto;
 }
 
 #columnsPanel {

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -202,7 +202,6 @@ body.dark #scoreInfo { background:#262a51; }
   </thead>
   <tbody></tbody>
 </table>
-<button id="legendBtn" class="legend-btn">ℹ️</button>
 <div id="legendPop" class="popover hidden">
   <div>• Fila roja: duplicado</div>
   <div>• 🔥 x1–x5: tendencia en el nombre</div>
@@ -338,6 +337,8 @@ async function fetchProducts() {
   products = [...allProducts];
   window.allProducts = allProducts;
   window.products = products;
+  selection.clear();
+  updateMasterState();
   renderTable();
 }
 
@@ -377,11 +378,13 @@ function renderTable() {
     const cb = document.createElement('input');
     cb.type = 'checkbox';
     cb.classList.add('rowCheck');
-    cb.dataset.id = item.id;
-    cb.checked = selection.has(item.id);
+    const rowId = String(item.id);
+    cb.dataset.id = rowId;
+    cb.checked = selection.has(rowId);
     tr.classList.toggle('selected', cb.checked);
     cb.addEventListener('change', () => {
-      if (cb.checked) selection.add(item.id); else selection.delete(item.id);
+      const id = cb.dataset.id;
+      if (cb.checked) selection.add(id); else selection.delete(id);
       tr.classList.toggle('selected', cb.checked);
       updateMasterState();
     });
@@ -475,7 +478,7 @@ function renderTable() {
     tr.appendChild(tdDel);
     tbody.appendChild(tr);
   });
-  currentPageIds = products.map(p => p.id);
+  currentPageIds = products.map(p => String(p.id));
   document.getElementById('listMeta').textContent = `${currentPageIds.length} resultados • Vista: Tabla ▾ (Tarjetas)`; // TODO: implementar vista Tarjetas
   if (window.refreshColumns) window.refreshColumns();
   if (window.applyColumnVisibility) window.applyColumnVisibility();
@@ -732,7 +735,7 @@ async function deleteProduct(id){
 
 // Delete selected products
 document.getElementById('btnDelete').onclick = () => {
-  const ids = Array.from(selection);
+  const ids = Array.from(selection, Number);
   if(!ids.length){ toast.info('Selecciona al menos un producto para eliminar'); return; }
   toast.info('¿Eliminar los productos seleccionados?', {actionText:'Eliminar', onAction: async () => {
     try{
@@ -753,7 +756,7 @@ document.getElementById('btnDelete').onclick = () => {
 
 // Export selected products as CSV
 document.getElementById('btnExport').onclick = async () => {
-  const ids = Array.from(selection);
+  const ids = Array.from(selection, Number);
   if(!ids.length){ toast.info('Selecciona productos para exportar'); return; }
   // Build query string
   const params = new URLSearchParams();
@@ -882,6 +885,8 @@ async function loadList(id){
     products = [...allProducts];
     window.allProducts = allProducts;
     window.products = products;
+    selection.clear();
+    updateMasterState();
     renderTable();
     // refresh lists to highlight active group
     loadLists();
@@ -904,7 +909,7 @@ document.getElementById('btnAddToGroup').onclick = async () => {
   const listSelect = document.getElementById('groupSelect');
   const lid = parseInt(listSelect.value);
   if(!lid){ toast.info('Selecciona un grupo'); return; }
-  const ids = Array.from(selection);
+  const ids = Array.from(selection, Number);
   if(!ids.length){ toast.info('Selecciona productos para añadir'); return; }
   try{
     const data = await fetchJson('/add_to_list', {method:'POST', body: JSON.stringify({id: lid, ids: ids})});

--- a/product_research_app/static/js/filters.js
+++ b/product_research_app/static/js/filters.js
@@ -62,6 +62,8 @@ function applyFiltersFromState() {
   window.products = products;
   buildActiveChips(filtersState);
   if (typeof startProgress === 'function') startProgress();
+  selection.clear();
+  updateMasterState();
   renderTable();
 }
 

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -15,17 +15,17 @@ function updateMasterState(){
   document.getElementById('btnDelete').disabled = selection.size===0;
   document.getElementById('btnExport').disabled = selection.size===0;
   if(bottomBar){
+    document.getElementById('selCount').textContent = `${selection.size} seleccionados`;
     if(selection.size>0){
       bottomBar.classList.remove('hidden');
-      document.getElementById('selCount').textContent = `${selection.size} seleccionados`;
     }else{
       bottomBar.classList.add('hidden');
     }
   }
 }
 master.addEventListener('change', ()=>{
-  if(master.checked){ currentPageIds.forEach(id=>selection.add(id)); }
-  else { currentPageIds.forEach(id=>selection.delete(id)); }
+  if(master.checked){ currentPageIds.forEach(id=>selection.add(String(id))); }
+  else { currentPageIds.forEach(id=>selection.delete(String(id))); }
   renderTable();
   updateMasterState();
 });
@@ -34,21 +34,19 @@ function firesFor(score0to5){
   const n = Math.max(0, Math.min(5, Math.round(score0to5 || 0)));
   return '🔥'.repeat(n);
 }
-
-const legendBtn = document.getElementById('legendBtn');
-const legendPop = document.getElementById('legendPop');
-if(legendBtn && legendPop){
-  legendBtn.addEventListener('click', ()=>legendPop.classList.toggle('hidden'));
-  document.addEventListener('click',(e)=>{ if(!legendPop.contains(e.target) && e.target!==legendBtn) legendPop.classList.add('hidden'); });
-}
-
 const table = document.getElementById('productTable');
 if(table){
   bottomBar = document.createElement('div');
   bottomBar.id = 'bottomBar';
   bottomBar.className = 'bottombar hidden';
-  bottomBar.innerHTML = '<div id="selCount"></div><div><button id="bbDelete">Eliminar</button><button id="bbExport">Exportar</button><button id="bbAddGroup">Añadir a grupo</button></div>';
+    bottomBar.innerHTML = '<div style="display:flex; align-items:center; gap:8px;"><button id="legendBtn" class="legend-btn">ℹ️</button><span id="selCount"></span></div><div><button id="bbDelete">Eliminar</button><button id="bbExport">Exportar</button><button id="bbAddGroup">Añadir a grupo</button></div>';
   table.parentElement.appendChild(bottomBar);
+    const legendBtn = document.getElementById('legendBtn');
+    const legendPop = document.getElementById('legendPop');
+    if(legendBtn && legendPop){
+      legendBtn.addEventListener('click', ()=>legendPop.classList.toggle('hidden'));
+      document.addEventListener('click',(e)=>{ if(!legendPop.contains(e.target) && e.target!==legendBtn) legendPop.classList.add('hidden'); });
+    }
   document.getElementById('bbDelete').addEventListener('click', ()=>document.getElementById('btnDelete').click());
   document.getElementById('bbExport').addEventListener('click', ()=>document.getElementById('btnExport').click());
   document.getElementById('bbAddGroup').addEventListener('click', ()=>document.getElementById('btnAddToGroup').click());


### PR DESCRIPTION
## Summary
- Move legend info button into the selection bar so it sits left of the selected count
- Reset selected counter when filters are applied, groups are switched, or the selection is cleared
- Normalize selected ID tracking so deselecting products correctly updates the counter

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68baf2d9aed08328a2648645dda4d0e1