### PR TITLE
feat(groups): eliminar grupos con confirmación y opción de mover/quitar productos

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -7,9 +7,16 @@ body {
   color: #222;
 }
 
+:root {
+  --dup-bg: #ffe5e5;
+  --dup-accent: #ff3b30;
+}
+
 body.dark {
   background: #1a1b2e;
   color: #eaeaea;
+  --dup-bg: #2A0000;
+  --dup-accent: #FF3B30;
 }
 
 table {
@@ -114,6 +121,20 @@ body.dark .popover {
 
 .table tbody tr.selected { background: #cde8ff; }
 body.dark .table tbody tr.selected { background: #243150; }
+
+.table tbody tr.is-duplicate {
+  background: var(--dup-bg);
+  border-left: 4px solid var(--dup-accent);
+}
+
+.table tbody tr.is-duplicate.selected {
+  background: var(--dup-bg);
+  border-left: 6px solid var(--dup-accent);
+}
+
+.table tbody tr.is-duplicate:hover {
+  background: var(--dup-bg);
+}
 
 .chip {
   display: inline-flex;

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -226,6 +226,7 @@ body.dark .weight-slider {
 <script src="/static/js/table.js"></script>
 <script src="/static/js/columns.js"></script>
 <script src="/static/js/add-group.js"></script>
+<script src="/static/js/manage-groups.js"></script>
 <script type="module">
 import { fetchJson } from "/static/js/net.js";
 window.fetchJson = fetchJson;
@@ -282,6 +283,45 @@ const columns = [
 ];
 
 let trendingWords = [];
+
+function mapTrendingScore(raw){
+  const n = Number(raw);
+  if (isNaN(n)) return 0;
+  if (n <= 5) return Math.max(0, Math.round(n));
+  if (n <= 9) return 0;
+  if (n <= 19) return 1;
+  if (n <= 34) return 2;
+  if (n <= 54) return 3;
+  if (n <= 79) return 4;
+  return 5;
+}
+
+function normalizeDupKey(item){
+  const norm = (str) => (str || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+  return norm(item.name) + '|' + norm(item.image_url);
+}
+
+function preprocessProducts(list){
+  const dupMap = new Map();
+  list.forEach(item => {
+    item.trending = mapTrendingScore(item.trendingScore);
+    if (item.extras && item.extras['duplicate_of']) {
+      item.isDuplicate = true;
+      return;
+    }
+    const key = normalizeDupKey(item);
+    item._dupKey = key;
+    const arr = dupMap.get(key);
+    if (arr) arr.push(item); else dupMap.set(key, [item]);
+  });
+  dupMap.forEach(arr => { if (arr.length > 1) arr.forEach(it => it.isDuplicate = true); });
+}
 
 const weightFields = [
   'magnitud_deseo',
@@ -367,6 +407,7 @@ async function fetchProducts() {
   const data = await fetchJson('/products');
   // keep a copy of all products for filtering
   allProducts = data;
+  preprocessProducts(allProducts);
   products = [...allProducts];
   window.allProducts = allProducts;
   window.products = products;
@@ -404,11 +445,9 @@ function renderTable() {
   // Render rows
     products.forEach(item => {
     const tr = document.createElement('tr');
-    // mark duplicate rows
-    if (item.extras && item.extras['duplicate_of']) {
-      tr.style.backgroundColor = 'rgba(255, 230, 230, 0.5)';
+    if (item.isDuplicate) {
+      tr.classList.add('is-duplicate');
     }
-    // trending highlighting is now indicated by fire emojis instead of row outline
     // Selection checkbox
     const tdSel = document.createElement('td');
     const cb = document.createElement('input');
@@ -466,14 +505,17 @@ function renderTable() {
         };
         td.appendChild(img);
       } else if (key === 'name' && value) {
-        const fireText = firesFor(item.trendingScore);
+        const fireCount = item.trending || 0;
+        const fireText = firesFor(fireCount);
         const nameSpan = document.createElement('span');
         nameSpan.textContent = value + (fireText ? ' ' : '');
         td.appendChild(nameSpan);
-        if (fireText) {
+        if (fireCount > 0) {
           const fireSpan = document.createElement('span');
           fireSpan.className = 'fires';
           fireSpan.textContent = fireText;
+          fireSpan.setAttribute('aria-label', `Tendencia: x${fireCount}`);
+          fireSpan.title = `Tendencia: x${fireCount}`;
           td.appendChild(fireSpan);
         }
         // If Kalodata URL exists, add copy link button
@@ -908,14 +950,20 @@ async function loadLists() {
 
 window.loadLists = loadLists;
 
-async function deleteList(id){
+async function deleteList(id, mode='remove', target=null){
   try{
-    const data = await fetchJson('/delete_list', {method:'POST', body: JSON.stringify({id:id})});
-    loadLists();
+    const body = {id:id, mode:mode};
+    if(mode === 'move' && target !== null){ body.targetGroupId = target; }
+    const data = await fetchJson('/delete_list', {method:'POST', body: JSON.stringify(body)});
+    await loadLists();
     if(currentGroupFilter === id){
       currentGroupFilter = -1;
       fetchProducts();
+      toast.info('Grupo eliminado. Vista cambiada a "Todos"');
+    } else {
+      toast.success('Grupo eliminado');
     }
+    return data;
   }catch(err){ console.error(err); toast.error('Error al eliminar grupo'); }
 }
 

--- a/product_research_app/static/js/add-group.js
+++ b/product_research_app/static/js/add-group.js
@@ -19,6 +19,7 @@
     lists.forEach(l => { html += `<div class="grp-item" data-id="${l.id}" style="padding:4px 8px; cursor:pointer;">${l.name}</div>`; });
     html += '</div>';
     html += '<div id="grpCreate" style="padding:4px 8px; margin-top:8px; cursor:pointer; border-top:1px solid #ccc;">Crear grupo...</div>';
+    html += '<div id="grpManage" style="padding:4px 8px; cursor:pointer; border-top:1px solid #ccc;">Gestionar grupos</div>';
     pop.innerHTML = html;
 
     pop.querySelectorAll('.grp-item').forEach(el => {
@@ -47,6 +48,8 @@
         buildList('');
       }catch(err){ console.error(err); toast.error('Error al crear grupo'); }
     });
+    const manage = pop.querySelector('#grpManage');
+    manage.addEventListener('click', () => { hide(); openManageGroups(); });
     search.focus();
   }
 

--- a/product_research_app/static/js/manage-groups.js
+++ b/product_research_app/static/js/manage-groups.js
@@ -1,0 +1,66 @@
+(function(){
+  function buildDialog(){
+    const overlay = window.ensureOverlayRoot ? window.ensureOverlayRoot() : document.body;
+    let dlg = document.getElementById('manageGroups');
+    if(!dlg){
+      dlg = document.createElement('div');
+      dlg.id = 'manageGroups';
+      dlg.className = 'popover hidden';
+      dlg.style.maxWidth = '320px';
+      overlay.appendChild(dlg);
+    }
+    const lists = (window.listCache || []);
+    let html = '<h3>Grupos</h3>';
+    html += '<div style="max-height:240px;overflow:auto;">';
+    lists.forEach(l => {
+      html += `<div class="mg-row" data-id="${l.id}" data-count="${l.count}" style="display:flex;justify-content:space-between;align-items:center;padding:4px 0;">`+
+              `<span>${l.name}</span>`+
+              `<button class="mg-del" title="Eliminar" aria-label="Eliminar" style="color:#c00;border:none;background:none;cursor:pointer;">🗑</button>`+
+              `</div>`;
+    });
+    html += '</div>';
+    html += '<div style="text-align:right;margin-top:8px;"><button id="mgClose">Cerrar</button></div>';
+    dlg.innerHTML = html;
+    dlg.querySelector('#mgClose').addEventListener('click', ()=> dlg.classList.add('hidden'));
+    dlg.querySelectorAll('.mg-del').forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        const row = e.target.closest('.mg-row');
+        const id = parseInt(row.dataset.id);
+        const count = parseInt(row.dataset.count);
+        btn.disabled = true;
+        try{
+          let mode = 'remove';
+          let target = null;
+          if(count > 0){
+            const move = confirm('Mover productos a otro grupo? Cancelar para quitar');
+            if(move){
+              const others = (window.listCache||[]).filter(g=>g.id!==id);
+              if(!others.length){ toast.info('No hay grupo destino'); btn.disabled=false; return; }
+              const opt = prompt('ID del grupo destino:\n'+ others.map(g=>`${g.id}: ${g.name}`).join('\n'));
+              if(!opt){ btn.disabled=false; return; }
+              target = parseInt(opt);
+              mode = 'move';
+            }
+          }else if(!confirm('Eliminar grupo vacío?')){ btn.disabled=false; return; }
+          await deleteList(id, mode, target);
+          buildDialog();
+        }catch(err){ console.error(err); }
+        btn.disabled = false;
+      });
+    });
+    return dlg;
+  }
+  window.openManageGroups = function(){
+    const dlg = buildDialog();
+    dlg.classList.remove('hidden');
+    dlg.style.visibility = 'hidden';
+    dlg.scrollTop = 0;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const w = dlg.offsetWidth;
+    const h = dlg.offsetHeight;
+    dlg.style.left = `${(vw - w)/2}px`;
+    dlg.style.top = `${(vh - h)/2}px`;
+    dlg.style.visibility = '';
+  }
+})();


### PR DESCRIPTION
## Summary
- add counts to group listings and new delete API supporting remove or move product associations
- include manage groups dialog with delete support from UI
- highlight duplicates with bold red styling and show 0–5 fire icons inside product names

## Testing
- `python -m py_compile product_research_app/database.py product_research_app/web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bca949853883289f55ca5f53432543