### PR TITLE
feat(ui): reordenar barra inferior y fijar popover de Columnas con portal y clamp

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -89,8 +89,6 @@ body.dark .legend-btn {
 
 .popover {
   position: fixed;
-  right: 16px;
-  top: calc(var(--header-h, 60px) + 56px);
   background: #fff;
   border: 1px solid #ccc;
   padding: 10px 12px;
@@ -105,22 +103,17 @@ body.dark .popover {
 #legendPop {
   left: 16px;
   bottom: 56px;
-  right: auto;
-  top: auto;
 }
-
 #columnsPanel {
-  position: fixed;
-  left: 0;
-  top: 0;
-  right: auto;
-  bottom: auto;
-  max-height: 60vh;
+  min-width: 200px;
+  max-height: 70vh;
   overflow: auto;
-  z-index: 1500;
 }
 
 .selected .fires { filter: grayscale(1); opacity: .6; }
+
+.table tbody tr.selected { background: #cde8ff; }
+body.dark .table tbody tr.selected { background: #243150; }
 
 .chip {
   display: inline-flex;
@@ -230,4 +223,8 @@ body.dark .bottombar {
   background: #0F1424;
   border-top: 1px solid #243150;
   color: #E5EAF5;
+}
+
+#productTable {
+  margin-bottom: 80px;
 }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -171,10 +171,10 @@ body.dark .weight-slider {
     <span id="selCount"></span>
   </div>
   <div style="display:flex; gap:8px; align-items:center;">
-    <button id="btnDelete" disabled title="Eliminar seleccionados" aria-label="Eliminar seleccionados">Eliminar</button>
-    <button id="btnExport" disabled title="Exportar seleccionados" aria-label="Exportar seleccionados">Exportar</button>
     <select id="groupSelect" aria-label="Filtrar por grupo"></select>
     <button id="btnAddToGroup" disabled title="Añadir seleccionados al grupo" aria-label="Añadir seleccionados al grupo">Añadir a grupo</button>
+    <button id="btnDelete" disabled title="Eliminar seleccionados" aria-label="Eliminar seleccionados">Eliminar</button>
+    <button id="btnExport" disabled title="Exportar seleccionados" aria-label="Exportar seleccionados">Exportar</button>
     <button id="btnColumns" title="Gestionar columnas" aria-label="Gestionar columnas">Columnas</button>
   </div>
 </div>

--- a/product_research_app/static/js/columns.js
+++ b/product_research_app/static/js/columns.js
@@ -64,8 +64,9 @@
       const rect = btn.getBoundingClientRect();
       panel.classList.remove('hidden');
       panel.style.visibility = 'hidden';
+      panel.scrollTop = 0;
       // initial position anchored to button
-      let top = rect.bottom;
+      let top = rect.bottom + 4;
       let left = rect.left;
       // measure and clamp within viewport
       const w = panel.offsetWidth;

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -57,3 +57,51 @@ if(bottomBar){
     });
   }
 }
+
+const tbody = table ? table.querySelector('tbody') : null;
+let lastClickedCheck = null;
+
+if (tbody) {
+  tbody.addEventListener('click', (e) => {
+    const checkbox = e.target.closest('input.rowCheck');
+    if (checkbox) {
+      if (e.shiftKey && lastClickedCheck) {
+        e.preventDefault();
+        const boxes = Array.from(tbody.querySelectorAll('input.rowCheck'));
+        const start = boxes.indexOf(checkbox);
+        const end = boxes.indexOf(lastClickedCheck);
+        const [min, max] = start < end ? [start, end] : [end, start];
+        const state = lastClickedCheck.checked;
+        for (let i = min; i <= max; i++) {
+          boxes[i].checked = state;
+          boxes[i].dispatchEvent(new Event('change'));
+        }
+      }
+      lastClickedCheck = checkbox;
+      return;
+    }
+
+    if (e.target.closest('button, a, input, select, textarea, label, img')) return;
+
+    const row = e.target.closest('tr');
+    if (!row) return;
+    const cb = row.querySelector('input.rowCheck');
+    if (!cb) return;
+
+    if (e.shiftKey && lastClickedCheck) {
+      const boxes = Array.from(tbody.querySelectorAll('input.rowCheck'));
+      const start = boxes.indexOf(cb);
+      const end = boxes.indexOf(lastClickedCheck);
+      const [min, max] = start < end ? [start, end] : [end, start];
+      const state = lastClickedCheck.checked;
+      for (let i = min; i <= max; i++) {
+        boxes[i].checked = state;
+        boxes[i].dispatchEvent(new Event('change'));
+      }
+    } else {
+      cb.checked = !cb.checked;
+      cb.dispatchEvent(new Event('change'));
+    }
+    lastClickedCheck = cb;
+  });
+}


### PR DESCRIPTION
## Summary
- Reordenar controles de la barra inferior para agrupar selección y acciones en el orden: selector, añadir, eliminar, exportar y columnas.
- Ajustar estilos globales para popovers y tabla, incluyendo portal para el panel de columnas con anchura mínima y altura máxima desplazable.
- Corregir posicionamiento dinámico del popover de columnas con desplazamiento, clamp a la ventana y reseteo de scroll.
- Delegar clics en el tbody para permitir seleccionar filas completas, ignorando elementos interactivos y admitiendo rangos con Shift.
- Resaltar filas seleccionadas en modos claro y oscuro.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca336d5b88328a123a078bade384c