### PR TITLE
feat(ui): modal de Gestión de grupos con diseño moderno y barra inferior fija al viewport

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -264,17 +264,17 @@ body.dark .table tbody tr:nth-child(odd) { background: #11192B; }
 .score-red { background: #3A1E1E; color: #F16969; }
 
 .bottombar {
-  position: sticky;
-  bottom: 0;
+  position: fixed;
   left: 0;
   right: 0;
+  bottom: 0;
   background: #f8fbff;
   border-top: 1px solid #ccc;
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
-  z-index: 25;
+  z-index: 100;
   color: #222;
 }
 body.dark .bottombar {
@@ -284,5 +284,187 @@ body.dark .bottombar {
 }
 
 #productTable {
-  margin-bottom: 80px;
+  margin-bottom: 0;
+}
+
+/* Modal base styles */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+  z-index: 1000;
+}
+.modal-overlay.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+.modal-overlay .modal {
+  background: #0F1424;
+  color: #E5EAF5;
+  border: 1px solid #34456B;
+  border-radius: 20px;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.4);
+  width: 90%;
+  max-width: 420px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  transform: scale(0.9);
+  opacity: 0;
+  transition: opacity 0.16s ease, transform 0.16s ease;
+}
+.modal-overlay.open .modal {
+  transform: scale(1);
+  opacity: 1;
+}
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 8px;
+}
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+.modal-subtitle {
+  margin-left: auto;
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+.modal-close {
+  background: none;
+  border: none;
+  color: #E5EAF5;
+  font-size: 20px;
+  cursor: pointer;
+  margin-left: 12px;
+}
+.modal-body {
+  padding: 0 20px 16px;
+  overflow-y: auto;
+}
+.modal-body input {
+  width: 100%;
+  padding: 8px;
+  border-radius: 8px;
+  border: 1px solid #34456B;
+  background: #1F2A44;
+  color: #E5EAF5;
+  margin-bottom: 12px;
+}
+.group-list {
+  max-height: 50vh;
+  overflow-y: auto;
+}
+.group-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px solid #243150;
+}
+.group-row:last-child {
+  border-bottom: none;
+}
+.group-actions button {
+  background: none;
+  border: none;
+  color: #F16969;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+.modal-footer {
+  padding: 12px 20px;
+  border-top: 1px solid #243150;
+  text-align: right;
+}
+.modal-footer button {
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: #1F2A44;
+  border: 1px solid #34456B;
+  color: #E5EAF5;
+  cursor: pointer;
+}
+.confirm-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.confirm-box {
+  background: #1F2A44;
+  padding: 20px;
+  border-radius: 12px;
+  border: 1px solid #34456B;
+  max-width: 90%;
+}
+.confirm-actions {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.confirm-actions button {
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid #34456B;
+  background: #0F1424;
+  color: #E5EAF5;
+  cursor: pointer;
+}
+.confirm-actions .btn-ok {
+  background: #3A6FD8;
+  border-color: #3A6FD8;
+}
+.prompt-input {
+  width: 100%;
+  padding: 8px;
+  margin-top: 8px;
+  border-radius: 6px;
+  border: 1px solid #34456B;
+  background: #0F1424;
+  color: #E5EAF5;
+}
+
+.confirm-box select {
+  width: 100%;
+  margin-top: 8px;
+  padding: 6px;
+  border-radius: 6px;
+  border: 1px solid #34456B;
+  background: #0F1424;
+  color: #E5EAF5;
+}
+
+.mg-del.loading {
+  position: relative;
+  color: transparent;
+  pointer-events: none;
+}
+.mg-del.loading::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  margin: -6px 0 0 -6px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -648,7 +648,7 @@ document.getElementById('autoWeightsGpt').onclick = async () => {
     + JSON.stringify(res.weights, null, 2) + '\n'
     + (res.justification ? ('Justificación: '+res.justification+'\n') : '')
     + '¿Aplicarlos?';
-  if(confirm(msg)){
+  if(await confirmDialog(msg)){
     renderWeights(res.weights);
     await saveWeightsConfig(res.weights);
     toast.success('Pesos guardados');
@@ -959,6 +959,8 @@ async function deleteGroup(id, opts={}){
     if(![200,204,404].includes(res.status)) throw new Error('bad status '+res.status);
     // purge local caches
     window.listCache = (window.listCache || []).filter(g => g.id !== id);
+    if(window.groupsMap) delete window.groupsMap[id];
+    if(window.groupsList) window.groupsList = (window.groupsList || []).filter(g => g.id !== id);
     try{
       const cache = JSON.parse(localStorage.getItem('groupsCache') || '[]');
       localStorage.setItem('groupsCache', JSON.stringify(cache.filter(g => g.id !== id)));
@@ -973,7 +975,6 @@ async function deleteGroup(id, opts={}){
     document.dispatchEvent(new CustomEvent('groups-updated'));
   }catch(err){
     console.error(err);
-    toast.error('Error al eliminar grupo');
     delete deleteInFlight[id];
     throw err;
   }

--- a/product_research_app/static/js/add-group.js
+++ b/product_research_app/static/js/add-group.js
@@ -39,12 +39,13 @@
     search.addEventListener('input', e => buildList(e.target.value.toLowerCase()));
     const create = pop.querySelector('#grpCreate');
     create.addEventListener('click', async () => {
-      const name = prompt('Nombre del grupo');
+      const name = await promptDialog('Crear grupo', 'Nombre del grupo');
       if(!name) return;
       try{
         await fetchJson('/create_list', {method:'POST', body: JSON.stringify({name})});
         await loadLists();
         buildList('');
+        toast.success(`Grupo "${name}" creado`);
       }catch(err){ console.error(err); toast.error('Error al crear grupo'); }
     });
     search.focus();

--- a/product_research_app/static/js/manage-groups.js
+++ b/product_research_app/static/js/manage-groups.js
@@ -1,85 +1,142 @@
 (function(){
-  function buildDialog(){
-    const overlay = window.ensureOverlayRoot ? window.ensureOverlayRoot() : document.body;
-    let dlg = document.getElementById('manageGroups');
-    if(!dlg){
-      dlg = document.createElement('div');
-      dlg.id = 'manageGroups';
-      dlg.className = 'popover hidden';
-      dlg.style.maxWidth = '320px';
-      overlay.appendChild(dlg);
-    }
+  let overlay;
+
+  function ensureModal(){
+    if(overlay) return overlay;
+    const root = window.ensureOverlayRoot ? window.ensureOverlayRoot() : document.body;
+    overlay = document.createElement('div');
+    overlay.id = 'manageGroupsModal';
+    overlay.className = 'modal-overlay hidden';
+    overlay.innerHTML = `
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="mgTitle">
+        <header class="modal-header">
+          <h2 id="mgTitle">Gestionar grupos</h2>
+          <span class="modal-subtitle" id="mgCount"></span>
+          <button class="modal-close" id="mgClose" aria-label="Cerrar">✕</button>
+        </header>
+        <div class="modal-body">
+          <input type="text" id="mgSearch" placeholder="Buscar grupo…" />
+          <div id="mgList" class="group-list"></div>
+        </div>
+        <footer class="modal-footer">
+          <button id="mgCreate">Crear grupo…</button>
+        </footer>
+      </div>`;
+    root.appendChild(overlay);
+
+    overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
+    overlay.querySelector('#mgClose').addEventListener('click', close);
+    overlay.querySelector('#mgSearch').addEventListener('input', e => renderList(e.target.value.toLowerCase()));
+    overlay.querySelector('#mgCreate').addEventListener('click', async () => {
+      const name = await promptDialog('Crear grupo', 'Nombre del grupo');
+      if(!name) return;
+      try {
+        await fetchJson('/create_list', {method:'POST', body: JSON.stringify({name})});
+        await loadLists();
+        renderList('');
+        toast.success(`Grupo "${name}" creado`);
+        document.dispatchEvent(new CustomEvent('groups-updated'));
+      } catch(err){ console.error(err); toast.error('Error al crear grupo'); }
+    });
+    return overlay;
+  }
+
+  function trapFocus(container){
+    const focusable = container.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    if(!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length-1];
+    container.addEventListener('keydown', e => {
+      if(e.key !== 'Tab') return;
+      if(e.shiftKey){
+        if(document.activeElement === first){ e.preventDefault(); last.focus(); }
+      }else{
+        if(document.activeElement === last){ e.preventDefault(); first.focus(); }
+      }
+    });
+  }
+
+  function confirmDelete(name, id){
+    return new Promise(res => {
+      const wrap = document.createElement('div');
+      wrap.className = 'confirm-overlay';
+      const lists = (window.listCache || []).filter(g => g.id !== id);
+      let opts = '<option value="" disabled selected>Mover a…</option>';
+      lists.forEach(l => { opts += `<option value="${l.id}">${l.name}</option>`; });
+      wrap.innerHTML = `<div class="confirm-box"><p>¿Eliminar grupo \"${name}\"?</p><select id="mgMoveSel">${opts}</select><div class="confirm-actions"><button class="btn-cancel">Cancelar</button><button class="btn-remove">Quitar del grupo</button><button class="btn-move" disabled>Mover y borrar</button></div></div>`;
+      overlay.appendChild(wrap);
+      const sel = wrap.querySelector('#mgMoveSel');
+      const btnMove = wrap.querySelector('.btn-move');
+      sel.addEventListener('change', () => { btnMove.disabled = !sel.value; });
+      wrap.querySelector('.btn-cancel').onclick = () => { wrap.remove(); res(null); };
+      wrap.querySelector('.btn-remove').onclick = () => { wrap.remove(); res({mode:'remove'}); };
+      btnMove.onclick = () => { const targetId = parseInt(sel.value); wrap.remove(); res({mode:'move', targetId}); };
+      wrap.querySelector('.btn-remove').focus();
+    });
+  }
+
+  function renderList(filter=''){
     const lists = (window.listCache || []);
-    let html = '<h3>Grupos</h3>';
-    html += '<div style="max-height:240px;overflow:auto;">';
-    lists.forEach(l => {
-      html += `<div class="mg-row" data-id="${l.id}" data-count="${l.count}" style="display:flex;justify-content:space-between;align-items:center;padding:4px 0;">`+
-              `<span>${l.name}</span>`+
-              `<button class="mg-del" title="Eliminar" aria-label="Eliminar" style="color:#c00;border:none;background:none;cursor:pointer;">🗑</button>`+
-              `</div>`;
-    });
-    html += '</div>';
-    html += '<div style="text-align:right;margin-top:8px;"><button id="mgClose">Cerrar</button></div>';
-    dlg.innerHTML = html;
-    dlg.querySelector('#mgClose').addEventListener('click', ()=> dlg.classList.add('hidden'));
-    dlg.querySelectorAll('.mg-del').forEach(btn => {
-      btn.addEventListener('click', async (e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        const row = e.target.closest('.mg-row');
-        const id = parseInt(row.dataset.id);
-        const count = parseInt(row.dataset.count);
-        const name = row.querySelector('span').textContent;
-        const prevHtml = btn.innerHTML;
-        row.style.pointerEvents = 'none';
-        btn.disabled = true;
-        btn.innerHTML = '⏳';
-        try{
-          let mode = 'remove';
-          let target = null;
-          if(count > 0){
-            const move = confirm('Mover productos a otro grupo? Cancelar para quitar');
-            if(move){
-              const others = (window.listCache||[]).filter(g=>g.id!==id);
-              if(!others.length){ toast.info('No hay grupo destino'); throw new Error('no target'); }
-              const opt = prompt('ID del grupo destino:\n'+ others.map(g=>`${g.id}: ${g.name}`).join('\n'));
-              if(!opt) throw new Error('cancel');
-              target = parseInt(opt);
-              mode = 'move';
-            }
-          }else if(!confirm('Eliminar grupo vacío?')){ throw new Error('cancel'); }
-          await deleteGroup(id, {mode, target});
-          dlg.classList.add('hidden');
-          toast.success(`Grupo "${name}" eliminado`);
-        }catch(err){
-          if(err.message!=='cancel') console.error(err);
-          row.style.pointerEvents = '';
-          btn.disabled = false;
-          btn.innerHTML = prevHtml;
-        }
-      });
-    });
-    return dlg;
-  }
-  window.openManageGroups = function(){
-    const dlg = buildDialog();
-    dlg.classList.remove('hidden');
-    dlg.style.visibility = 'hidden';
-    dlg.scrollTop = 0;
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    const w = dlg.offsetWidth;
-    const h = dlg.offsetHeight;
-    dlg.style.left = `${(vw - w)/2}px`;
-    dlg.style.top = `${(vh - h)/2}px`;
-    dlg.style.visibility = '';
-  }
-  const btn = document.getElementById('btnManageGroups');
-  if(btn) btn.addEventListener('click', openManageGroups);
-  document.addEventListener('keydown', e => {
-    if(e.altKey && e.key.toLowerCase() === 'g' && !['INPUT','TEXTAREA','SELECT'].includes(e.target.tagName)){
-      e.preventDefault();
-      openManageGroups();
+    const listEl = overlay.querySelector('#mgList');
+    const countEl = overlay.querySelector('#mgCount');
+    if(countEl) countEl.textContent = `${lists.length} grupos`;
+    const rows = lists.filter(l => l.name.toLowerCase().includes(filter));
+    if(rows.length === 0){
+      listEl.innerHTML = '<p style="padding:8px;">Sin grupos</p>';
+      return;
     }
-  });
+    let html = '';
+    rows.forEach(l => {
+      html += `<div class="group-row" data-id="${l.id}">
+        <span class="group-name">${l.name}</span>
+        <span class="group-count">${l.count}</span>
+        <div class="group-actions"><button class="mg-del" aria-label="Eliminar">Eliminar</button></div>
+      </div>`;
+    });
+    listEl.innerHTML = html;
+    listEl.querySelectorAll('.mg-del').forEach(btn => btn.addEventListener('click', handleDelete));
+  }
+
+  async function handleDelete(e){
+    const btn = e.target;
+    const row = btn.closest('.group-row');
+    const id = parseInt(row.dataset.id);
+    const name = row.querySelector('.group-name').textContent;
+    const choice = await confirmDelete(name, id);
+    if(!choice) return;
+    btn.disabled = true;
+    btn.classList.add('loading');
+    try {
+      await deleteGroup(id, choice);
+      close();
+      toast.success(`Grupo "${name}" eliminado`);
+    } catch(err){ console.error(err); toast.error(`Error al eliminar grupo: ${err.message}`); btn.disabled = false; btn.classList.remove('loading'); }
+  }
+
+  function open(){
+    const modal = ensureModal();
+    renderList('');
+    modal.classList.remove('hidden');
+    requestAnimationFrame(() => modal.classList.add('open'));
+    document.body.style.overflow = 'hidden';
+    const search = modal.querySelector('#mgSearch');
+    if(search) search.focus();
+    trapFocus(modal);
+    document.addEventListener('keydown', escHandler);
+  }
+
+  function close(){
+    if(!overlay) return;
+    overlay.classList.remove('open');
+    setTimeout(() => overlay.classList.add('hidden'), 120);
+    document.body.style.overflow = '';
+    document.removeEventListener('keydown', escHandler);
+  }
+
+  function escHandler(e){ if(e.key === 'Escape') close(); }
+
+  window.openManageGroups = open;
+  const btn = document.getElementById('btnManageGroups');
+  if(btn) btn.addEventListener('click', open);
 })();
+

--- a/product_research_app/static/js/overlay.js
+++ b/product_research_app/static/js/overlay.js
@@ -24,3 +24,36 @@
     ensureOverlayRoot();
   }
 })();
+
+(function(){
+  function confirmDialog(msg, opts={}){
+    const {okText='Aceptar', cancelText='Cancelar'} = opts;
+    return new Promise(res => {
+      const root = window.ensureOverlayRoot ? window.ensureOverlayRoot() : document.body;
+      const wrap = document.createElement('div');
+      wrap.className = 'confirm-overlay';
+      wrap.innerHTML = `<div class="confirm-box"><p>${msg}</p><div class="confirm-actions"><button class="btn-cancel">${cancelText}</button><button class="btn-ok">${okText}</button></div></div>`;
+      root.appendChild(wrap);
+      wrap.querySelector('.btn-cancel').onclick = () => { wrap.remove(); res(false); };
+      wrap.querySelector('.btn-ok').onclick = () => { wrap.remove(); res(true); };
+      wrap.querySelector('.btn-ok').focus();
+    });
+  }
+
+  function promptDialog(title, placeholder=''){
+    return new Promise(res => {
+      const root = window.ensureOverlayRoot ? window.ensureOverlayRoot() : document.body;
+      const wrap = document.createElement('div');
+      wrap.className = 'confirm-overlay';
+      wrap.innerHTML = `<div class="confirm-box"><h3>${title}</h3><input class="prompt-input" placeholder="${placeholder}"><div class="confirm-actions"><button class="btn-cancel">Cancelar</button><button class="btn-ok">Aceptar</button></div></div>`;
+      root.appendChild(wrap);
+      const input = wrap.querySelector('input');
+      input.focus();
+      wrap.querySelector('.btn-cancel').onclick = () => { wrap.remove(); res(null); };
+      wrap.querySelector('.btn-ok').onclick = () => { const v = input.value.trim(); wrap.remove(); res(v || null); };
+    });
+  }
+
+  window.confirmDialog = confirmDialog;
+  window.promptDialog = promptDialog;
+})();

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -39,6 +39,11 @@ function updateMasterState(){
     const selEl = document.getElementById('selCount');
     if(selEl) selEl.textContent = `${selection.size} seleccionados`;
     bottomBar.classList.toggle('hidden', disable);
+    if(!disable){
+      document.body.style.paddingBottom = bottomBar.offsetHeight + 'px';
+    } else {
+      document.body.style.paddingBottom = '';
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Redesign group management modal with dark theme, search, internal confirmations, and creation flow
- Fix bottom action bar to viewport and pad content dynamically
- Embed group deletion flow with move or remove options, custom dialogs, and toast notifications

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bcb37188f883289c1c1e4056905051