### PR TITLE
Add desire fields and update product API

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -308,14 +308,10 @@ const columns = [
   { key: 'Creator Conversion Ratio', label: 'Tasa Conversión', type: 'string' },
   { key: 'Launch Date', label: 'Fecha Lanzamiento', type: 'string' },
   { key: 'Date Range', label: 'Rango Fechas', type: 'string' },
-  { key: 'magnitud_deseo', label: 'Magnitud deseo', type: 'number' },
-  { key: 'nivel_consciencia', label: 'Nivel consciencia', type: 'number' },
-  { key: 'saturacion_mercado', label: 'Saturación mercado', type: 'number' },
-  { key: 'facilidad_anuncio', label: 'Facilidad anuncio', type: 'number' },
-  { key: 'facilidad_logistica', label: 'Facilidad logística', type: 'number' },
-  { key: 'escalabilidad', label: 'Escalabilidad', type: 'number' },
-  { key: 'engagement_shareability', label: 'Engagement/shareability', type: 'number' },
-  { key: 'durabilidad_recurrencia', label: 'Durabilidad/recurrencia', type: 'number' },
+  { key: 'desire_text', label: 'Desire', type: 'string' },
+  { key: 'desire_magnitude', label: 'Desire Magnitude', type: 'string' },
+  { key: 'awareness_level', label: 'Awareness Level', type: 'string' },
+  { key: 'competition_level', label: 'Competition Level', type: 'string' },
   { key: 'winner_score_v2_pct', label: 'Winner Score', type: 'number' },
 ];
 
@@ -358,6 +354,21 @@ function preprocessProducts(list){
     if (arr) arr.push(item); else dupMap.set(key, [item]);
   });
   dupMap.forEach(arr => { if (arr.length > 1) arr.forEach(it => it.isDuplicate = true); });
+}
+
+async function saveField(item, field, value, onError){
+  try{
+    const data = await fetchJson('/products/update-field', {method:'POST', body: JSON.stringify({id: item.id, field, value})});
+    if(data.error) throw new Error(data.error);
+    Object.assign(item, data);
+    toast.success('Guardado');
+    return data;
+  }catch(e){
+    console.error(e);
+    toast.error('Error al guardar');
+    if(onError) onError();
+    throw e;
+  }
 }
 
 const weightFields = [
@@ -581,6 +592,7 @@ function renderTable() {
       const td = document.createElement('td');
       const key = col.key;
       td.setAttribute('data-key', key);
+      td.style.verticalAlign = 'middle';
       let value = '';
       if (weightFields.includes(key)) {
         value = item.winner_score_v2_breakdown && item.winner_score_v2_breakdown.scores ? item.winner_score_v2_breakdown.scores[key] : '';
@@ -588,12 +600,57 @@ function renderTable() {
           const j = item.winner_score_v2_breakdown.justifications[key];
           if (j) td.title = 'Justificación: ' + j;
         }
-      } else if (['id','name','category','price','image_url','winner_score_v2_pct'].includes(key)) {
+      } else if (['id','name','category','price','image_url','winner_score_v2_pct','desire_text','desire_magnitude','awareness_level','competition_level'].includes(key)) {
         value = item[key];
       } else {
         value = item.extras ? item.extras[key] : '';
       }
-      if (key === 'winner_score_v2_pct') {
+      if (key === 'desire_text') {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.value = value || '';
+        input.style.width = '160px';
+        let prev = input.value;
+        let timer;
+        function commit(){
+          clearTimeout(timer);
+          saveField(item, key, input.value, () => input.value = prev).then(()=>{ prev = input.value; });
+        }
+        input.addEventListener('input', () => { clearTimeout(timer); timer = setTimeout(commit, 300); });
+        input.addEventListener('blur', commit);
+        input.addEventListener('keydown', e => { if(e.key === 'Enter'){ e.preventDefault(); commit(); input.blur(); }});
+        td.appendChild(input);
+      } else if (key === 'desire_magnitude') {
+        const sel = document.createElement('select');
+        sel.style.width = '130px';
+        ['', 'Low', 'Medium', 'High'].forEach(v => { const opt = document.createElement('option'); opt.value = v; opt.textContent = v; sel.appendChild(opt); });
+        sel.value = value || '';
+        let prev = sel.value;
+        sel.addEventListener('change', () => {
+          saveField(item, key, sel.value, () => sel.value = prev).then(()=>{ prev = sel.value; });
+        });
+        td.appendChild(sel);
+      } else if (key === 'awareness_level') {
+        const sel = document.createElement('select');
+        sel.style.width = '170px';
+        ['', 'Unaware', 'Problem-Aware', 'Solution-Aware', 'Product-Aware', 'Most Aware'].forEach(v => { const opt = document.createElement('option'); opt.value = v; opt.textContent = v; sel.appendChild(opt); });
+        sel.value = value || '';
+        let prev = sel.value;
+        sel.addEventListener('change', () => {
+          saveField(item, key, sel.value, () => sel.value = prev).then(()=>{ prev = sel.value; });
+        });
+        td.appendChild(sel);
+      } else if (key === 'competition_level') {
+        const sel = document.createElement('select');
+        sel.style.width = '130px';
+        ['', 'Low', 'Medium', 'High'].forEach(v => { const opt = document.createElement('option'); opt.value = v; opt.textContent = v; sel.appendChild(opt); });
+        sel.value = value || '';
+        let prev = sel.value;
+        sel.addEventListener('change', () => {
+          saveField(item, key, sel.value, () => sel.value = prev).then(()=>{ prev = sel.value; });
+        });
+        td.appendChild(sel);
+      } else if (key === 'winner_score_v2_pct') {
         const sc = parseFloat(value);
         if (!isNaN(sc)) {
           td.innerHTML = '<span class="' + winnerScoreClass(sc) + '">' + Math.round(sc) + '</span>';
@@ -696,7 +753,7 @@ function sortBy(field, type) {
   products.sort((a, b) => {
     let va;
     let vb;
-    if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'winner_score_v2_pct') {
+    if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'winner_score_v2_pct' || field === 'desire_text' || field === 'desire_magnitude' || field === 'awareness_level' || field === 'competition_level') {
       va = a[field];
       vb = b[field];
     } else if (weightFields.includes(field)) {


### PR DESCRIPTION
## Summary
- add `desire_text`, `desire_magnitude`, `awareness_level` and `competition_level` columns with null reset in SQLite setup
- expose new fields with pagination in `/products` and return ordered product data
- implement `/products/update-field` for validated per-cell edits
- replace old desire column block in frontend with editable desire fields

## Testing
- `python -m py_compile product_research_app/database.py product_research_app/web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdaa7cd2ec83288ea1fb664907ed6e