### PR TITLE
Refactor top bar layout into two sticky rows

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -13,19 +13,59 @@ body.dark {
 }
 
 :root {
-  --appbar-h: 60px;
-  --controlbar-h: 52px;
+  --topbar-h: 56px;
+  --toolbar-h: 44px;
 }
 
-.sticky-thead {
+/* Sticky top bars */
+.app-topbar, .table-toolbar {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  flex-wrap:wrap;
+  gap:8px;
+  padding:8px 12px;
+  background:#f8fbff;
+  border-bottom:1px solid #ccc;
+  box-shadow:0 2px 4px rgba(0,0,0,0.05);
+}
+.app-topbar {
   position: sticky;
-  top: calc(var(--appbar-h) + var(--controlbar-h));
+  top: 0;
+  z-index: 1000;
+  min-height: var(--topbar-h);
+}
+.table-toolbar {
+  position: sticky;
+  top: var(--topbar-h, 56px);
+  z-index: 999;
+  min-height: var(--toolbar-h);
+}
+body.dark .app-topbar, body.dark .table-toolbar {
+  background:#0F1424;
+  border-bottom:1px solid #243150;
+  color:#E5EAF5;
+}
+.app-topbar .left, .app-topbar .right, .table-toolbar .left, .table-toolbar .right {
+  display:flex;
+  align-items:center;
+  gap:8px;
+  flex-wrap:wrap;
+}
+/* Smaller search input */
+.app-topbar #searchInput { width: 200px; max-width: 220px; }
+/* Sticky table header below the top bars */
+table thead th {
+  position: sticky;
+  top: calc(var(--topbar-h, 56px) + var(--toolbar-h, 44px));
   background: #f8fbff;
-  z-index: 10;
+  z-index: 998;
 }
-body.dark .sticky-thead {
-  background: #131A2E;
+body.dark table thead th {
+  background: #0F1424;
 }
+
+
 
 .drawer.right {
   position: fixed;
@@ -63,7 +103,7 @@ body.dark .legend-btn {
 .popover {
   position: fixed;
   right: 16px;
-  top: calc(var(--appbar-h) + var(--controlbar-h) + 56px);
+  top: calc(var(--topbar-h, 56px) + var(--toolbar-h, 44px) + 56px);
   background: #fff;
   border: 1px solid #ccc;
   padding: 10px 12px;
@@ -144,20 +184,7 @@ body.dark .chip button { color: #A9B4D0; }
 
 /* Control bar sticks beneath the app bar */
 #controlBar {
-  position: sticky;
-  top: var(--appbar-h);
-  z-index: 30;
-  background: #432874;
-  color: #fff;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 12px;
-  gap: 8px;
-  flex-wrap: wrap;
-  width: 100%;
-  box-sizing: border-box;
-  min-height: var(--controlbar-h);
+  /* deprecated */
 }
 
 .table tr { height: 52px; }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -48,66 +48,6 @@ body.dark pre { background:#2e315f; }
 body.dark .weight-slider {
   accent-color:#7a53d6;
 }
-#pageBar, #tableToolbar {
-  display:flex;
-  justify-content:space-between;
-  align-items:center;
-  flex-wrap:wrap;
-  gap:8px;
-  background:#f8fbff;
-  border-bottom:1px solid #ccc;
-  padding:8px 12px;
-}
-body.dark #pageBar, body.dark #tableToolbar {
-  background:#0F1424;
-  border-bottom:1px solid #243150;
-  color:#E5EAF5;
-}
-#pageBar .left, #pageBar .right, #tableToolbar .left, #tableToolbar .right {
-  display:flex;
-  align-items:center;
-  gap:8px;
-  flex-wrap:wrap;
-}
-
-:root { --controlbar-h: 54px; }
-/* Make unified control bar sticky and compact */
-#controlBar {
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  display:flex;
-  justify-content:space-between;
-  align-items:center;
-  flex-wrap:wrap;
-  gap:8px;
-  background:#f8fbff;
-  border-bottom:1px solid #ccc;
-  padding:8px 12px;
-}
-body.dark #controlBar {
-  background:#0F1424;
-  border-bottom:1px solid #243150;
-  color:#E5EAF5;
-}
-#controlBar .left, #controlBar .right {
-  display:flex;
-  align-items:center;
-  gap:8px;
-  flex-wrap:wrap;
-}
-/* Smaller search input to avoid overlap */
-#controlBar #searchInput { width: 240px; max-width: 260px; }
-/* Sticky table header below the control bar */
-.sticky-thead th {
-  position: sticky;
-  top: var(--controlbar-h);
-  background: #f8fbff;
-  z-index: 500;
-}
-body.dark .sticky-thead th {
-  background: #0F1424;
-}
 </style>
 </head>
 <body class="dark">
@@ -127,25 +67,32 @@ body.dark .sticky-thead th {
 </div>
 </header>
 </div>
-<!-- Unified control bar replacing page and table toolbars -->
-<div aria-label="Barra de controles" id="controlBar" role="toolbar">
-<div class="left">
-<input id="searchInput" placeholder="Buscar producto o palabra clave..." type="text"/>
-<button id="searchBtn">Buscar</button>
-<button id="btnFilters">Filtros</button>
-<div id="activeFilterChips"></div>
-<div id="listMeta">0 resultados</div>
+<div class="app-topbar" role="toolbar">
+  <div class="left">
+    <input id="searchInput" placeholder="Buscar producto o palabra clave..." type="text"/>
+    <button id="searchBtn">Buscar</button>
+  </div>
+  <div class="right">
+    <select aria-label="Seleccionar grupo" id="groupSelect"></select>
+    <button aria-label="Añadir a grupo" disabled="" id="btnAddToGroup">Añadir a grupo</button>
+    <button aria-controls="promptDrawer" aria-haspopup="dialog" id="sendPrompt" type="button">Consulta a GPT</button>
+    <button id="btnColumns">Columnas</button>
+    <button disabled="" id="btnExport">Exportar</button>
+    <button disabled="" id="btnDelete">Eliminar</button>
+    <input id="newListName" style="display:none;" type="text"/>
+    <button id="createListBtn" style="display:none;">Crear grupo</button>
+  </div>
 </div>
-<div class="right">
-<button aria-label="Información de columnas" class="legend-btn" id="legendBtn">ℹ️</button>
-<span aria-live="polite" id="selCount"></span>
-<select aria-label="Seleccionar grupo" id="groupSelect"></select>
-<button aria-label="Añadir a grupo" disabled="" id="btnAddToGroup">Añadir a grupo</button>
-<button aria-controls="promptDrawer" aria-haspopup="dialog" id="sendPrompt" type="button">Consulta a GPT</button>
-<button id="btnColumns">Columnas</button>
-<button disabled="" id="btnExport">Exportar</button>
-<button disabled="" id="btnDelete">Eliminar</button>
-</div>
+<div class="table-toolbar">
+  <div class="left">
+    <button id="btnFilters">Filtros</button>
+    <div id="activeFilterChips"></div>
+    <div id="listMeta">0 resultados</div>
+  </div>
+  <div class="right">
+    <span aria-live="polite" id="selCount"></span>
+    <button aria-label="Información de columnas" class="legend-btn" id="legendBtn">ℹ️</button>
+  </div>
 </div>
 <input aria-label="Seleccionar todo" id="selectAll" style="display:none;" type="checkbox"/>
 <div id="config" style="display:none;">
@@ -232,7 +179,7 @@ body.dark .sticky-thead th {
 </div>
 </div>
 <table id="productTable">
-<thead class="sticky-thead">
+<thead>
 <tr id="headerRow"></tr>
 </thead>
 <tbody></tbody>
@@ -1147,69 +1094,14 @@ window.parseDate = parseDate;
 <script src="/static/js/filters.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-  function ensureBar(id) {
-    let bar = document.getElementById(id);
-    if (!bar) {
-      bar = document.createElement('div');
-      bar.id = id;
-      bar.setAttribute('role', 'toolbar');
-      bar.innerHTML = '<div class="left"></div><div class="right"></div>';
-      document.body.insertBefore(bar, document.body.firstChild);
-    }
-    if (!bar.querySelector('.left')) {
-      const left = document.createElement('div');
-      left.className = 'left';
-      bar.appendChild(left);
-    }
-    if (!bar.querySelector('.right')) {
-      const right = document.createElement('div');
-      right.className = 'right';
-      bar.appendChild(right);
-    }
-    return bar;
-  }
-  const controlBar = ensureBar('controlBar');
-  function setControlBarHeightVar(){
-    const h = controlBar.offsetHeight || 54;
-    document.documentElement.style.setProperty('--controlbar-h', h + 'px');
-  }
-  setControlBarHeightVar();
-  window.addEventListener('resize', setControlBarHeightVar);
-  const zones = {
-    left: controlBar.querySelector('.left'),
-    right: controlBar.querySelector('.right')
-  };
-  const moves = [
-    ['searchInput', zones.left],
-    ['searchBtn', zones.left],
-    ['btnFilters', zones.left],
-    ['activeFilterChips', zones.left],
-    ['listMeta', zones.left],
-    ['legendBtn', zones.right],
-    ['selCount', zones.right],
-    ['groupSelect', zones.right],
-    ['btnAddToGroup', zones.right],
-    ['sendPrompt', zones.right],
-    ['btnColumns', zones.right],
-    ['btnExport', zones.right],
-    ['btnDelete', zones.right]
-  ];
-  moves.forEach(([id, target]) => {
-    const el = document.getElementById(id);
-    if (el && target) {
-      target.appendChild(el);
-    }
-  });
-  // Ensure group creation controls are visible and in the control bar
+
   const nameInp = document.getElementById('newListName');
   const createBtn = document.getElementById('createListBtn');
   if (nameInp && createBtn) {
     nameInp.style.display = '';
     nameInp.placeholder = nameInp.placeholder || 'Nuevo grupo';
     nameInp.style.width = nameInp.style.width || '140px';
-    zones.right.appendChild(nameInp);
     createBtn.style.display = '';
-    zones.right.appendChild(createBtn);
     nameInp.addEventListener('keydown', (ev) => {
       if (ev.key === 'Enter') {
         createBtn.click();
@@ -1217,17 +1109,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  const bottomBar = document.getElementById('bottomBar');
-  const master = document.getElementById('selectAll');
-  if (master) {
-    master.style.display = 'none';
-    document.body.appendChild(master);
-  }
-  
-  // Populate groups after controls are placed
   if (typeof loadLists === 'function') { loadLists(); }
-bottomBar?.remove();
 });
 </script>
-<div id="listsContainer" style="display:none;"></div><input id="newListName" style="display:none;" type="text"/><button id="createListBtn" style="display:none;">Crear grupo</button></body>
+<div id="listsContainer" style="display:none;"></div></body>
 </html>


### PR DESCRIPTION
## Summary
- Define `--topbar-h` and `--toolbar-h` and apply sticky positioning for the top bar, secondary toolbar and table header
- Remove runtime height calculations and simplify the `<thead>` markup

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bc6547452483288dffcd009470e17d