### PR TITLE
Add desire and awareness product fields

### DIFF
--- a/product_research_app/migrations/add_desire_fields.sql
+++ b/product_research_app/migrations/add_desire_fields.sql
@@ -1,0 +1,13 @@
+-- Migration for desire/awareness/competition fields
+-- Rename existing Spanish columns if present
+ALTER TABLE products RENAME COLUMN magnitud_deseo TO desire_magnitude;
+ALTER TABLE products RENAME COLUMN nivel_consciencia TO awareness_level;
+ALTER TABLE products RENAME COLUMN saturacion_mercado TO competition_level;
+-- Add new desire column
+ALTER TABLE products ADD COLUMN desire TEXT;
+-- Drop obsolete columns if they exist
+ALTER TABLE products DROP COLUMN facilidad_anuncio;
+ALTER TABLE products DROP COLUMN facilidad_logistica;
+ALTER TABLE products DROP COLUMN escalabilidad;
+ALTER TABLE products DROP COLUMN engagement_shareability;
+ALTER TABLE products DROP COLUMN durabilidad_recurrencia;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 beautifulsoup4
 Pillow
+openpyxl


### PR DESCRIPTION
## Summary
- add desire, awareness, and competition columns to products table
- expose desire-related fields through API with create, update, list and import/export
- provide SQL migration script and openpyxl dependency for XLSX export

## Testing
- `python -m py_compile product_research_app/database.py product_research_app/main.py product_research_app/web_app.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68bd7d56939c8328a703bf3b02a0af9d