### PR TITLE
feat: add toolbars and relocate controls

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -12,11 +12,18 @@ body.dark {
   color: #eaeaea;
 }
 
+:root {
+  --appbar-h: 60px;
+  --pagebar-h: 52px;
+  --tabletoolbar-h: 44px;
+  --table-offset: calc(var(--appbar-h) + var(--pagebar-h) + var(--tabletoolbar-h));
+}
+
 .sticky-thead {
   position: sticky;
-  top: calc(var(--header-h, 60px) + var(--toolbar-h, 0px));
+  top: var(--table-offset);
   background: #f8fbff;
-  z-index: 15;
+  z-index: 10;
 }
 body.dark .sticky-thead {
   background: #131A2E;
@@ -54,24 +61,11 @@ body.dark .legend-btn {
     border: 1px solid #34456B;
 }
 
-.bottombar .controls {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex: 1;
-  flex-wrap: wrap;
-}
-
-.bottombar .actions {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
 
 .popover {
   position: fixed;
   right: 16px;
-  top: calc(var(--header-h, 60px) + var(--toolbar-h, 0px) + 56px);
+  top: calc(var(--table-offset) + 56px);
   background: #fff;
   border: 1px solid #ccc;
   padding: 10px 12px;
@@ -125,6 +119,20 @@ body.dark .chip button { color: #A9B4D0; }
 
 #topBar { position: sticky; top: 0; z-index: 40; }
 
+#pageBar {
+  position: sticky;
+  top: var(--appbar-h);
+  z-index: 30;
+  min-height: var(--pagebar-h);
+}
+
+#tableToolbar {
+  position: sticky;
+  top: calc(var(--appbar-h) + var(--pagebar-h));
+  z-index: 20;
+  min-height: var(--tabletoolbar-h);
+}
+
 .table tr { height: 52px; }
 .table td, .table th { padding: 8px 12px; }
 body.dark .table tbody tr:nth-child(odd) { background: #11192B; }
@@ -134,23 +142,24 @@ body.dark .table tbody tr:nth-child(odd) { background: #11192B; }
 .score-amber { background: #3A3119; color: #F1B44C; }
 .score-red { background: #3A1E1E; color: #F16969; }
 
-.bottombar {
-  position: sticky;
-  top: var(--header-h, 60px);
-  left: 0;
-  right: 0;
+#pageBar, #tableToolbar {
   background: #f8fbff;
   border-bottom: 1px solid #ccc;
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 8px 12px;
-  z-index: 25;
-  color: #222;
+  gap: 8px;
   flex-wrap: wrap;
 }
-body.dark .bottombar {
+body.dark #pageBar, body.dark #tableToolbar {
   background: #0F1424;
   border-bottom: 1px solid #243150;
   color: #E5EAF5;
+}
+#pageBar .left, #pageBar .right, #tableToolbar .left, #tableToolbar .right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
 }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -68,6 +68,14 @@ body.dark .weight-slider {
     </div>
   </header>
 </div>
+<div id="pageBar" role="toolbar">
+  <div class="left"></div>
+  <div class="right"></div>
+</div>
+<div id="tableToolbar" role="toolbar">
+  <div class="left"></div>
+  <div class="right"></div>
+</div>
 <div id="config" style="display:none;">
   <label>API Key: <input type="password" id="apiKey" /></label>
   <button id="toggleApiKey" style="display:none;">Cambiar API Key</button>
@@ -1074,5 +1082,60 @@ window.parseDate = parseDate;
 </script>
 <div id="chartTooltip" style="position:absolute; background:#fff; border:1px solid #333; padding:4px; font-size:12px; border-radius:4px; pointer-events:none; display:none; z-index:2000;"></div>
 <script src="/static/js/filters.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  function ensureBar(id) {
+    let bar = document.getElementById(id);
+    if (!bar) {
+      bar = document.createElement('div');
+      bar.id = id;
+      bar.setAttribute('role', 'toolbar');
+      bar.innerHTML = '<div class="left"></div><div class="right"></div>';
+      document.body.insertBefore(bar, document.body.firstChild);
+    }
+    if (!bar.querySelector('.left')) {
+      const left = document.createElement('div');
+      left.className = 'left';
+      bar.appendChild(left);
+    }
+    if (!bar.querySelector('.right')) {
+      const right = document.createElement('div');
+      right.className = 'right';
+      bar.appendChild(right);
+    }
+    return bar;
+  }
+  const pageBar = ensureBar('pageBar');
+  const tableToolbar = ensureBar('tableToolbar');
+  const zones = {
+    pageLeft: pageBar.querySelector('.left'),
+    pageRight: pageBar.querySelector('.right'),
+    tableLeft: tableToolbar.querySelector('.left'),
+    tableRight: tableToolbar.querySelector('.right')
+  };
+  const moves = [
+    ['searchInput', zones.pageLeft],
+    ['searchBtn', zones.pageLeft],
+    ['btnFilters', zones.pageLeft],
+    ['activeFilterChips', zones.pageLeft],
+    ['listMeta', zones.pageLeft],
+    ['newListName', zones.pageRight],
+    ['createListBtn', zones.pageRight],
+    ['groupSelect', zones.pageRight],
+    ['sendPrompt', zones.pageRight],
+    ['selectAll', zones.tableLeft],
+    ['btnColumns', zones.tableRight],
+    ['btnAddToGroup', zones.tableRight],
+    ['btnExport', zones.tableRight],
+    ['btnDelete', zones.tableRight]
+  ];
+  moves.forEach(([id, target]) => {
+    const el = document.getElementById(id);
+    if (el && target && el.parentElement !== target) {
+      target.appendChild(el);
+    }
+  });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add pageBar and tableToolbar containers with left/right zones
- relocate existing controls by id into new toolbars without duplicating nodes
- style new toolbars and ensure idempotent migration script
- define sticky height variables and z-index offsets so page and table toolbars stack under the app bar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc434b091c8328b8a12f306f919200