### PR TITLE
Add desire and awareness product fields

### DIFF
--- a/product_research_app/migrations/add_desire_fields.sql
+++ b/product_research_app/migrations/add_desire_fields.sql
@@ -1,0 +1,13 @@
+-- Migration for desire/awareness/competition fields
+-- Rename existing Spanish columns if present
+ALTER TABLE products RENAME COLUMN magnitud_deseo TO desire_magnitude;
+ALTER TABLE products RENAME COLUMN nivel_consciencia TO awareness_level;
+ALTER TABLE products RENAME COLUMN saturacion_mercado TO competition_level;
+-- Add new desire column
+ALTER TABLE products ADD COLUMN desire TEXT;
+-- Drop obsolete columns if they exist
+ALTER TABLE products DROP COLUMN facilidad_anuncio;
+ALTER TABLE products DROP COLUMN facilidad_logistica;
+ALTER TABLE products DROP COLUMN escalabilidad;
+ALTER TABLE products DROP COLUMN engagement_shareability;
+ALTER TABLE products DROP COLUMN durabilidad_recurrencia;

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -203,6 +203,17 @@ body.dark .chip {
 }
 body.dark .chip button { color: #A9B4D0; }
 
+.chip.selected {
+  background: #0077cc;
+  color: #fff;
+  border-color: #0077cc;
+}
+body.dark .chip.selected {
+  background: #34456B;
+  border-color: #34456B;
+  color: #fff;
+}
+
 #topBar { position: sticky; top: 0; z-index: 50; background: #f8fbff; }
 body.dark #topBar { background: #1a1b2e; }
 #searchRow {

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -80,6 +80,7 @@ body.dark .weight-slider {
       <div id="listMeta">0 resultados</div>
     </div>
   </div>
+  <div id="levelFilterChips" style="display:flex; flex-wrap:wrap; gap:6px; padding:4px 0;"></div>
 </div>
 <div id="config" style="display:none;">
   <label>API Key: <input type="password" id="apiKey" /></label>
@@ -269,14 +270,10 @@ const columns = [
   { key: 'Creator Conversion Ratio', label: 'Tasa Conversión', type: 'string' },
   { key: 'Launch Date', label: 'Fecha Lanzamiento', type: 'string' },
   { key: 'Date Range', label: 'Rango Fechas', type: 'string' },
-  { key: 'magnitud_deseo', label: 'Magnitud deseo', type: 'number' },
-  { key: 'nivel_consciencia', label: 'Nivel consciencia', type: 'number' },
-  { key: 'saturacion_mercado', label: 'Saturación mercado', type: 'number' },
-  { key: 'facilidad_anuncio', label: 'Facilidad anuncio', type: 'number' },
-  { key: 'facilidad_logistica', label: 'Facilidad logística', type: 'number' },
-  { key: 'escalabilidad', label: 'Escalabilidad', type: 'number' },
-  { key: 'engagement_shareability', label: 'Engagement/shareability', type: 'number' },
-  { key: 'durabilidad_recurrencia', label: 'Durabilidad/recurrencia', type: 'number' },
+  { key: 'desire', label: 'Desire', type: 'string' },
+  { key: 'desire_magnitude', label: 'Desire Magnitude', type: 'string' },
+  { key: 'awareness_level', label: 'Awareness Level', type: 'string' },
+  { key: 'competition_level', label: 'Competition Level', type: 'string' },
   { key: 'winner_score_v2_pct', label: 'Winner Score', type: 'number' },
 ];
 
@@ -322,15 +319,24 @@ function preprocessProducts(list){
 }
 
 const weightFields = [
-  'magnitud_deseo',
-  'nivel_consciencia',
-  'saturacion_mercado',
-  'facilidad_anuncio',
-  'facilidad_logistica',
-  'escalabilidad',
-  'engagement_shareability',
-  'durabilidad_recurrencia'
+  'desire_magnitude',
+  'awareness_level',
+  'competition_level'
 ];
+
+const desireMagDesc = {
+  'Low': 'Nice-to-have, no urgente',
+  'Medium': 'Necesidad real, no crítica',
+  'High': 'Necesidad fuerte/urgente'
+};
+
+const awarenessDesc = {
+  'Unaware': 'No reconoce el problema',
+  'Problem-Aware': 'Conoce que tiene un problema',
+  'Solution-Aware': 'Busca soluciones disponibles',
+  'Product-Aware': 'Conoce nuestro producto',
+  'Most Aware': 'Listo para comprar'
+};
 const WEIGHTS_LS_KEY = 'winnerScoreWeights:v1';
 let weightStore = {};
 let persistTimer;
@@ -488,6 +494,22 @@ async function fetchProducts() {
   renderTable();
 }
 
+async function saveField(id, field, value){
+  try{
+    const payload = {};
+    payload[field] = value || null;
+    const updated = await fetchJson(`/products/${id}`, {method:'PUT', body: JSON.stringify(payload)});
+    const idx = allProducts.findIndex(p => p.id === id);
+    if(idx >= 0) allProducts[idx][field] = updated[field];
+    const idx2 = products.findIndex(p => p.id === id);
+    if(idx2 >= 0) products[idx2][field] = updated[field];
+    toast.success('Guardado');
+  }catch(e){
+    console.error(e);
+    toast.error('Error al guardar');
+  }
+}
+
 function renderTable() {
   const headerRow = document.getElementById('headerRow');
   const tbody = document.querySelector('#productTable tbody');
@@ -518,6 +540,7 @@ function renderTable() {
   // Render rows
     products.forEach(item => {
     const tr = document.createElement('tr');
+    tr.dataset.id = item.id;
     if (item.isDuplicate) {
       tr.classList.add('is-duplicate');
     }
@@ -543,14 +566,65 @@ function renderTable() {
       const key = col.key;
       td.setAttribute('data-key', key);
       let value = '';
-      if (weightFields.includes(key)) {
+      if (key === 'desire') {
+        value = item.desire || '';
+        const ta = document.createElement('textarea');
+        ta.value = value;
+        ta.rows = 1;
+        ta.maxLength = 180;
+        ta.style.width = '100%';
+        ta.style.resize = 'vertical';
+        ta.onblur = () => saveField(item.id, 'desire', ta.value.trim());
+        ta.oninput = () => { ta.style.height = 'auto'; ta.style.height = ta.scrollHeight + 'px'; };
+        td.appendChild(ta);
+      } else if (key === 'desire_magnitude') {
+        value = item.desire_magnitude || '';
+        const sel = document.createElement('select');
+        ['', 'Low', 'Medium', 'High'].forEach(v => {
+          const opt = document.createElement('option');
+          opt.value = v;
+          opt.textContent = v;
+          if (desireMagDesc[v]) opt.title = desireMagDesc[v];
+          sel.appendChild(opt);
+        });
+        sel.value = value;
+        sel.title = desireMagDesc[value] || '';
+        sel.onchange = () => { saveField(item.id, 'desire_magnitude', sel.value || null); sel.title = desireMagDesc[sel.value] || ''; };
+        td.appendChild(sel);
+      } else if (key === 'awareness_level') {
+        value = item.awareness_level || '';
+        const sel = document.createElement('select');
+        ['', 'Unaware', 'Problem-Aware', 'Solution-Aware', 'Product-Aware', 'Most Aware'].forEach(v => {
+          const opt = document.createElement('option');
+          opt.value = v;
+          opt.textContent = v;
+          if (awarenessDesc[v]) opt.title = awarenessDesc[v];
+          sel.appendChild(opt);
+        });
+        sel.value = value;
+        sel.title = awarenessDesc[value] || '';
+        sel.onchange = () => { saveField(item.id, 'awareness_level', sel.value || null); sel.title = awarenessDesc[sel.value] || ''; };
+        td.appendChild(sel);
+      } else if (key === 'competition_level') {
+        value = item.competition_level || '';
+        const sel = document.createElement('select');
+        ['', 'Low', 'Medium', 'High'].forEach(v => {
+          const opt = document.createElement('option');
+          opt.value = v;
+          opt.textContent = v;
+          sel.appendChild(opt);
+        });
+        sel.value = value;
+        sel.onchange = () => saveField(item.id, 'competition_level', sel.value || null);
+        td.appendChild(sel);
+      } else if (['id','name','category','price','image_url','winner_score_v2_pct'].includes(key)) {
+        value = item[key];
+      } else if (weightFields.includes(key)) {
         value = item.winner_score_v2_breakdown && item.winner_score_v2_breakdown.scores ? item.winner_score_v2_breakdown.scores[key] : '';
         if (item.winner_score_v2_breakdown && item.winner_score_v2_breakdown.justifications) {
           const j = item.winner_score_v2_breakdown.justifications[key];
           if (j) td.title = 'Justificación: ' + j;
         }
-      } else if (['id','name','category','price','image_url','winner_score_v2_pct'].includes(key)) {
-        value = item[key];
       } else {
         value = item.extras ? item.extras[key] : '';
       }
@@ -618,7 +692,7 @@ function renderTable() {
             td.textContent = num.toLocaleString();
           }
         }
-      } else {
+      } else if (!['desire','desire_magnitude','awareness_level','competition_level'].includes(key)) {
         td.textContent = value || '';
       }
       tr.appendChild(td);
@@ -657,7 +731,7 @@ function sortBy(field, type) {
   products.sort((a, b) => {
     let va;
     let vb;
-    if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'winner_score_v2_pct') {
+    if (['id','name','category','price','image_url','winner_score_v2_pct','desire','desire_magnitude','awareness_level','competition_level'].includes(field)) {
       va = a[field];
       vb = b[field];
     } else if (weightFields.includes(field)) {

--- a/product_research_app/static/js/filters.js
+++ b/product_research_app/static/js/filters.js
@@ -5,6 +5,9 @@ let filtersState = {
   dateMax: '',
   ratingMin: null,
   category: '',
+  desireMagnitude: '',
+  awarenessLevel: '',
+  competitionLevel: '',
 };
 
 const idMap = {
@@ -49,6 +52,15 @@ function applyFiltersFromState() {
       const cat = (item.category || '').toString().toLowerCase();
       if (!cat.includes(filtersState.category)) return false;
     }
+    if (filtersState.desireMagnitude) {
+      if ((item.desire_magnitude || '') !== filtersState.desireMagnitude) return false;
+    }
+    if (filtersState.awarenessLevel) {
+      if ((item.awareness_level || '') !== filtersState.awarenessLevel) return false;
+    }
+    if (filtersState.competitionLevel) {
+      if ((item.competition_level || '') !== filtersState.competitionLevel) return false;
+    }
     return true;
   });
   // Mutate the global products array in place so renderTable sees the filtered list
@@ -72,6 +84,9 @@ function buildActiveChips(state) {
   if (state.dateMax) chips.push(['dateMax', `Hasta ${state.dateMax}`]);
   if (state.ratingMin !== null && !isNaN(state.ratingMin)) chips.push(['ratingMin', `Rating ≥ ${state.ratingMin}`]);
   if (state.category) chips.push(['category', `Cat: ${state.category}`]);
+  if (state.desireMagnitude) chips.push(['desireMagnitude', `DM: ${state.desireMagnitude}`]);
+  if (state.awarenessLevel) chips.push(['awarenessLevel', `Awareness: ${state.awarenessLevel}`]);
+  if (state.competitionLevel) chips.push(['competitionLevel', `Competition: ${state.competitionLevel}`]);
   chips.forEach(([key, label]) => {
     const chip = document.createElement('span');
     chip.className = 'chip';
@@ -84,7 +99,9 @@ function buildActiveChips(state) {
       } else {
         filtersState[key] = '';
       }
-      document.getElementById(idMap[key]).value = '';
+      const elId = idMap[key];
+      const el = elId ? document.getElementById(elId) : null;
+      if (el) el.value = '';
       applyFiltersFromState();
     };
     chip.appendChild(btn);
@@ -115,8 +132,9 @@ document.getElementById('clearFilters')?.addEventListener('click', () => {
   document.getElementById('filterDateMax').value = '';
   document.getElementById('filterRatingMin').value = '';
   document.getElementById('filterCategory').value = '';
-  filtersState = { priceMin: null, priceMax: null, dateMin: '', dateMax: '', ratingMin: null, category: '' };
+  filtersState = { priceMin: null, priceMax: null, dateMin: '', dateMax: '', ratingMin: null, category: '', desireMagnitude: '', awarenessLevel: '', competitionLevel: '' };
   applyFiltersFromState();
+  updateLevelChips();
 });
 
 document.addEventListener('keydown', (e) => {
@@ -145,3 +163,43 @@ function updateHeaderHeight() {
 }
 window.addEventListener('load', updateHeaderHeight);
 window.addEventListener('resize', updateHeaderHeight);
+
+const levelMap = {
+  desireMagnitude: ['Low','Medium','High'],
+  awarenessLevel: ['Unaware','Problem-Aware','Solution-Aware','Product-Aware','Most Aware'],
+  competitionLevel: ['Low','Medium','High']
+};
+
+function updateLevelChips(){
+  document.querySelectorAll('#levelFilterChips .chip').forEach(chip => {
+    const field = chip.dataset.field;
+    const val = chip.dataset.value;
+    chip.classList.toggle('selected', filtersState[field] === val);
+  });
+}
+
+function buildLevelFilterChips(){
+  const container = document.getElementById('levelFilterChips');
+  if(!container) return;
+  container.innerHTML = '';
+  Object.entries(levelMap).forEach(([field, values]) => {
+    const group = document.createElement('div');
+    values.forEach(val => {
+      const chip = document.createElement('span');
+      chip.className = 'chip';
+      chip.textContent = val;
+      chip.dataset.field = field;
+      chip.dataset.value = val;
+      chip.onclick = () => {
+        filtersState[field] = filtersState[field] === val ? '' : val;
+        applyFiltersFromState();
+        updateLevelChips();
+      };
+      group.appendChild(chip);
+    });
+    container.appendChild(group);
+  });
+  updateLevelChips();
+}
+
+buildLevelFilterChips();

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 beautifulsoup4
 Pillow
+openpyxl


### PR DESCRIPTION
## Summary
- expose Desire, Desire Magnitude, Awareness Level, and Competition Level columns in the product grid
- allow inline editing with textarea/select controls and validate against fixed options
- add chip-based filters for level fields with dark-mode styling

## Testing
- `python -m py_compile product_research_app/database.py product_research_app/main.py product_research_app/web_app.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68bd7d56939c8328a703bf3b02a0af9d