### PR TITLE
Reorganizar barra de acciones de productos

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -12,32 +12,9 @@ body.dark {
   color: #eaeaea;
 }
 
-.table-toolbar {
-  position: sticky;
-  top: var(--header-h, 60px);
-  z-index: 20;
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 12px;
-  background: #f8fbff;
-  border-bottom: 1px solid #ccc;
-  color: #222;
-}
-body.dark .table-toolbar {
-  background: #131A2E;
-  border-bottom: 1px solid #243150;
-  color: #E5EAF5;
-}
-
-.table-toolbar > :first-child { justify-self: start; }
-.table-toolbar > :nth-child(2) { justify-self: center; }
-.table-toolbar > :last-child { justify-self: end; display: flex; gap: 8px; }
-
 .sticky-thead {
   position: sticky;
-  top: calc(var(--header-h, 60px) + 44px);
+  top: var(--header-h, 60px);
   background: #f8fbff;
   z-index: 15;
 }
@@ -75,6 +52,18 @@ body.dark .drawer.right {
 body.dark .legend-btn {
     background: #1F2A44;
     border: 1px solid #34456B;
+}
+
+.bottombar .controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.bottombar .actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .popover {

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -162,30 +162,29 @@ body.dark .weight-slider {
   </div>
 </div>
 
-<div id="table-toolbar" class="table-toolbar">
-  <div style="display:flex; align-items:center; gap:8px;">
-    <input type="checkbox" id="selectAll">
-    <button id="btnFilters">Filtros</button>
-    <div id="activeFilterChips" style="display:flex; flex-wrap:wrap;"></div>
-    <div>
-      <select id="groupSelect"></select>
-      <button id="btnAddToGroup">Añadir</button>
-    </div>
-  </div>
-  <div id="listMeta">0 resultados • Vista: Tabla ▾ (Tarjetas)</div>
-  <div>
-    <button id="btnColumns">Columnas</button>
-    <button id="btnDelete" disabled>Eliminar</button>
-    <button id="btnExport" disabled>Exportar</button>
-  </div>
-</div>
-
 <table id="productTable">
   <thead class="sticky-thead">
     <tr id="headerRow"></tr>
   </thead>
   <tbody></tbody>
 </table>
+<div id="bottomBar" class="bottombar">
+  <div class="controls">
+    <button id="legendBtn" class="legend-btn">ℹ️</button>
+    <input type="checkbox" id="selectAll">
+    <button id="btnFilters">Filtros</button>
+    <div id="activeFilterChips" style="display:flex; flex-wrap:wrap;"></div>
+    <select id="groupSelect"></select>
+    <span id="selCount"></span>
+  </div>
+  <div id="listMeta">0 resultados • Vista: Tabla ▾ (Tarjetas)</div>
+  <div class="actions">
+    <button id="btnAddToGroup" disabled>Añadir a grupo</button>
+    <button id="btnColumns">Columnas</button>
+    <button id="btnDelete" disabled>Eliminar</button>
+    <button id="btnExport" disabled>Exportar</button>
+  </div>
+</div>
 <div id="legendPop" class="popover hidden">
   <div>• Fila roja: duplicado</div>
   <div>• 🔥 x1–x5: tendencia en el nombre</div>

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -1,7 +1,6 @@
 const selection = new Set();
 let currentPageIds = [];
 const master = document.getElementById('selectAll');
-let bottomBar = null;
 
 import('./format.js').then(m => {
   window.abbr = m.abbr;
@@ -12,16 +11,12 @@ function updateMasterState(){
   const selectedOnPage = currentPageIds.filter(id => selection.has(id)).length;
   master.indeterminate = selectedOnPage>0 && selectedOnPage<currentPageIds.length;
   master.checked = selectedOnPage===currentPageIds.length && currentPageIds.length>0;
-  document.getElementById('btnDelete').disabled = selection.size===0;
-  document.getElementById('btnExport').disabled = selection.size===0;
-  if(bottomBar){
-    document.getElementById('selCount').textContent = `${selection.size} seleccionados`;
-    if(selection.size>0){
-      bottomBar.classList.remove('hidden');
-    }else{
-      bottomBar.classList.add('hidden');
-    }
-  }
+  const disable = selection.size===0;
+  document.getElementById('btnDelete').disabled = disable;
+  document.getElementById('btnExport').disabled = disable;
+  document.getElementById('btnAddToGroup').disabled = disable;
+  const selCount = document.getElementById('selCount');
+  if(selCount){ selCount.textContent = selection.size ? `${selection.size} seleccionados` : ''; }
 }
 master.addEventListener('change', ()=>{
   if(master.checked){ currentPageIds.forEach(id=>selection.add(String(id))); }
@@ -34,20 +29,9 @@ function firesFor(score0to5){
   const n = Math.max(0, Math.min(5, Math.round(score0to5 || 0)));
   return '🔥'.repeat(n);
 }
-const table = document.getElementById('productTable');
-if(table){
-  bottomBar = document.createElement('div');
-  bottomBar.id = 'bottomBar';
-  bottomBar.className = 'bottombar hidden';
-    bottomBar.innerHTML = '<div style="display:flex; align-items:center; gap:8px;"><button id="legendBtn" class="legend-btn">ℹ️</button><span id="selCount"></span></div><div><button id="bbDelete">Eliminar</button><button id="bbExport">Exportar</button><button id="bbAddGroup">Añadir a grupo</button></div>';
-  table.parentElement.appendChild(bottomBar);
-    const legendBtn = document.getElementById('legendBtn');
-    const legendPop = document.getElementById('legendPop');
-    if(legendBtn && legendPop){
-      legendBtn.addEventListener('click', ()=>legendPop.classList.toggle('hidden'));
-      document.addEventListener('click',(e)=>{ if(!legendPop.contains(e.target) && e.target!==legendBtn) legendPop.classList.add('hidden'); });
-    }
-  document.getElementById('bbDelete').addEventListener('click', ()=>document.getElementById('btnDelete').click());
-  document.getElementById('bbExport').addEventListener('click', ()=>document.getElementById('btnExport').click());
-  document.getElementById('bbAddGroup').addEventListener('click', ()=>document.getElementById('btnAddToGroup').click());
+const legendBtn = document.getElementById('legendBtn');
+const legendPop = document.getElementById('legendPop');
+if(legendBtn && legendPop){
+  legendBtn.addEventListener('click', ()=>legendPop.classList.toggle('hidden'));
+  document.addEventListener('click',(e)=>{ if(!legendPop.contains(e.target) && e.target!==legendBtn) legendPop.classList.add('hidden'); });
 }


### PR DESCRIPTION
## Summary
- Mover controles de filtros, selección y grupos a una barra inferior
- Eliminar botones duplicados y ubicar el botón de columnas junto a las acciones
- Añadir mayor separación entre botones de acción

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bc3cddb2fc8328b5e09e9c8e0b01b3