### PR TITLE
feat(ui): mover “Gestionar grupos” junto a “Añadir a grupo” y mejorar estados de botones

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -10,6 +10,10 @@ body {
 :root {
   --dup-bg: #ffe5e5;
   --dup-accent: #ff3b30;
+  --bar-btn-bg: #e0f0ff;
+  --bar-btn-border: #0077cc;
+  --bar-btn-color: #0077cc;
+  --bar-btn-focus: #0077cc;
 }
 
 body.dark {
@@ -17,6 +21,10 @@ body.dark {
   color: #eaeaea;
   --dup-bg: #2A0000;
   --dup-accent: #FF3B30;
+  --bar-btn-bg: #1F2A44;
+  --bar-btn-border: #34456B;
+  --bar-btn-color: #E5EAF5;
+  --bar-btn-focus: #3A6FD8;
 }
 
 table {
@@ -92,6 +100,35 @@ body.dark .drawer.right {
 body.dark .legend-btn {
     background: #1F2A44;
     border: 1px solid #34456B;
+}
+
+.bar-btn {
+  background: var(--bar-btn-bg);
+  border: 1px solid var(--bar-btn-border);
+  border-radius: 8px;
+  padding: 4px 8px;
+  color: var(--bar-btn-color);
+  cursor: pointer;
+  opacity: 0.92;
+  transition: box-shadow .15s ease, opacity .15s ease, transform .1s ease;
+}
+.bar-btn:hover:not(:disabled) {
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+  opacity: 1;
+}
+.bar-btn:active:not(:disabled) {
+  transform: scale(0.98);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  transition-duration: .08s;
+}
+.bar-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bar-btn-focus);
+}
+.bar-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .popover {
@@ -234,8 +271,8 @@ body.dark .table tbody tr:nth-child(odd) { background: #11192B; }
   background: #f8fbff;
   border-top: 1px solid #ccc;
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 8px;
   padding: 8px 12px;
   z-index: 25;
   color: #222;

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -166,17 +166,14 @@ body.dark .weight-slider {
   <tbody></tbody>
 </table>
 <div id="bottomBar" class="bottombar hidden">
-  <div style="display:flex; align-items:center; gap:8px;">
-    <button id="legendBtn" class="legend-btn" title="Mostrar leyenda" aria-label="Mostrar leyenda">ℹ️</button>
-    <span id="selCount"></span>
-  </div>
-  <div style="display:flex; gap:8px; align-items:center;">
-    <select id="groupSelect" aria-label="Filtrar por grupo"></select>
-    <button id="btnAddToGroup" disabled title="Añadir seleccionados al grupo" aria-label="Añadir seleccionados al grupo">Añadir a grupo</button>
-    <button id="btnDelete" disabled title="Eliminar seleccionados" aria-label="Eliminar seleccionados">Eliminar</button>
-    <button id="btnExport" disabled title="Exportar seleccionados" aria-label="Exportar seleccionados">Exportar</button>
-    <button id="btnColumns" title="Gestionar columnas" aria-label="Gestionar columnas">Columnas</button>
-  </div>
+  <button id="legendBtn" class="legend-btn" title="Mostrar leyenda" aria-label="Mostrar leyenda">ℹ️</button>
+  <span id="selCount"></span>
+  <select id="groupSelect" aria-label="Filtrar por grupo"></select>
+  <button id="btnAddToGroup" class="bar-btn" disabled title="Añadir seleccionados al grupo" aria-label="Añadir seleccionados al grupo">Añadir a grupo</button>
+  <button id="btnManageGroups" class="bar-btn" title="Gestionar grupos" aria-label="Gestionar grupos">Gestionar grupos</button>
+  <button id="btnDelete" class="bar-btn" disabled title="Eliminar seleccionados" aria-label="Eliminar seleccionados">Eliminar</button>
+  <button id="btnExport" class="bar-btn" disabled title="Exportar seleccionados" aria-label="Exportar seleccionados">Exportar</button>
+  <button id="btnColumns" class="bar-btn" title="Gestionar columnas" aria-label="Gestionar columnas">Columnas</button>
 </div>
 <div id="legendPop" class="popover hidden">
   <div>• Fila roja: duplicado</div>

--- a/product_research_app/static/js/add-group.js
+++ b/product_research_app/static/js/add-group.js
@@ -19,7 +19,6 @@
     lists.forEach(l => { html += `<div class="grp-item" data-id="${l.id}" style="padding:4px 8px; cursor:pointer;">${l.name}</div>`; });
     html += '</div>';
     html += '<div id="grpCreate" style="padding:4px 8px; margin-top:8px; cursor:pointer; border-top:1px solid #ccc;">Crear grupo...</div>';
-    html += '<div id="grpManage" style="padding:4px 8px; cursor:pointer; border-top:1px solid #ccc;">Gestionar grupos</div>';
     pop.innerHTML = html;
 
     pop.querySelectorAll('.grp-item').forEach(el => {
@@ -48,8 +47,6 @@
         buildList('');
       }catch(err){ console.error(err); toast.error('Error al crear grupo'); }
     });
-    const manage = pop.querySelector('#grpManage');
-    manage.addEventListener('click', () => { hide(); openManageGroups(); });
     search.focus();
   }
 

--- a/product_research_app/static/js/manage-groups.js
+++ b/product_research_app/static/js/manage-groups.js
@@ -63,4 +63,12 @@
     dlg.style.top = `${(vh - h)/2}px`;
     dlg.style.visibility = '';
   }
+  const btn = document.getElementById('btnManageGroups');
+  if(btn) btn.addEventListener('click', openManageGroups);
+  document.addEventListener('keydown', e => {
+    if(e.altKey && e.key.toLowerCase() === 'g' && !['INPUT','TEXTAREA','SELECT'].includes(e.target.tagName)){
+      e.preventDefault();
+      openManageGroups();
+    }
+  });
 })();


### PR DESCRIPTION
## Summary
- Reorder bottom bar controls and add dedicated **Gestionar grupos** button next to **Añadir a grupo**
- Introduce unified `bar-btn` styles with hover, active, focus-visible and disabled states using theme tokens
- Add Alt+G shortcut and click handler to open group management dialog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcac83e2f0832887230129e5999b70