### PR TITLE
feat: disable legacy scoring and add winner score v2 model

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -1,10 +1,9 @@
-"""
-Configuration management for Product Research Copilot.
+"""Configuration management for Product Research Copilot.
 
 The application stores user configuration such as the OpenAI API key and
 preferred model in a JSON file (config.json) located in the application's
-directory.  These helpers encapsulate loading and saving this configuration
-file.  If the file does not exist, default values are returned.
+directory. These helpers encapsulate loading and saving this configuration
+file. If the file does not exist, default values are returned.
 """
 
 import json
@@ -18,14 +17,14 @@ CONFIG_FILE = Path(__file__).resolve().parent / "config.json"
 def load_config() -> Dict[str, Any]:
     """Load configuration from disk.
 
-    Returns a dictionary with at least the keys ``api_key`` and ``model``.  If
-    the file does not exist, an empty configuration is returned.
+    Returns a dictionary with at least the keys ``api_key`` and ``model``.
+    If the file does not exist, an empty configuration is returned.
     """
+
     if CONFIG_FILE.exists():
         try:
             with open(CONFIG_FILE, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            # ensure expected keys exist
             if not isinstance(data, dict):
                 return {}
             return data
@@ -36,6 +35,7 @@ def load_config() -> Dict[str, Any]:
 
 def save_config(config: Dict[str, Any]) -> None:
     """Persist configuration to disk atomically."""
+
     tmp_path = CONFIG_FILE.with_suffix(".tmp")
     with open(tmp_path, "w", encoding="utf-8") as f:
         json.dump(config, f, ensure_ascii=False, indent=2)
@@ -44,12 +44,14 @@ def save_config(config: Dict[str, Any]) -> None:
 
 def get_api_key() -> Optional[str]:
     """Return the stored OpenAI API key if present."""
+
     config = load_config()
     return config.get("api_key")
 
 
 def get_model() -> str:
     """Return the configured model or default to 'gpt-4o'."""
+
     config = load_config()
     model = config.get("model")
     if not model:
@@ -62,11 +64,12 @@ def get_weights() -> Dict[str, float]:
 
     The configuration may include a ``weights`` object mapping metric names
     (momentum, saturation, differentiation, social_proof, margin, logistics)
-    to numeric values.  If a weight is missing or invalid it defaults to 1.0.
+    to numeric values. If a weight is missing or invalid it defaults to 1.0.
 
     Returns:
         A dictionary of six weights used to compute the overall score.
     """
+
     cfg = load_config()
     default = {
         "momentum": 1.0,
@@ -84,3 +87,70 @@ def get_weights() -> Dict[str, float]:
         except Exception:
             weights[k] = v
     return weights
+
+
+def is_scoring_v2_enabled() -> bool:
+    """Return whether Winner Score v2 flow is enabled.
+
+    The configuration may contain a nested structure like::
+
+        {"scoring": {"v2": {"enabled": true}}}
+
+    If the key is missing or invalid the flag defaults to ``True``.
+    """
+
+    cfg = load_config()
+    try:
+        return bool(cfg.get("scoring", {}).get("v2", {}).get("enabled", True))
+    except Exception:
+        return True
+
+
+# ---------------- Winner Score v2 weights -----------------
+
+SCORING_V2_DEFAULT_WEIGHTS: Dict[str, float] = {
+    "magnitud_deseo": 0.125,
+    "nivel_consciencia": 0.125,
+    "saturacion_mercado": 0.125,
+    "facilidad_anuncio": 0.125,
+    "facilidad_logistica": 0.125,
+    "escalabilidad": 0.125,
+    "engagement_shareability": 0.125,
+    "durabilidad_recurrencia": 0.125,
+}
+
+
+def get_scoring_v2_weights() -> Dict[str, float]:
+    """Return the weighting factors for Winner Score v2 variables.
+
+    The configuration may include a ``scoring_v2_weights`` object mapping the
+    eight Winner Score variables to numeric values between 0 and 1. If weights
+    are missing or invalid, defaults are used and the result is normalized so
+    that the sum of all weights equals 1.
+    """
+
+    cfg = load_config()
+    user_weights = cfg.get("scoring_v2_weights", {})
+    weights: Dict[str, float] = {}
+    total = 0.0
+    for key, default in SCORING_V2_DEFAULT_WEIGHTS.items():
+        try:
+            val = float(user_weights.get(key, default))
+            if val < 0:
+                val = 0.0
+        except Exception:
+            val = default
+        weights[key] = val
+        total += val
+    if total <= 0:
+        return SCORING_V2_DEFAULT_WEIGHTS.copy()
+    return {k: v / total for k, v in weights.items()}
+
+
+def set_scoring_v2_weights(weights: Dict[str, float]) -> None:
+    """Persist Winner Score v2 weights to configuration."""
+
+    cfg = load_config()
+    cfg["scoring_v2_weights"] = weights
+    save_config(cfg)
+

--- a/product_research_app/database.py
+++ b/product_research_app/database.py
@@ -83,9 +83,30 @@ def initialize_database(conn: sqlite3.Connection) -> None:
             summary TEXT,
             explanations JSON,
             created_at TEXT NOT NULL,
+            winner_score_v2_raw REAL,
+            winner_score_v2_pct REAL,
+            winner_score_v2_breakdown JSON,
             FOREIGN KEY(product_id) REFERENCES products(id) ON DELETE CASCADE
         )
         """
+    )
+    cur.execute("PRAGMA table_info(scores)")
+    cols = [row[1] for row in cur.fetchall()]
+    if "winner_score_v2_raw" not in cols:
+        cur.execute("ALTER TABLE scores ADD COLUMN winner_score_v2_raw REAL")
+    if "winner_score_v2_pct" not in cols:
+        cur.execute("ALTER TABLE scores ADD COLUMN winner_score_v2_pct REAL")
+    if "winner_score_v2_breakdown" not in cols:
+        cur.execute("ALTER TABLE scores ADD COLUMN winner_score_v2_breakdown JSON")
+    if "winner_score_v2" in cols:
+        cur.execute(
+            "UPDATE scores SET winner_score_v2_raw = winner_score_v2 WHERE winner_score_v2_raw IS NULL"
+        )
+    cur.execute(
+        "UPDATE scores SET winner_score_v2_pct = ((winner_score_v2_raw - 8) / 32.0) * 100 WHERE winner_score_v2_raw IS NOT NULL AND winner_score_v2_pct IS NULL"
+    )
+    cur.execute(
+        "UPDATE scores SET winner_score_v2_breakdown = '{}' WHERE winner_score_v2_breakdown IS NULL"
     )
     # Lists table
     cur.execute(
@@ -193,16 +214,27 @@ def insert_score(
     logistics: float,
     summary: str,
     explanations: Dict[str, Any],
+    winner_score_v2_raw: Optional[float] = None,
+    winner_score_v2_pct: Optional[float] = None,
+    winner_score_v2_breakdown: Optional[Dict[str, Any]] = None,
 ) -> int:
     """Insert a new AI score for a product."""
+
     cur = conn.cursor()
     created_at = datetime.utcnow().isoformat()
+    if winner_score_v2_raw is None and winner_score_v2_pct is not None:
+        winner_score_v2_raw = 8 + (winner_score_v2_pct / 100.0) * 32
+    if winner_score_v2_pct is None and winner_score_v2_raw is not None:
+        winner_score_v2_pct = ((winner_score_v2_raw - 8) / 32.0) * 100
+    if winner_score_v2_breakdown is None:
+        winner_score_v2_breakdown = {}
     cur.execute(
         """
         INSERT INTO scores (
             product_id, model, total_score, momentum, saturation, differentiation,
-            social_proof, margin, logistics, summary, explanations, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, json(?), ?)
+            social_proof, margin, logistics, summary, explanations, created_at,
+            winner_score_v2_raw, winner_score_v2_pct, winner_score_v2_breakdown)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, json(?), ?, ?, ?, json(?))
         """,
         (
             product_id,
@@ -217,6 +249,9 @@ def insert_score(
             summary,
             json_dump(explanations),
             created_at,
+            winner_score_v2_raw,
+            winner_score_v2_pct,
+            json_dump(winner_score_v2_breakdown),
         ),
     )
     conn.commit()

--- a/product_research_app/gpt.py
+++ b/product_research_app/gpt.py
@@ -329,6 +329,105 @@ def evaluate_product(
     return result
 
 
+# ---------------- Winner Score v2 evaluation -----------------
+
+
+WINNER_SCORE_V2_FIELDS = [
+    "magnitud_deseo",
+    "nivel_consciencia",
+    "saturacion_mercado",
+    "facilidad_anuncio",
+    "facilidad_logistica",
+    "escalabilidad",
+    "engagement_shareability",
+    "durabilidad_recurrencia",
+]
+
+
+def build_winner_score_prompt(product: Dict[str, Any]) -> str:
+    """Construct the Winner Score v2 prompt for a product.
+
+    The prompt requests the model to rate eight variables from 1 to 5 based on
+    the product's title, description and category. The model must answer with a
+    JSON object containing the integer scores for each variable.
+
+    Args:
+        product: Mapping with optional keys ``title``/``name``, ``description``
+            and ``category`` describing the product.
+
+    Returns:
+        A Spanish prompt string to send to the model.
+    """
+
+    title = product.get("title") or product.get("name") or ""
+    description = product.get("description") or ""
+    category = product.get("category") or ""
+    prompt = f"""
+Eres un analista de producto para e-commerce.
+Te doy un título, descripción y categoría.
+Evalúa del 1 al 5 (solo números enteros) cada una de estas variables:
+- Magnitud del deseo
+- Nivel de consciencia del mercado
+- Saturación / sofisticación (estima según categoría y competencia implícita)
+- Facilidad de explicar en un anuncio
+- Facilidad logística (peso/envío/fragilidad, estima por categoría)
+- Escalabilidad (aplica a mucha gente o a pocos)
+- Engagement / shareability (atractivo visual o viral)
+- Durabilidad / recurrencia de compra
+
+Título: {title}
+Descripción: {description}
+Categoría: {category}
+
+Devuelve en formato JSON:
+{{
+  "magnitud_deseo": x,
+  "nivel_consciencia": x,
+  "saturacion_mercado": x,
+  "facilidad_anuncio": x,
+  "facilidad_logistica": x,
+  "escalabilidad": x,
+  "engagement_shareability": x,
+  "durabilidad_recurrencia": x
+}}
+"""
+    return prompt.strip()
+
+
+def evaluate_winner_score(
+    api_key: str, model: str, product: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Call OpenAI to obtain Winner Score v2 sub-scores for a product.
+
+    Args:
+        api_key: OpenAI API key.
+        model: Identifier of the chat model to use.
+        product: Mapping with product information.
+
+    Returns:
+        Parsed JSON dictionary with the eight variables. Missing or invalid
+        values are left as-is for the caller to handle.
+
+    Raises:
+        OpenAIError: If the API call fails or returns invalid content.
+    """
+
+    prompt = build_winner_score_prompt(product)
+    messages = [
+        {
+            "role": "system",
+            "content": "Eres un asistente que responde únicamente con JSON válido.",
+        },
+        {"role": "user", "content": prompt},
+    ]
+    resp_json = call_openai_chat(api_key, model, messages)
+    try:
+        content = resp_json["choices"][0]["message"]["content"].strip()
+        result = json.loads(content)
+    except Exception as exc:
+        raise OpenAIError(f"La respuesta de la IA no está en formato JSON válido: {exc}") from exc
+    return result
+
 def simplify_product_names(api_key: str, model: str, names: List[str], *, temperature: float = 0.2) -> Dict[str, str]:
     """
     Simplify a list of product names by removing brand names and extra descriptors.
@@ -375,4 +474,73 @@ def simplify_product_names(api_key: str, model: str, names: List[str], *, temper
     except Exception:
         # If parsing or the API call fails, return an empty mapping
         return {}
+
+
+def recommend_winner_weights(
+    api_key: str,
+    model: str,
+    samples: List[Dict[str, Any]],
+    success_key: str,
+) -> Dict[str, float]:
+    """Ask GPT to propose weights for Winner Score variables.
+
+    This helper sends a list of sample products, each containing the eight
+    Winner Score variables and a real-world success metric (``success_key``),
+    and asks the model to return a JSON object with normalized weights that
+    best correlate with the provided metric.
+
+    Args:
+        api_key: OpenAI API key.
+        model: Chat model identifier.
+        samples: List of mappings with the eight variables and a success value.
+        success_key: Name of the success metric (e.g. ``orders`` or ``revenue``)
+            included in each sample.
+
+    Returns:
+        Mapping of variable name to weight, normalized so the sum equals 1. If
+        the model does not return valid weights, a uniform distribution is
+        returned instead.
+    """
+
+    if not samples:
+        # no data -> uniform weights
+        return {k: 1.0 / len(WINNER_SCORE_V2_FIELDS) for k in WINNER_SCORE_V2_FIELDS}
+
+    sample_json = json.dumps(samples[:20], ensure_ascii=False)
+    prompt = (
+        "Analiza la siguiente muestra de productos representada como un array JSON. "
+        f"Cada producto incluye un valor '{success_key}' que indica su éxito real y las ocho subpuntuaciones de Winner Score v2. "
+        "Devuelve únicamente un objeto JSON con pesos normalizados (suma=1) para las claves: "
+        + ", ".join(WINNER_SCORE_V2_FIELDS) + "."
+        " Los pesos deben maximizar la correlación con el éxito."\
+    )
+    prompt += "\nMuestra:\n" + sample_json
+    messages = [
+        {"role": "system", "content": "Eres un analista experto en estadística de productos."},
+        {"role": "user", "content": prompt},
+    ]
+    try:
+        resp = call_openai_chat(api_key, model, messages)
+        content = resp["choices"][0]["message"]["content"].strip()
+        weights = json.loads(content)
+        if not isinstance(weights, dict):
+            raise ValueError("Respuesta no es un objeto JSON")
+    except Exception:
+        # fallback to uniform weights
+        return {k: 1.0 / len(WINNER_SCORE_V2_FIELDS) for k in WINNER_SCORE_V2_FIELDS}
+
+    total = 0.0
+    cleaned: Dict[str, float] = {}
+    for key in WINNER_SCORE_V2_FIELDS:
+        try:
+            val = float(weights.get(key, 0.0))
+            if val < 0:
+                val = 0.0
+        except Exception:
+            val = 0.0
+        cleaned[key] = val
+        total += val
+    if total <= 0:
+        return {k: 1.0 / len(WINNER_SCORE_V2_FIELDS) for k in WINNER_SCORE_V2_FIELDS}
+    return {k: v / total for k, v in cleaned.items()}
 

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -49,9 +49,6 @@ body.dark pre { background:#2e315f; }
 body.dark .weight-slider {
   accent-color:#7a53d6;
 }
-/* Info box */
-#scoreInfo { display:none; }
-body.dark #scoreInfo { background:#262a51; }
 </style>
 </head>
 <body class="dark">
@@ -95,64 +92,16 @@ body.dark #scoreInfo { background:#262a51; }
       <option value="gpt-3.5-turbo">GPT-3.5 Turbo</option>
     </select>
   </label>
-  <!-- Pesos para ajustar el cálculo del score -->
-  <div id="weights" style="margin-top:10px; display:flex; flex-wrap:wrap; gap:12px;">
-    <div style="display:flex; flex-direction:column;">
-      <label>Momentum</label>
-      <input type="range" id="w_momentum" min="0" max="2" step="0.1" value="1" class="weight-slider">
-      <span id="val_momentum" style="font-size:12px; text-align:center;">1.0</span>
-    </div>
-    <div style="display:flex; flex-direction:column;">
-      <label>Saturación</label>
-      <input type="range" id="w_saturation" min="0" max="2" step="0.1" value="1" class="weight-slider">
-      <span id="val_saturation" style="font-size:12px; text-align:center;">1.0</span>
-    </div>
-    <div style="display:flex; flex-direction:column;">
-      <label>Diferenciación</label>
-      <input type="range" id="w_differentiation" min="0" max="2" step="0.1" value="1" class="weight-slider">
-      <span id="val_differentiation" style="font-size:12px; text-align:center;">1.0</span>
-    </div>
-    <div style="display:flex; flex-direction:column;">
-      <label>Prueba Social</label>
-      <input type="range" id="w_social_proof" min="0" max="2" step="0.1" value="1" class="weight-slider">
-      <span id="val_social_proof" style="font-size:12px; text-align:center;">1.0</span>
-    </div>
-    <div style="display:flex; flex-direction:column;">
-      <label>Margen</label>
-      <input type="range" id="w_margin" min="0" max="2" step="0.1" value="1" class="weight-slider">
-      <span id="val_margin" style="font-size:12px; text-align:center;">1.0</span>
-    </div>
-    <div style="display:flex; flex-direction:column;">
-      <label>Logística</label>
-      <input type="range" id="w_logistics" min="0" max="2" step="0.1" value="1" class="weight-slider">
-      <span id="val_logistics" style="font-size:12px; text-align:center;">1.0</span>
-    </div>
-  </div>
   <button id="saveConfig">Guardar configuración</button>
-  <button id="autoWeights">Ajustar pesos automáticamente</button>
-  <button id="toggleScoreInfo">¿Cómo se calcula el score?</button>
 </div>
-<div id="scoreInfo" class="card">
-  <strong>Criterios del score:</strong>
-  <ul>
-    <li><strong>Momentum</strong>: Evaluación de la tendencia de interés/ventas en los últimos 7, 14 y 30 días.</li>
-    <li><strong>Saturación</strong>: Número de competidores y saturación del mercado.</li>
-    <li><strong>Diferenciación</strong>: Unicidad del producto y ángulos de marketing.</li>
-    <li><strong>Prueba Social</strong>: Indicadores de aceptación como reseñas e interacciones.</li>
-    <li><strong>Margen</strong>: Margen de beneficio estimado según precio y coste.</li>
-    <li><strong>Logística</strong>: Complejidad logística (peso, fragilidad, variantes, envío).</li>
-  </ul>
-  <p>El <em>total score</em> se calcula como una media ponderada de los seis criterios. A continuación se muestran valores y rangos sugeridos para cada peso (puedes ajustarlos manualmente):</p>
-  <p><em>¿Qué sucede al ajustar los pesos?</em> Aumentar un peso (por ejemplo de 1.0 a 1.5) hace que ese criterio tenga más influencia en el score final. Disminuirlo (por ejemplo de 1.0 a 0.5) reduce su importancia. Valores muy bajos (cercanos a 0) prácticamente eliminan la influencia del criterio, mientras que valores altos (>1.5) lo priorizan mucho sobre los demás.</p>
-  <ul>
-    <li>Momentum: valor por defecto 1.0 (rango recomendado 0.5–1.5)</li>
-    <li>Saturación: valor por defecto 1.0 (rango recomendado 0.5–1.5)</li>
-    <li>Diferenciación: valor por defecto 1.0 (rango recomendado 1.0–2.0)</li>
-    <li>Prueba Social: valor por defecto 1.0 (rango recomendado 0.5–1.5)</li>
-    <li>Margen: valor por defecto 1.0 (rango recomendado 1.0–2.0)</li>
-    <li>Logística: valor por defecto 1.0 (rango recomendado 0.5–1.0)</li>
-  </ul>
-  <p>Puedes hacer clic en “Ajustar pesos automáticamente” para que el sistema determine pesos basados en los datos de tus productos evaluados.</p>
+<div id="weightsCard" class="card" style="display:none; max-width:420px;">
+  <strong>Ponderaciones Winner Score</strong>
+  <div id="weightsContainer" style="margin-top:8px; display:flex; flex-direction:column; gap:6px;"></div>
+  <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:6px;">
+    <button id="autoWeightsGpt">Ajustar por IA</button>
+    <button id="autoWeightsStat">Ajustar estadístico</button>
+    <button id="saveWeights">Guardar</button>
+  </div>
 </div>
 <div id="custom">
   <textarea id="customPrompt" rows="3" placeholder="Escribe tu consulta personalizada a GPT"></textarea><br/>
@@ -268,7 +217,6 @@ body.dark #scoreInfo { background:#262a51; }
     <label>Fecha hasta<br><input type="date" id="filterDateMax"></label>
     <label>Rating mín<br><input type="number" id="filterRatingMin" step="0.1" min="0" max="5"></label>
     <label>Categoría<br><input type="text" id="filterCategory"></label>
-    <label>Score mín<br><input type="number" id="filterScoreMin" step="0.1"></label>
   </div>
   <div style="display:flex; gap:8px; margin-top:12px;">
     <button id="applyFilters" style="flex:1;">Aplicar</button>
@@ -306,10 +254,47 @@ const columns = [
   { key: 'Creator Conversion Ratio', label: 'Tasa Conversión', type: 'string' },
   { key: 'Launch Date', label: 'Fecha Lanzamiento', type: 'string' },
   { key: 'Date Range', label: 'Rango Fechas', type: 'string' },
-  { key: 'score', label: 'Score', type: 'number' },
+  { key: 'winner_score_v2_pct', label: 'Winner Score', type: 'number' },
 ];
 
 let trendingWords = [];
+
+const weightFields = [
+  'magnitud_deseo',
+  'nivel_consciencia',
+  'saturacion_mercado',
+  'facilidad_anuncio',
+  'facilidad_logistica',
+  'escalabilidad',
+  'engagement_shareability',
+  'durabilidad_recurrencia'
+];
+
+function renderWeights(weights){
+  const container = document.getElementById('weightsContainer');
+  if (!container) return;
+  container.innerHTML = '';
+  weightFields.forEach(key => {
+    const row = document.createElement('div');
+    row.style.display = 'flex';
+    row.style.alignItems = 'center';
+    row.style.gap = '6px';
+    const label = document.createElement('label');
+    label.textContent = key;
+    label.style.minWidth = '160px';
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = '0.01';
+    input.min = '0';
+    input.max = '1';
+    input.value = (weights[key] ?? 0).toFixed(3);
+    input.dataset.key = key;
+    input.className = 'weight-slider';
+    row.appendChild(label);
+    row.appendChild(input);
+    container.appendChild(row);
+  });
+}
 
 async function loadConfig() {
   try {
@@ -317,23 +302,12 @@ async function loadConfig() {
     if (cfg.model) {
       document.getElementById('modelSelect').value = cfg.model;
     }
-    if (cfg.weights) {
-      const keys = ['momentum','saturation','differentiation','social_proof','margin','logistics'];
-      keys.forEach(k => {
-        if (cfg.weights[k] !== undefined) {
-          const el = document.getElementById('w_' + k);
-          if (el) {
-            el.value = cfg.weights[k];
-            el.dispatchEvent(new Event('input'));
-          }
-        }
-      });
-    }
     if (cfg.has_api_key) {
       const apiInput = document.getElementById('apiKey');
       apiInput.style.display = 'none';
       document.getElementById('toggleApiKey').style.display = 'inline-block';
     }
+    renderWeights(cfg.scoring_v2_weights || {});
   } catch (err) {
     console.error('Error loading config', err);
   }
@@ -430,15 +404,15 @@ function renderTable() {
       const key = col.key;
       td.setAttribute('data-key', key);
       let value = '';
-      if (['id','name','category','price','image_url','score'].includes(key)) {
+      if (['id','name','category','price','image_url','winner_score_v2_pct'].includes(key)) {
         value = item[key];
       } else {
         value = item.extras ? item.extras[key] : '';
       }
-      if (key === 'score') {
+      if (key === 'winner_score_v2_pct') {
         const sc = parseFloat(value);
         if (!isNaN(sc)) {
-          td.innerHTML = '<span class="' + scoreClass(sc) + '">' + Math.round(sc) + '</span>';
+          td.innerHTML = '<span class="' + winnerScoreClass(sc) + '">' + Math.round(sc) + '</span>';
         }
       } else if (key === 'image_url' && value) {
         const img = document.createElement('img');
@@ -530,7 +504,7 @@ function sortBy(field, type) {
   products.sort((a, b) => {
     let va;
     let vb;
-    if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'score') {
+    if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'winner_score_v2_pct') {
       va = a[field];
       vb = b[field];
     } else {
@@ -560,8 +534,42 @@ window.onload = () => { loadConfig(); fetchProducts(); };
 // Toggle config panel
 document.getElementById('configBtn').onclick = () => {
   const cfg = document.getElementById('config');
-  if (!cfg) return;
-  cfg.style.display = (cfg.style.display === 'none' || cfg.style.display === '') ? 'block' : 'none';
+  const wcard = document.getElementById('weightsCard');
+  if (!cfg || !wcard) return;
+  const show = (cfg.style.display === 'none' || cfg.style.display === '') ? 'block' : 'none';
+  cfg.style.display = show;
+  wcard.style.display = show;
+};
+
+async function saveWeightsConfig(weights){
+  await fetchJson('/setconfig',{method:'POST', body: JSON.stringify({scoring_v2_weights: weights})});
+}
+
+async function saveWeights(){
+  const inputs = document.querySelectorAll('#weightsContainer input');
+  const weights = {};
+  let total = 0;
+  inputs.forEach(inp => {
+    const v = parseFloat(inp.value) || 0;
+    weights[inp.dataset.key] = v;
+    total += v;
+  });
+  if (total <= 0){ toast.error('Pesos inválidos'); return; }
+  Object.keys(weights).forEach(k => weights[k] = weights[k] / total);
+  await saveWeightsConfig(weights);
+  toast.success('Pesos guardados');
+}
+
+document.getElementById('saveWeights').onclick = saveWeights;
+document.getElementById('autoWeightsGpt').onclick = async () => {
+  const w = await fetchJson('/auto_weights_v2_gpt',{method:'POST'});
+  renderWeights(w);
+  await saveWeightsConfig(w);
+};
+document.getElementById('autoWeightsStat').onclick = async () => {
+  const w = await fetchJson('/auto_weights_v2_stat',{method:'POST'});
+  renderWeights(w);
+  await saveWeightsConfig(w);
 };
 // Handle file upload: clicking the upload button opens file chooser
 const fileInputEl = document.getElementById('fileInput');
@@ -615,16 +623,6 @@ document.getElementById('saveConfig').onclick = async () => {
   const payload = {};
   if(key) payload.api_key = key;
   payload.model = model;
-  // collect weights
-  const weights = {
-    momentum: parseFloat(document.getElementById('w_momentum').value) || 0,
-    saturation: parseFloat(document.getElementById('w_saturation').value) || 0,
-    differentiation: parseFloat(document.getElementById('w_differentiation').value) || 0,
-    social_proof: parseFloat(document.getElementById('w_social_proof').value) || 0,
-    margin: parseFloat(document.getElementById('w_margin').value) || 0,
-    logistics: parseFloat(document.getElementById('w_logistics').value) || 0,
-  };
-  payload.weights = weights;
   const data = await fetchJson('/setconfig', {method:'POST', body: JSON.stringify(payload)});
   if(data.error){ toast.error('Error: '+data.error); } else {
     toast.success('Configuración guardada');
@@ -636,23 +634,6 @@ document.getElementById('saveConfig').onclick = async () => {
     }
   }
 };
-// auto weights button
-document.getElementById('autoWeights').onclick = async () => {
-  const data = await fetchJson('/auto_weights', {method:'POST'});
-  if (data.error) {
-    toast.error('Error al ajustar pesos: ' + data.error);
-    return;
-  }
-  // Update weight inputs
-  document.getElementById('w_momentum').value = (data.momentum || 1).toFixed(2);
-  document.getElementById('w_saturation').value = (data.saturation || 1).toFixed(2);
-  document.getElementById('w_differentiation').value = (data.differentiation || 1).toFixed(2);
-  document.getElementById('w_social_proof').value = (data.social_proof || 1).toFixed(2);
-  document.getElementById('w_margin').value = (data.margin || 1).toFixed(2);
-  document.getElementById('w_logistics').value = (data.logistics || 1).toFixed(2);
-  toast.info('Pesos ajustados automáticamente. No olvides guardarlos.');
-};
-
 // search feature
 document.getElementById('searchBtn').onclick = () => {
   const term = document.getElementById('searchInput').value.trim().toLowerCase();
@@ -711,12 +692,6 @@ document.getElementById('toggleApiKey').onclick = () => {
   document.getElementById('toggleApiKey').style.display = 'none';
 };
 
-// toggle score info box
-document.getElementById('toggleScoreInfo').onclick = () => {
-  const box = document.getElementById('scoreInfo');
-  box.style.display = box.style.display === 'none' || box.style.display === '' ? 'block' : 'none';
-};
-
 // Show overlay with larger image
 function showOverlay(src){
   const overlay = document.getElementById('imgOverlay');
@@ -730,26 +705,6 @@ document.getElementById('imgOverlay').onclick = (e) => {
     document.getElementById('imgOverlay').style.display = 'none';
   }
 };
-
-// Setup weight slider labels and colors
-['momentum','saturation','differentiation','social_proof','margin','logistics'].forEach(key => {
-  const slider = document.getElementById('w_'+key);
-  const label = document.getElementById('val_'+key);
-  if (slider && label) {
-    const update = () => {
-      const val = parseFloat(slider.value);
-      label.textContent = val.toFixed(1);
-      // set gradient color: low (gray) <0.7, mid (yellow) 0.7-1.3, high (green)
-      let color;
-      if (val < 0.7) color = '#888888';
-      else if (val < 1.3) color = '#d4a017';
-      else color = '#2c8c28';
-      slider.style.background = `linear-gradient(to right, ${color} ${(val/2)*100}%, #ccc ${(val/2)*100}%)`;
-    };
-    slider.addEventListener('input', update);
-    update();
-  }
-});
 
 // Delete a single product by ID
 async function deleteProduct(id){
@@ -994,8 +949,8 @@ async function loadTrends(){
   trendingWords = (data.keywords || []).map(([w])=>w.toLowerCase());
   let html = '<h3>Tendencias</h3>';
   if(data.top_products && data.top_products.length){
-    html += '<strong>Top productos por puntuación:</strong><ol>';
-    data.top_products.forEach(item=>{ html += `<li>${item.name} (Score: ${item.score.toFixed(2)})</li>`; });
+    html += '<strong>Top productos por Winner Score:</strong><ol>';
+      data.top_products.forEach(item=>{ html += `<li>${item.name} (Winner Score: ${item.winner_score_v2_pct.toFixed(2)})</li>`; });
     html += '</ol>';
   }
   cont.innerHTML = html;

--- a/product_research_app/static/js/filters.js
+++ b/product_research_app/static/js/filters.js
@@ -5,7 +5,6 @@ let filtersState = {
   dateMax: '',
   ratingMin: null,
   category: '',
-  scoreMin: null,
 };
 
 const idMap = {
@@ -14,8 +13,7 @@ const idMap = {
   dateMin: 'filterDateMin',
   dateMax: 'filterDateMax',
   ratingMin: 'filterRatingMin',
-  category: 'filterCategory',
-  scoreMin: 'filterScoreMin'
+  category: 'filterCategory'
 };
 
 function toggleDrawer() {
@@ -51,10 +49,6 @@ function applyFiltersFromState() {
       const cat = (item.category || '').toString().toLowerCase();
       if (!cat.includes(filtersState.category)) return false;
     }
-    if (filtersState.scoreMin !== null && !isNaN(filtersState.scoreMin)) {
-      const sc = item.score;
-      if (sc === null || sc === undefined || sc < filtersState.scoreMin) return false;
-    }
     return true;
   });
   // Mutate the global products array in place so renderTable sees the filtered list
@@ -78,7 +72,6 @@ function buildActiveChips(state) {
   if (state.dateMax) chips.push(['dateMax', `Hasta ${state.dateMax}`]);
   if (state.ratingMin !== null && !isNaN(state.ratingMin)) chips.push(['ratingMin', `Rating ≥ ${state.ratingMin}`]);
   if (state.category) chips.push(['category', `Cat: ${state.category}`]);
-  if (state.scoreMin !== null && !isNaN(state.scoreMin)) chips.push(['scoreMin', `Score ≥ ${state.scoreMin}`]);
   chips.forEach(([key, label]) => {
     const chip = document.createElement('span');
     chip.className = 'chip';
@@ -86,7 +79,7 @@ function buildActiveChips(state) {
     const btn = document.createElement('button');
     btn.textContent = '×';
     btn.onclick = () => {
-      if (['priceMin','priceMax','ratingMin','scoreMin'].includes(key)) {
+      if (['priceMin','priceMax','ratingMin'].includes(key)) {
         filtersState[key] = null;
       } else {
         filtersState[key] = '';
@@ -105,14 +98,12 @@ document.getElementById('applyFilters')?.addEventListener('click', () => {
   const pMinVal = document.getElementById('filterPriceMin').value;
   const pMaxVal = document.getElementById('filterPriceMax').value;
   const rMinVal = document.getElementById('filterRatingMin').value;
-  const sMinVal = document.getElementById('filterScoreMin').value;
   filtersState.priceMin = pMinVal ? parseFloat(pMinVal) : null;
   filtersState.priceMax = pMaxVal ? parseFloat(pMaxVal) : null;
   filtersState.dateMin = document.getElementById('filterDateMin').value;
   filtersState.dateMax = document.getElementById('filterDateMax').value;
   filtersState.ratingMin = rMinVal ? parseFloat(rMinVal) : null;
   filtersState.category = document.getElementById('filterCategory').value.trim().toLowerCase();
-  filtersState.scoreMin = sMinVal ? parseFloat(sMinVal) : null;
   applyFiltersFromState();
   closeDrawer();
 });
@@ -124,8 +115,7 @@ document.getElementById('clearFilters')?.addEventListener('click', () => {
   document.getElementById('filterDateMax').value = '';
   document.getElementById('filterRatingMin').value = '';
   document.getElementById('filterCategory').value = '';
-  document.getElementById('filterScoreMin').value = '';
-  filtersState = { priceMin: null, priceMax: null, dateMin: '', dateMax: '', ratingMin: null, category: '', scoreMin: null };
+  filtersState = { priceMin: null, priceMax: null, dateMin: '', dateMax: '', ratingMin: null, category: '' };
   applyFiltersFromState();
 });
 

--- a/product_research_app/static/js/format.js
+++ b/product_research_app/static/js/format.js
@@ -4,7 +4,7 @@ export function abbr(n){
   return String(n);
 }
 
-export function scoreClass(s){
+export function winnerScoreClass(s){
   if(s>=80) return 'badge score-green';
   if(s>=60) return 'badge score-amber';
   return 'badge score-red';

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -5,7 +5,7 @@ let bottomBar = null;
 
 import('./format.js').then(m => {
   window.abbr = m.abbr;
-  window.scoreClass = m.scoreClass;
+  window.winnerScoreClass = m.winnerScoreClass;
 });
 
 function updateMasterState(){

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -29,12 +29,24 @@ from pathlib import Path
 import cgi
 import threading
 import sqlite3
+import math
 from typing import Dict, Any
 
 from . import database
 from . import config
 from . import gpt
 from . import title_analyzer
+
+WINNER_V2_FIELDS = [
+    "magnitud_deseo",
+    "nivel_consciencia",
+    "saturacion_mercado",
+    "facilidad_anuncio",
+    "facilidad_logistica",
+    "escalabilidad",
+    "engagement_shareability",
+    "durabilidad_recurrencia",
+]
 
 APP_DIR = Path(__file__).resolve().parent
 DB_PATH = APP_DIR / "data.sqlite3"
@@ -231,22 +243,31 @@ class RequestHandler(BaseHTTPRequestHandler):
             for p in database.list_products(conn):
                 scores = database.get_scores_for_product(conn, p["id"])
                 score = scores[0] if scores else None
-                # flatten some important extra fields
-                # ``extra" column is stored as JSON text. Use indexing since sqlite3.Row has no .get().
                 extra = p["extra"] if "extra" in p.keys() else {}
                 try:
                     extra_dict = json.loads(extra) if isinstance(extra, str) else (extra or {})
                 except Exception:
-                    extra_dict = {}  # fallback on parse error
+                    extra_dict = {}
+                score_value = None
+                if score:
+                    key = (
+                        "winner_score_v2_pct"
+                        if config.is_scoring_v2_enabled()
+                        else "total_score"
+                    )
+                    score_value = score.get(key)
                 row = {
                     "id": p["id"],
                     "name": p["name"],
                     "category": p["category"],
                     "price": p["price"],
                     "image_url": p["image_url"],
-                    "score": score["total_score"] if score else None,
                     "extras": extra_dict,
                 }
+                if config.is_scoring_v2_enabled():
+                    row["winner_score_v2_pct"] = score_value
+                else:
+                    row["score"] = score_value
                 rows.append(row)
             self._set_json()
             self.wfile.write(json.dumps(rows).encode("utf-8"))
@@ -257,6 +278,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             data = {
                 "model": cfg.get("model", "gpt-4o"),
                 "weights": cfg.get("weights", {}),
+                "scoring_v2_weights": cfg.get("scoring_v2_weights", {}),
                 "has_api_key": bool(cfg.get("api_key")),
                 # do not include the API key for security
             }
@@ -309,15 +331,27 @@ class RequestHandler(BaseHTTPRequestHandler):
                         extra_dict = json.loads(extra) if isinstance(extra, str) else (extra or {})
                     except Exception:
                         extra_dict = {}
-                    rows.append({
+                    score_value = None
+                    if score:
+                        key = (
+                            "winner_score_v2_pct"
+                            if config.is_scoring_v2_enabled()
+                            else "total_score"
+                        )
+                        score_value = score.get(key)
+                    row = {
                         "id": p["id"],
                         "name": p["name"],
                         "category": p["category"],
                         "price": p["price"],
                         "image_url": p["image_url"],
-                        "score": score["total_score"] if score else None,
                         "extras": extra_dict,
-                    })
+                    }
+                    if config.is_scoring_v2_enabled():
+                        row["winner_score_v2_pct"] = score_value
+                    else:
+                        row["score"] = score_value
+                    rows.append(row)
                 self._set_json()
                 self.wfile.write(json.dumps(rows).encode("utf-8"))
                 return
@@ -518,14 +552,20 @@ class RequestHandler(BaseHTTPRequestHandler):
                 scores = database.get_scores_for_product(conn, p["id"])
                 score_val = None
                 if scores:
+                    key = (
+                        "winner_score_v2_pct"
+                        if config.is_scoring_v2_enabled()
+                        else "total_score"
+                    )
                     try:
-                        score_val = scores[0]["total_score"]
+                        score_val = scores[0][key]
                     except Exception:
                         score_val = None
                 if score_val is not None:
                     rows.append((p["id"], p["name"], score_val))
             rows.sort(key=lambda x: x[2], reverse=True)
-            top_products = [{"id": r[0], "name": r[1], "score": r[2]} for r in rows[:10]]
+            key_name = "winner_score_v2_pct" if config.is_scoring_v2_enabled() else "score"
+            top_products = [{"id": r[0], "name": r[1], key_name: r[2]} for r in rows[:10]]
 
             self._set_json()
             self.wfile.write(json.dumps({
@@ -626,6 +666,12 @@ class RequestHandler(BaseHTTPRequestHandler):
             return
         if path == "/auto_weights":
             self.handle_auto_weights()
+            return
+        if path == "/auto_weights_v2_gpt":
+            self.handle_auto_weights_v2_gpt()
+            return
+        if path == "/auto_weights_v2_stat":
+            self.handle_auto_weights_v2_stat()
             return
         if path == "/delete":
             self.handle_delete()
@@ -886,6 +932,11 @@ class RequestHandler(BaseHTTPRequestHandler):
                     name_map = {}
                     api_key = config.get_api_key() or os.environ.get('OPENAI_API_KEY')
                     model = config.get_model()
+                    weights_map = (
+                        config.get_scoring_v2_weights()
+                        if config.is_scoring_v2_enabled()
+                        else {}
+                    )
                     if api_key and model and names_list:
                         try:
                             name_map = gpt.simplify_product_names(api_key, model, names_list)
@@ -1021,6 +1072,11 @@ class RequestHandler(BaseHTTPRequestHandler):
                     name_map = {}
                     api_key = config.get_api_key() or os.environ.get('OPENAI_API_KEY')
                     model = config.get_model()
+                    weights_map = (
+                        config.get_scoring_v2_weights()
+                        if config.is_scoring_v2_enabled()
+                        else {}
+                    )
                     if api_key and model and names_list:
                         try:
                             name_map = gpt.simplify_product_names(api_key, model, names_list)
@@ -1062,6 +1118,58 @@ class RequestHandler(BaseHTTPRequestHandler):
                             source=filename,
                             extra=extra,
                         )
+                        if (
+                            config.is_scoring_v2_enabled()
+                            and api_key
+                            and model
+                        ):
+                            try:
+                                resp = gpt.evaluate_winner_score(
+                                    api_key,
+                                    model,
+                                    {
+                                        "title": simplified,
+                                        "description": description,
+                                        "category": category,
+                                    },
+                                )
+                                scores = {}
+                                for field in WINNER_V2_FIELDS:
+                                    try:
+                                        val = int(resp.get(field, 3))
+                                    except Exception:
+                                        val = 3
+                                    if val < 1:
+                                        val = 1
+                                    if val > 5:
+                                        val = 5
+                                    scores[field] = val
+                                weighted = sum(
+                                    scores[f] * weights_map.get(f, 0.0)
+                                    for f in WINNER_V2_FIELDS
+                                )
+                                raw_score = weighted * 8.0
+                                pct = ((raw_score - 8.0) / 32.0) * 100.0
+                                breakdown = {"scores": scores, "weights": weights_map}
+                                database.insert_score(
+                                    conn,
+                                    product_id=pid,
+                                    model=model,
+                                    total_score=0,
+                                    momentum=0,
+                                    saturation=0,
+                                    differentiation=0,
+                                    social_proof=0,
+                                    margin=0,
+                                    logistics=0,
+                                    summary="",
+                                    explanations={},
+                                    winner_score_v2_raw=raw_score,
+                                    winner_score_v2_pct=pct,
+                                    winner_score_v2_breakdown=breakdown,
+                                )
+                            except Exception:
+                                pass
                         inserted += 1
                         inserted_ids.append(pid)
                 except Exception as exc:
@@ -1180,16 +1288,66 @@ class RequestHandler(BaseHTTPRequestHandler):
         api_key = config.get_api_key() or os.environ.get('OPENAI_API_KEY')
         model = config.get_model()
         evaluated = 0
+        if config.is_scoring_v2_enabled():
+            weights_map = config.get_scoring_v2_weights()
+            for p in database.list_products(conn):
+                if database.get_scores_for_product(conn, p['id']):
+                    continue
+                if not (api_key and model):
+                    continue
+                try:
+                    resp = gpt.evaluate_winner_score(api_key, model, dict(p))
+                    scores = {}
+                    for field in WINNER_V2_FIELDS:
+                        try:
+                            val = int(resp.get(field, 3))
+                        except Exception:
+                            val = 3
+                        if val < 1:
+                            val = 1
+                        if val > 5:
+                            val = 5
+                        scores[field] = val
+                    weighted = sum(
+                        scores[f] * weights_map.get(f, 0.0) for f in WINNER_V2_FIELDS
+                    )
+                    raw_score = weighted * 8.0
+                    pct = ((raw_score - 8.0) / 32.0) * 100.0
+                    breakdown = {"scores": scores, "weights": weights_map}
+                    database.insert_score(
+                        conn,
+                        product_id=p['id'],
+                        model=model,
+                        total_score=0,
+                        momentum=0,
+                        saturation=0,
+                        differentiation=0,
+                        social_proof=0,
+                        margin=0,
+                        logistics=0,
+                        summary="",
+                        explanations={},
+                        winner_score_v2_raw=raw_score,
+                        winner_score_v2_pct=pct,
+                        winner_score_v2_breakdown=breakdown,
+                    )
+                    evaluated += 1
+                except Exception:
+                    continue
+            self._set_json()
+            self.wfile.write(json.dumps({"evaluated": evaluated}).encode('utf-8'))
+            return
+        # Fallback to legacy evaluation if v2 is disabled
+        evaluated = 0
+        weights_map = config.get_weights()
+        sum_weights = sum(weights_map.values()) or 1.0
         for p in database.list_products(conn):
-            # Skip if already evaluated
             if database.get_scores_for_product(conn, p['id']):
                 continue
             metrics = None
-            # Try GPT evaluation first if API key and model exist
             if api_key:
                 try:
                     result = gpt.evaluate_product(api_key, model, dict(p))
-                    # Build metrics from GPT response
                     metrics = {
                         'momentum': float(result.get('momentum_score', 5.0)),
                         'saturation': float(result.get('saturation_score', 5.0)),
@@ -1210,7 +1368,6 @@ class RequestHandler(BaseHTTPRequestHandler):
                 except Exception:
                     metrics = None
             if metrics is None:
-                # offline heuristic evaluation
                 offline = offline_evaluate(dict(p))
                 metrics = {
                     'momentum': offline['momentum'],
@@ -1222,9 +1379,6 @@ class RequestHandler(BaseHTTPRequestHandler):
                 }
                 summary = offline['summary']
                 explanations = offline['explanations']
-            # compute weighted total score
-            weights_map = config.get_weights()
-            sum_weights = sum(weights_map.values()) or 1.0
             weighted_total = (
                 metrics['momentum'] * weights_map.get('momentum', 1.0)
                 + metrics['saturation'] * weights_map.get('saturation', 1.0)
@@ -1233,7 +1387,6 @@ class RequestHandler(BaseHTTPRequestHandler):
                 + metrics['margin'] * weights_map.get('margin', 1.0)
                 + metrics['logistics'] * weights_map.get('logistics', 1.0)
             ) / sum_weights
-            # Convert weighted_total (approx 1-9) to integer 0-100
             try:
                 score_int = int(round(((weighted_total - 1.0) / 8.0) * 100))
                 if score_int < 0:
@@ -1283,6 +1436,14 @@ class RequestHandler(BaseHTTPRequestHandler):
                 except Exception:
                     continue
             cfg['weights'] = weights
+        if 'scoring_v2_weights' in data and isinstance(data['scoring_v2_weights'], dict):
+            weights_v2 = cfg.get('scoring_v2_weights', {})
+            for k, v in data['scoring_v2_weights'].items():
+                try:
+                    weights_v2[k] = float(v)
+                except Exception:
+                    continue
+            cfg['scoring_v2_weights'] = weights_v2
         config.save_config(cfg)
         self._set_json()
         self.wfile.write(json.dumps({"status": "ok"}).encode('utf-8'))
@@ -1382,6 +1543,98 @@ class RequestHandler(BaseHTTPRequestHandler):
             factor = float(len(metrics)) / total
             for k in weights:
                 weights[k] *= factor
+        self._set_json()
+        self.wfile.write(json.dumps(weights).encode('utf-8'))
+
+    def _collect_samples_for_weights(self):
+        """Gather products with Winner Score v2 breakdown and success metric."""
+        conn = ensure_db()
+        rows = database.list_products(conn)
+        samples = []
+        metric_key = None
+        for p in rows:
+            try:
+                extra = json.loads(p["extra"] or "{}")
+            except Exception:
+                extra = {}
+            success = None
+            if metric_key and metric_key in extra:
+                try:
+                    success = float(extra[metric_key])
+                except Exception:
+                    success = None
+            if success is None:
+                for key in ("orders", "revenue", "gmv", "sales", "units"):
+                    if key in extra:
+                        try:
+                            success = float(extra[key])
+                            metric_key = metric_key or key
+                            break
+                        except Exception:
+                            continue
+            if success is None:
+                continue
+            scores_rows = database.get_scores_for_product(conn, p["id"])
+            if not scores_rows:
+                continue
+            srow = scores_rows[0]
+            try:
+                breakdown = json.loads(srow["winner_score_v2_breakdown"] or "{}")
+                scores = breakdown.get("scores") or {}
+            except Exception:
+                continue
+            if not scores or any(k not in scores for k in WINNER_V2_FIELDS):
+                continue
+            sample = {k: float(scores[k]) for k in WINNER_V2_FIELDS}
+            sample[metric_key] = success
+            samples.append(sample)
+            if len(samples) >= 50:
+                break
+        return samples, metric_key
+
+    def handle_auto_weights_v2_gpt(self):
+        samples, metric_key = self._collect_samples_for_weights()
+        if not samples or not metric_key:
+            self._set_json(400)
+            self.wfile.write(json.dumps({"error": "Datos insuficientes"}).encode('utf-8'))
+            return
+        api_key = config.get_api_key() or os.environ.get('OPENAI_API_KEY')
+        model = config.get_model()
+        if not api_key or not model:
+            self._set_json(400)
+            self.wfile.write(json.dumps({"error": "No API key configured"}).encode('utf-8'))
+            return
+        try:
+            weights = gpt.recommend_winner_weights(api_key, model, samples, metric_key)
+        except Exception as exc:
+            self._set_json(500)
+            self.wfile.write(json.dumps({"error": str(exc)}).encode('utf-8'))
+            return
+        config.set_scoring_v2_weights(weights)
+        self._set_json()
+        self.wfile.write(json.dumps(weights).encode('utf-8'))
+
+    def handle_auto_weights_v2_stat(self):
+        samples, metric_key = self._collect_samples_for_weights()
+        if not samples or not metric_key or len(samples) < 2:
+            self._set_json(400)
+            self.wfile.write(json.dumps({"error": "Datos insuficientes"}).encode('utf-8'))
+            return
+        # compute Pearson correlation between each variable and success
+        ys = [s[metric_key] for s in samples]
+        mean_y = sum(ys) / len(ys)
+        denom_y = math.sqrt(sum((y - mean_y) ** 2 for y in ys)) or 1.0
+        weights = {}
+        for field in WINNER_V2_FIELDS:
+            xs = [s[field] for s in samples]
+            mean_x = sum(xs) / len(xs)
+            denom_x = math.sqrt(sum((x - mean_x) ** 2 for x in xs)) or 1.0
+            num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+            corr = abs(num / (denom_x * denom_y)) if denom_x and denom_y else 0.0
+            weights[field] = corr
+        total = sum(weights.values()) or 1.0
+        weights = {k: v / total for k, v in weights.items()}
+        config.set_scoring_v2_weights(weights)
         self._set_json()
         self.wfile.write(json.dumps(weights).encode('utf-8'))
 


### PR DESCRIPTION
## Summary
- add GPT helper to recommend normalized Winner Score weights from real product samples
- expose GPT-based and statistical auto-tuning endpoints with config persistence
- add UI sliders plus "Ajustar por IA" and "Ajustar estadístico" buttons for Winner Score weights

## Testing
- `python -m py_compile product_research_app/config.py product_research_app/database.py product_research_app/web_app.py product_research_app/main.py product_research_app/gpt.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb29bfc75c8328b94630b4afed67bf