### PR TITLE
feat(settings): espaciado en API Key y persistencia de Winner Score

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -159,6 +159,11 @@ body.dark .popover {
 .table tbody tr.selected { background: #cde8ff; }
 body.dark .table tbody tr.selected { background: #243150; }
 
+/* Spacing for configuration panel */
+#config {
+  padding-top: 16px;
+}
+
 .table tbody tr.is-duplicate {
   background: var(--dup-bg);
   border-left: 4px solid var(--dup-accent);

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -96,6 +96,11 @@ body.dark .weight-slider {
 <div id="weightsCard" class="card" style="display:none; max-width:420px;">
   <strong>Ponderaciones Winner Score</strong>
   <div id="weightsContainer" style="margin-top:8px; display:flex; flex-direction:column; gap:6px;"></div>
+  <div style="margin-top:8px;">
+    <label style="display:flex; align-items:center; gap:4px;">
+      <input type="checkbox" id="lockWeights"> Bloquear pesos
+    </label>
+  </div>
   <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:6px;">
     <button id="autoWeightsGpt">Ajustar pesos con IA</button>
     <button id="autoWeightsStat">Ajustar estadístico</button>
@@ -332,6 +337,26 @@ const weightFields = [
   'engagement_shareability',
   'durabilidad_recurrencia'
 ];
+const WEIGHTS_LS_KEY = 'winnerScoreWeights:v1';
+let weightStore = {};
+let persistTimer;
+let backendWeightsEnabled = true;
+
+function defaultWeights(){
+  const w = {};
+  const v = 1 / weightFields.length;
+  weightFields.forEach(k => w[k] = v);
+  return w;
+}
+
+function normalizeWeights(obj){
+  let total = 0;
+  weightFields.forEach(k => { total += parseFloat(obj[k]) || 0; });
+  if(total <= 0) return defaultWeights();
+  const out = {};
+  weightFields.forEach(k => { out[k] = ((parseFloat(obj[k]) || 0) / total); });
+  return out;
+}
 
 function renderWeights(weights){
   const container = document.getElementById('weightsContainer');
@@ -353,27 +378,80 @@ function renderWeights(weights){
     input.value = (weights[key] ?? 0).toFixed(3);
     input.dataset.key = key;
     input.className = 'weight-slider';
+    input.addEventListener('input', e => {
+      weightStore[e.target.dataset.key] = parseFloat(e.target.value) || 0;
+      scheduleWeightPersist();
+    });
     row.appendChild(label);
     row.appendChild(input);
     container.appendChild(row);
   });
 }
 
+function scheduleWeightPersist(){
+  clearTimeout(persistTimer);
+  persistTimer = setTimeout(persistWeights, 400);
+}
+
+async function persistWeights(){
+  weightStore = normalizeWeights(weightStore);
+  if(backendWeightsEnabled){
+    try{
+      await fetchJson('/setconfig',{method:'POST', body: JSON.stringify({scoring_v2_weights: weightStore})});
+    }catch(e){
+      backendWeightsEnabled = false;
+      localStorage.setItem(WEIGHTS_LS_KEY, JSON.stringify(weightStore));
+    }
+  }else{
+    localStorage.setItem(WEIGHTS_LS_KEY, JSON.stringify(weightStore));
+  }
+  renderWeights(weightStore);
+}
+
+function initWeights(cfgWeights){
+  let weights = cfgWeights;
+  if(!weights || Object.keys(weights).length === 0){
+    try{
+      const saved = localStorage.getItem(WEIGHTS_LS_KEY);
+      if(saved) weights = JSON.parse(saved);
+    }catch(e){}
+  }
+  if(!weights) weights = defaultWeights();
+  weightStore = {...weights};
+  renderWeights(weightStore);
+}
+
+async function applyWeights(newWeights, persistNow = true){
+  if(document.getElementById('lockWeights')?.checked){
+    toast.info('Pesos bloqueados');
+    return;
+  }
+  weightStore = {...newWeights};
+  renderWeights(weightStore);
+  if(persistNow){
+    clearTimeout(persistTimer);
+    await persistWeights();
+    toast.success('Pesos guardados');
+  }
+}
+
 async function loadConfig() {
+  let cfg = {};
   try {
-    const cfg = await fetchJson('/config');
-    if (cfg.model) {
-      document.getElementById('modelSelect').value = cfg.model;
-    }
-    if (cfg.has_api_key) {
-      const apiInput = document.getElementById('apiKey');
-      apiInput.style.display = 'none';
-      document.getElementById('toggleApiKey').style.display = 'inline-block';
-    }
-    renderWeights(cfg.scoring_v2_weights || {});
+    cfg = await fetchJson('/config');
   } catch (err) {
+    backendWeightsEnabled = false;
     console.error('Error loading config', err);
   }
+  if (cfg.model) {
+    document.getElementById('modelSelect').value = cfg.model;
+  }
+  if (cfg.has_api_key) {
+    const apiInput = document.getElementById('apiKey');
+    apiInput.style.display = 'none';
+    document.getElementById('toggleApiKey').style.display = 'inline-block';
+  }
+  initWeights(cfg.scoring_v2_weights);
 }
 
 // Microinteraction progress bar
@@ -623,22 +701,9 @@ document.getElementById('configBtn').onclick = () => {
   wcard.style.display = show;
 };
 
-async function saveWeightsConfig(weights){
-  await fetchJson('/setconfig',{method:'POST', body: JSON.stringify({scoring_v2_weights: weights})});
-}
-
 async function saveWeights(){
-  const inputs = document.querySelectorAll('#weightsContainer input');
-  const weights = {};
-  let total = 0;
-  inputs.forEach(inp => {
-    const v = parseFloat(inp.value) || 0;
-    weights[inp.dataset.key] = v;
-    total += v;
-  });
-  if (total <= 0){ toast.error('Pesos inválidos'); return; }
-  Object.keys(weights).forEach(k => weights[k] = weights[k] / total);
-  await saveWeightsConfig(weights);
+  clearTimeout(persistTimer);
+  await persistWeights();
   toast.success('Pesos guardados');
 }
 
@@ -651,17 +716,13 @@ document.getElementById('autoWeightsGpt').onclick = async () => {
     + (res.justification ? ('Justificación: '+res.justification+'\n') : '')
     + '¿Aplicarlos?';
   if(await confirmDialog(msg)){
-    renderWeights(res.weights);
-    await saveWeightsConfig(res.weights);
-    toast.success('Pesos guardados');
+    await applyWeights(res.weights);
   }
 };
 document.getElementById('autoWeightsStat').onclick = async () => {
   const res = await fetchJson('/scoring/v2/auto-weights-stat',{method:'POST'});
   if(res.error){ toast.error(res.error); return; }
-  renderWeights(res.weights);
-  await saveWeightsConfig(res.weights);
-  toast.success('Pesos guardados');
+  await applyWeights(res.weights);
 };
 // Handle file upload: clicking the upload button opens file chooser
 const fileInputEl = document.getElementById('fileInput');


### PR DESCRIPTION
## Summary
- add top padding to configuration panel for API Key area
- persist Winner Score weights with backend/localStorage fallback and debounce
- optional lock to prevent automatic weight overrides

## Testing
- `python -m py_compile product_research_app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcb9f1385c83288e07d78bc0f46a0f