### PR TITLE
feat(groups): eliminar grupos con confirmación y opción de mover/quitar productos

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -226,6 +226,7 @@ body.dark .weight-slider {
 <script src="/static/js/table.js"></script>
 <script src="/static/js/columns.js"></script>
 <script src="/static/js/add-group.js"></script>
+<script src="/static/js/manage-groups.js"></script>
 <script type="module">
 import { fetchJson } from "/static/js/net.js";
 window.fetchJson = fetchJson;
@@ -908,14 +909,20 @@ async function loadLists() {
 
 window.loadLists = loadLists;
 
-async function deleteList(id){
+async function deleteList(id, mode='remove', target=null){
   try{
-    const data = await fetchJson('/delete_list', {method:'POST', body: JSON.stringify({id:id})});
-    loadLists();
+    const body = {id:id, mode:mode};
+    if(mode === 'move' && target !== null){ body.targetGroupId = target; }
+    const data = await fetchJson('/delete_list', {method:'POST', body: JSON.stringify(body)});
+    await loadLists();
     if(currentGroupFilter === id){
       currentGroupFilter = -1;
       fetchProducts();
+      toast.info('Grupo eliminado. Vista cambiada a "Todos"');
+    } else {
+      toast.success('Grupo eliminado');
     }
+    return data;
   }catch(err){ console.error(err); toast.error('Error al eliminar grupo'); }
 }
 

--- a/product_research_app/static/js/add-group.js
+++ b/product_research_app/static/js/add-group.js
@@ -19,6 +19,7 @@
     lists.forEach(l => { html += `<div class="grp-item" data-id="${l.id}" style="padding:4px 8px; cursor:pointer;">${l.name}</div>`; });
     html += '</div>';
     html += '<div id="grpCreate" style="padding:4px 8px; margin-top:8px; cursor:pointer; border-top:1px solid #ccc;">Crear grupo...</div>';
+    html += '<div id="grpManage" style="padding:4px 8px; cursor:pointer; border-top:1px solid #ccc;">Gestionar grupos</div>';
     pop.innerHTML = html;
 
     pop.querySelectorAll('.grp-item').forEach(el => {
@@ -47,6 +48,8 @@
         buildList('');
       }catch(err){ console.error(err); toast.error('Error al crear grupo'); }
     });
+    const manage = pop.querySelector('#grpManage');
+    manage.addEventListener('click', () => { hide(); openManageGroups(); });
     search.focus();
   }
 

--- a/product_research_app/static/js/manage-groups.js
+++ b/product_research_app/static/js/manage-groups.js
@@ -1,0 +1,66 @@
+(function(){
+  function buildDialog(){
+    const overlay = window.ensureOverlayRoot ? window.ensureOverlayRoot() : document.body;
+    let dlg = document.getElementById('manageGroups');
+    if(!dlg){
+      dlg = document.createElement('div');
+      dlg.id = 'manageGroups';
+      dlg.className = 'popover hidden';
+      dlg.style.maxWidth = '320px';
+      overlay.appendChild(dlg);
+    }
+    const lists = (window.listCache || []);
+    let html = '<h3>Grupos</h3>';
+    html += '<div style="max-height:240px;overflow:auto;">';
+    lists.forEach(l => {
+      html += `<div class="mg-row" data-id="${l.id}" data-count="${l.count}" style="display:flex;justify-content:space-between;align-items:center;padding:4px 0;">`+
+              `<span>${l.name}</span>`+
+              `<button class="mg-del" title="Eliminar" aria-label="Eliminar" style="color:#c00;border:none;background:none;cursor:pointer;">🗑</button>`+
+              `</div>`;
+    });
+    html += '</div>';
+    html += '<div style="text-align:right;margin-top:8px;"><button id="mgClose">Cerrar</button></div>';
+    dlg.innerHTML = html;
+    dlg.querySelector('#mgClose').addEventListener('click', ()=> dlg.classList.add('hidden'));
+    dlg.querySelectorAll('.mg-del').forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        const row = e.target.closest('.mg-row');
+        const id = parseInt(row.dataset.id);
+        const count = parseInt(row.dataset.count);
+        btn.disabled = true;
+        try{
+          let mode = 'remove';
+          let target = null;
+          if(count > 0){
+            const move = confirm('Mover productos a otro grupo? Cancelar para quitar');
+            if(move){
+              const others = (window.listCache||[]).filter(g=>g.id!==id);
+              if(!others.length){ toast.info('No hay grupo destino'); btn.disabled=false; return; }
+              const opt = prompt('ID del grupo destino:\n'+ others.map(g=>`${g.id}: ${g.name}`).join('\n'));
+              if(!opt){ btn.disabled=false; return; }
+              target = parseInt(opt);
+              mode = 'move';
+            }
+          }else if(!confirm('Eliminar grupo vacío?')){ btn.disabled=false; return; }
+          await deleteList(id, mode, target);
+          buildDialog();
+        }catch(err){ console.error(err); }
+        btn.disabled = false;
+      });
+    });
+    return dlg;
+  }
+  window.openManageGroups = function(){
+    const dlg = buildDialog();
+    dlg.classList.remove('hidden');
+    dlg.style.visibility = 'hidden';
+    dlg.scrollTop = 0;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const w = dlg.offsetWidth;
+    const h = dlg.offsetHeight;
+    dlg.style.left = `${(vw - w)/2}px`;
+    dlg.style.top = `${(vh - h)/2}px`;
+    dlg.style.visibility = '';
+  }
+})();


### PR DESCRIPTION
## Summary
- add counts to group listings and new delete API supporting remove or move product associations
- include manage groups dialog with delete support from UI
- update group popover and client logic to refresh lists and handle deleted current view

## Testing
- `python -m py_compile product_research_app/database.py product_research_app/web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bca949853883289f55ca5f53432543