### PR TITLE
Start bulk import IDs at zero when table empty

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -62,7 +62,6 @@ body.dark .weight-slider {
     <div style="flex:1; display:flex; justify-content:flex-end; gap:8px; align-items:center;">
       <input type="file" id="fileInput" style="display:none;" />
       <button id="uploadBtn" title="Subir archivo">📤</button>
-      <button id="importHistoryBtn">Ver últimos imports</button>
       <button id="refreshBtn" title="Actualizar lista">🔄</button>
       <button id="trendsBtn" title="Ver tendencias">📊</button>
       <button id="darkToggle" title="Modo oscuro">🌙</button>
@@ -85,7 +84,6 @@ body.dark .weight-slider {
   </div>
 </div>
 <div id="importBanner" style="display:none; padding:8px; text-align:center;"></div>
-<div id="importHistory" class="card" style="display:none;"></div>
 <div id="config" style="display:none;">
   <label>API Key: <input type="password" id="apiKey" /></label>
   <button id="toggleApiKey" style="display:none;">Cambiar API Key</button>
@@ -260,7 +258,7 @@ async function pollImportStatus(id) {
       if (data.status === 'done') {
         fetchProducts();
         const n = data.rows_imported || 0;
-        toast.success(`Importación completada: ${n} filas nuevas`);
+        toast.success(`Importación completada: ${n} filas nuevas. IDs desde 0 si era la primera importación.`);
       } else {
         toast.error(data.error || 'Error en importación');
       }
@@ -727,23 +725,6 @@ function sortBy(field, type) {
 }
 
 document.getElementById('refreshBtn').onclick = fetchProducts;
-const historyBtn = document.getElementById('importHistoryBtn');
-if(historyBtn){
-  historyBtn.onclick = async () => {
-    const list = await fetchJson('/_import_history?limit=20');
-    const cont = document.getElementById('importHistory');
-    if(cont){
-      let html = '<h3>Últimos imports</h3><ul>';
-      list.forEach(it => {
-        const date = new Date(it.updated_at || it.created_at).toLocaleString();
-        html += `<li>${it.task_id}: ${it.status} - ${date}</li>`;
-      });
-      html += '</ul>';
-      cont.innerHTML = html;
-      cont.style.display = 'block';
-    }
-  };
-}
 window.onload = () => {
   loadConfig();
   fetchProducts();


### PR DESCRIPTION
## Summary
- allow `insert_product` to accept an explicit `product_id`
- compute base ID in XLSX import: start at 0 if table empty, else `MAX(id)+1`
- remove "Ver últimos imports" UI and its backend calls, and clarify import completion toast

## Testing
- `python -m py_compile product_research_app/web_app.py product_research_app/database.py`
- `python - <<'PY'
from product_research_app import database
from pathlib import Path
import sqlite3

db_path = Path('temp_test.sqlite3')
if db_path.exists(): db_path.unlink()
conn = database.get_connection(db_path)
database.initialize_database(conn)

# First import when table empty
cur = conn.cursor()
cur.execute('BEGIN')
cur.execute('SELECT COUNT(*) FROM products')
count = cur.fetchone()[0]
cur.execute('SELECT COALESCE(MAX(id), -1) FROM products')
max_id = cur.fetchone()[0]
base_id = 0 if count == 0 else max_id + 1
for idx in range(3):
    row_id = base_id + idx
    database.insert_product(conn, name=f'P{idx}', product_id=row_id, commit=False)
conn.commit()
cur.execute('SELECT id FROM products ORDER BY id')
print('IDs after first import', [r[0] for r in cur.fetchall()])

# Second import when table not empty
cur.execute('BEGIN')
cur.execute('SELECT COUNT(*) FROM products')
count = cur.fetchone()[0]
cur.execute('SELECT COALESCE(MAX(id), -1) FROM products')
max_id = cur.fetchone()[0]
base_id = 0 if count == 0 else max_id + 1
for idx in range(2):
    row_id = base_id + idx
    database.insert_product(conn, name=f'Q{idx}', product_id=row_id, commit=False)
conn.commit()
cur.execute('SELECT id FROM products ORDER BY id')
print('IDs after second import', [r[0] for r in cur.fetchall()])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bd9f74705083288ee766a20e260913