### PR TITLE
Fix undefined database connection in upload scoring

### DIFF
--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -1290,7 +1290,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             weights_map = config.get_scoring_v2_weights()
             for pid in inserted_ids:
                 # Recupera el registro del producto
-                p_rec = database.get_product(conn_eval, pid)
+                p_rec = database.get_product(conn, pid)
                 # Ejecuta GPT para obtener puntuaciones v2
                 resp = gpt.evaluate_winner_score(
                     api_key, model,
@@ -1317,7 +1317,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                     "sources": {f: "gpt" for f in WINNER_V2_FIELDS},
                 }
                 database.insert_score(
-                    conn_eval,
+                    conn,
                     product_id=pid,
                     model=model or "",
                     total_score=0,


### PR DESCRIPTION
## Summary
- use existing database connection when scoring newly uploaded products

## Testing
- `python -m py_compile product_research_app/web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc3b3088ec832886998c79df4fb876