### PR TITLE
feat: add SQLite purge and reset utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,31 @@ scripts/dev-check.sh
 ```
 
 Para habilitar HTTPS local consulta [docs/dev-https.md](docs/dev-https.md).
+
+## Mantenimiento SQLite — Reinicio total (solo desarrollo)
+
+El proyecto incluye un comando para vaciar por completo la tabla de productos y
+reiniciar el contador de IDs de la base de datos SQLite. Está pensado solo para
+entornos de desarrollo.
+
+```
+python -m product_research_app.maintenance purge-and-reset \
+  --yes --i-know-what-im-doing --no-prompt
+```
+
+- Crea un respaldo automático en `backups/` antes de realizar cambios.
+- Requiere que `APP_ENV` o `ENV` sea `development` o `local`.
+- En otros entornos se rechazará salvo que se añada `--dangerously-on-prod`
+  junto con las confirmaciones dobles.
+- Bandera `--force` ignora claves foráneas (imprime advertencias visibles).
+
+### Uso en CI
+
+En pipelines de integración continua puede ejecutarse en modo no interactivo
+añadiendo la bandera `--no-prompt` y asegurando que las variables de entorno
+correspondan al entorno de desarrollo.
+
+### Recuperación ante fallos
+
+Si algo sale mal, restaura la copia de seguridad reemplazando el archivo de la
+base de datos por el último backup generado en `backups/`.

--- a/product_research_app/maintenance.py
+++ b/product_research_app/maintenance.py
@@ -1,0 +1,181 @@
+import argparse
+import os
+import shutil
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+PREFIX = "[SQLite-Maintenance]"
+
+
+def log(msg: str) -> None:
+    print(f"{PREFIX} {msg}")
+
+
+def locate_db(repo_root: Path) -> Path:
+    default = repo_root / "product_research_app" / "data.sqlite3"
+    if default.exists():
+        return default
+    for path in repo_root.rglob("*.sqlite*"):
+        if path.is_file():
+            return path
+    raise FileNotFoundError("No se encontró ningún archivo SQLite")
+
+
+def find_foreign_key_refs(conn: sqlite3.Connection, target: str) -> List[str]:
+    cur = conn.cursor()
+    tables = [row[0] for row in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    refs = []
+    for tbl in tables:
+        fk_cur = cur.execute(f"PRAGMA foreign_key_list({tbl})")
+        for fk in fk_cur.fetchall():
+            # fk[2] is the table referenced
+            if fk[2] == target:
+                refs.append(tbl)
+                break
+    return refs
+
+
+def _insert_dummy(conn: sqlite3.Connection, table: str) -> int:
+    cur = conn.cursor()
+    info = cur.execute(f"PRAGMA table_info({table})").fetchall()
+    cols: List[str] = []
+    vals: List[object] = []
+    for _, name, coltype, notnull, dflt, pk in info:
+        if pk:
+            continue
+        if notnull and dflt is None:
+            cols.append(name)
+            t = coltype.upper() if coltype else ""
+            if any(x in t for x in ["INT", "REAL", "NUM"]):
+                vals.append(0)
+            else:
+                # Generic placeholder
+                vals.append("test")
+    if cols:
+        placeholders = ",".join(["?"] * len(cols))
+        columns = ",".join(cols)
+        cur.execute(f"INSERT INTO {table} ({columns}) VALUES ({placeholders})", vals)
+    else:
+        cur.execute(f"INSERT INTO {table} DEFAULT VALUES")
+    return cur.lastrowid
+
+
+def purge_and_reset(args: argparse.Namespace) -> int:
+    env = os.getenv("APP_ENV") or os.getenv("ENV")
+    allowed_envs = {"development", "local"}
+    if env not in allowed_envs and not args.dangerously_on_prod:
+        log("Entorno no permitido. Use --dangerously-on-prod si está seguro.")
+        return 1
+    if args.no_prompt:
+        if not (args.yes and args.i_know):
+            log("Faltan confirmaciones --yes y --i-know-what-im-doing.")
+            return 2
+    else:
+        if not args.yes:
+            resp = input("Esta acción eliminará datos. Escribe 'yes' para continuar: ")
+            if resp.strip().lower() != "yes":
+                log("Operación cancelada por el usuario.")
+                return 2
+        if not args.i_know:
+            resp = input("Escribe 'I know what I'm doing' para continuar: ")
+            if resp.strip() != "I know what I'm doing":
+                log("Operación cancelada por el usuario.")
+                return 2
+    repo_root = Path(__file__).resolve().parent.parent
+    try:
+        db_path = locate_db(repo_root)
+    except FileNotFoundError as e:
+        log(str(e))
+        return 1
+    log(f"Base de datos objetivo: {db_path}")
+    backup_dir = repo_root / "backups"
+    backup_dir.mkdir(exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    backup_path = backup_dir / f"{db_path.name}.{timestamp}.bak"
+    shutil.copy2(db_path, backup_path)
+    log(f"Copia de seguridad creada en {backup_path}")
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        cur = conn.cursor()
+        table = args.table
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name = ?", (table,)
+        )
+        if not cur.fetchone():
+            log(f"La tabla '{table}' no existe.")
+            return 1
+        refs = find_foreign_key_refs(conn, table)
+        if refs and not args.force:
+            log(f"Existen claves foráneas apuntando a {table}: {', '.join(refs)}")
+            log("Use --force para continuar de todas maneras.")
+            return 1
+        if refs and args.force:
+            log("ADVERTENCIA: Forzando a pesar de claves foráneas activas.")
+        cur.execute(f"SELECT COUNT(*) FROM {table}")
+        rows = cur.fetchone()[0]
+        cur.execute("SELECT seq FROM sqlite_sequence WHERE name=?", (table,))
+        seq_row = cur.fetchone()
+        seq_before = seq_row[0] if seq_row else 0
+        if rows == 0 and seq_before in (0, None):
+            log("La tabla ya está vacía y el contador reiniciado. Nada que hacer.")
+            return 0
+        try:
+            cur.execute("BEGIN")
+            cur.execute(f"DELETE FROM {table}")
+            cur.execute("DELETE FROM sqlite_sequence WHERE name=?", (table,))
+            conn.commit()
+        except sqlite3.DatabaseError as e:
+            conn.rollback()
+            log(f"Error al limpiar la tabla: {e}")
+            return 3
+        try:
+            conn.execute("VACUUM")
+        except sqlite3.DatabaseError as e:
+            log(f"Error en VACUUM: {e}")
+            return 3
+        cur.execute("SELECT seq FROM sqlite_sequence WHERE name=?", (table,))
+        seq_row = cur.fetchone()
+        seq_after = seq_row[0] if seq_row else 0
+        try:
+            cur.execute("BEGIN")
+            new_id = _insert_dummy(conn, table)
+            cur.execute("ROLLBACK")
+        except Exception as e:
+            cur.execute("ROLLBACK")
+            log(f"Error verificando inserción: {e}")
+            return 3
+        log(f"Filas eliminadas: {rows}")
+        log(f"Contador antes: {seq_before} / después: {seq_after}")
+        log(f"Verificación final, próxima id será {new_id}")
+        conn.close()
+        return 0
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Herramientas de mantenimiento SQLite")
+    sub = parser.add_subparsers(dest="command")
+    p = sub.add_parser("purge-and-reset", help="Vacía tabla y reinicia IDs")
+    p.add_argument("--table", default="products")
+    p.add_argument("--yes", action="store_true", help="Confirmar acción")
+    p.add_argument("--i-know-what-im-doing", dest="i_know", action="store_true", help="Confirmación adicional")
+    p.add_argument("--no-prompt", action="store_true", help="Modo no interactivo")
+    p.add_argument("--force", action="store_true", help="Ignorar claves foráneas")
+    p.add_argument("--dangerously-on-prod", action="store_true", dest="dangerously_on_prod", help="Permite ejecución en producción")
+    args = parser.parse_args(argv)
+    if args.command == "purge-and-reset":
+        return purge_and_reset(args)
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,88 @@
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+from product_research_app import database
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DB_PATH = REPO_ROOT / "product_research_app" / "data.sqlite3"
+
+
+class PurgeResetTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if DB_PATH.exists():
+            DB_PATH.unlink()
+        conn = database.get_connection(DB_PATH)
+        database.initialize_database(conn)
+        conn.close()
+
+    def tearDown(self) -> None:
+        if DB_PATH.exists():
+            DB_PATH.unlink()
+        backups = REPO_ROOT / "backups"
+        if backups.exists():
+            for f in backups.iterdir():
+                f.unlink()
+
+    def _run(self, extra_args=None, env=None):
+        args = [
+            "python",
+            "-m",
+            "product_research_app.maintenance",
+            "purge-and-reset",
+            "--yes",
+            "--i-know-what-im-doing",
+            "--no-prompt",
+        ]
+        if extra_args:
+            args.extend(extra_args)
+        env_vars = os.environ.copy()
+        env_vars.update({"APP_ENV": "development"})
+        if env:
+            env_vars.update(env)
+        return subprocess.run(
+            args,
+            cwd=REPO_ROOT,
+            env=env_vars,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_base_case_resets_id(self):
+        conn = database.get_connection(DB_PATH)
+        database.insert_product(conn, name="a")
+        database.insert_product(conn, name="b")
+        database.insert_product(conn, name="c")
+        conn.close()
+        res = self._run(extra_args=["--force"])
+        self.assertEqual(res.returncode, 0, res.stdout + res.stderr)
+        conn = database.get_connection(DB_PATH)
+        new_id = database.insert_product(conn, name="nuevo")
+        conn.close()
+        self.assertEqual(new_id, 1)
+
+    def test_idempotent(self):
+        conn = database.get_connection(DB_PATH)
+        database.insert_product(conn, name="x")
+        conn.close()
+        res1 = self._run(extra_args=["--force"])
+        self.assertEqual(res1.returncode, 0)
+        res2 = self._run(extra_args=["--force"])
+        self.assertEqual(res2.returncode, 0)
+        self.assertIn("nada que hacer", res2.stdout.lower())
+
+    def test_foreign_keys(self):
+        res = self._run()
+        self.assertEqual(res.returncode, 1)
+        self.assertIn("claves foráneas", res.stdout.lower())
+        res_force = self._run(extra_args=["--force"])
+        self.assertEqual(res_force.returncode, 0)
+
+    def test_environment_guard(self):
+        res = self._run(extra_args=["--force"], env={"APP_ENV": "production", "ENV": "production"})
+        self.assertEqual(res.returncode, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add purge-and-reset CLI for SQLite maintenance
- document destructive reset workflow for developers
- cover reset scenarios with unit tests

## Testing
- `python -m unittest -v tests/test_maintenance.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc2a2395608328bf8efb3d075d41f4