### PR TITLE
Add editable desire fields and paginate products API

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -286,6 +286,7 @@ let allProducts = [];
 let products = [];
 let sortField = null;
 let sortDir = 1;
+let totalCount = 0;
 function updateResultsBadge(total) {
   const meta = document.getElementById('listMeta');
   if (!meta) return;
@@ -296,6 +297,34 @@ function updateResultsBadge(total) {
 window.updateResultsBadge = updateResultsBadge;
 window.allProducts = allProducts;
 window.products = products;
+
+function debounce(fn, delay){
+  let t, lastArgs;
+  function wrapped(...args){
+    lastArgs = args;
+    clearTimeout(t);
+    t = setTimeout(() => {
+      t = null;
+      fn(...lastArgs);
+    }, delay);
+  }
+  wrapped.flush = () => {
+    if(t){
+      clearTimeout(t);
+      t = null;
+      fn(...lastArgs);
+    }
+  };
+  return wrapped;
+}
+
+async function saveField(id, field, value){
+  await fetchJson('/products/update-field', {
+    method: 'POST',
+    body: JSON.stringify({id, field, value})
+  });
+  toast.success('Guardado');
+}
 const columns = [
   { key: 'id', label: 'ID', type: 'number' },
   { key: 'image_url', label: 'Imagen', type: 'image' },
@@ -308,15 +337,11 @@ const columns = [
   { key: 'Creator Conversion Ratio', label: 'Tasa Conversión', type: 'string' },
   { key: 'Launch Date', label: 'Fecha Lanzamiento', type: 'string' },
   { key: 'Date Range', label: 'Rango Fechas', type: 'string' },
-  { key: 'magnitud_deseo', label: 'Magnitud deseo', type: 'number' },
-  { key: 'nivel_consciencia', label: 'Nivel consciencia', type: 'number' },
-  { key: 'saturacion_mercado', label: 'Saturación mercado', type: 'number' },
-  { key: 'facilidad_anuncio', label: 'Facilidad anuncio', type: 'number' },
-  { key: 'facilidad_logistica', label: 'Facilidad logística', type: 'number' },
-  { key: 'escalabilidad', label: 'Escalabilidad', type: 'number' },
-  { key: 'engagement_shareability', label: 'Engagement/shareability', type: 'number' },
-  { key: 'durabilidad_recurrencia', label: 'Durabilidad/recurrencia', type: 'number' },
-  { key: 'winner_score_v2_pct', label: 'Winner Score', type: 'number' },
+  { key: 'desire_text', label: 'Desire', type: 'string' },
+  { key: 'desire_magnitude', label: 'Desire Magnitude', type: 'string' },
+  { key: 'awareness_level', label: 'Awareness Level', type: 'string' },
+  { key: 'competition_level', label: 'Competition Level', type: 'string' },
+  { key: 'winner_score', label: 'Winner Score', type: 'number' },
 ];
 
 let trendingWords = [];
@@ -517,14 +542,16 @@ function isTrending(name) {
 
 async function fetchProducts() {
   const data = await fetchJson('/products');
+  totalCount = data.total || 0;
   // keep a copy of all products for filtering
-  allProducts = data;
+  allProducts = data.items || [];
   preprocessProducts(allProducts);
   products = [...allProducts];
   window.allProducts = allProducts;
   window.products = products;
   selection.clear();
   renderTable();
+  updateResultsBadge(totalCount);
 }
 
 function renderTable() {
@@ -588,12 +615,12 @@ function renderTable() {
           const j = item.winner_score_v2_breakdown.justifications[key];
           if (j) td.title = 'Justificación: ' + j;
         }
-      } else if (['id','name','category','price','image_url','winner_score_v2_pct'].includes(key)) {
+      } else if (['id','name','category','price','image_url','winner_score','desire_text','desire_magnitude','awareness_level','competition_level'].includes(key)) {
         value = item[key];
       } else {
         value = item.extras ? item.extras[key] : '';
       }
-      if (key === 'winner_score_v2_pct') {
+      if (key === 'winner_score') {
         const sc = parseFloat(value);
         if (!isNaN(sc)) {
           td.innerHTML = '<span class="' + winnerScoreClass(sc) + '">' + Math.round(sc) + '</span>';
@@ -646,6 +673,93 @@ function renderTable() {
           };
           td.appendChild(btnCopy);
         }
+      } else if (key === 'desire_text') {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.value = value || '';
+        input.style.width = '160px';
+        td.style.verticalAlign = 'middle';
+        let prev = input.value;
+        const saver = debounce(async val => {
+          try {
+            await saveField(item.id, 'desire_text', val);
+            prev = val;
+          } catch (e) {
+            input.value = prev;
+          }
+        }, 300);
+        input.addEventListener('input', e => saver(e.target.value));
+        input.addEventListener('blur', () => saver.flush());
+        input.addEventListener('keydown', e => {
+          if (e.key === 'Enter') { e.preventDefault(); saver.flush(); input.blur(); }
+        });
+        td.appendChild(input);
+      } else if (key === 'desire_magnitude') {
+        const select = document.createElement('select');
+        ['', 'Low', 'Medium', 'High'].forEach(v => {
+          const o = document.createElement('option');
+          o.value = v;
+          o.textContent = v;
+          select.appendChild(o);
+        });
+        select.value = value || '';
+        select.style.width = '120px';
+        td.style.verticalAlign = 'middle';
+        let prev = select.value;
+        select.addEventListener('change', async () => {
+          const val = select.value;
+          try {
+            await saveField(item.id, 'desire_magnitude', val);
+            prev = val;
+          } catch (e) {
+            select.value = prev;
+          }
+        });
+        td.appendChild(select);
+      } else if (key === 'awareness_level') {
+        const select = document.createElement('select');
+        ['', 'Unaware', 'Problem-Aware', 'Solution-Aware', 'Product-Aware', 'Most Aware'].forEach(v => {
+          const o = document.createElement('option');
+          o.value = v;
+          o.textContent = v;
+          select.appendChild(o);
+        });
+        select.value = value || '';
+        select.style.width = '160px';
+        td.style.verticalAlign = 'middle';
+        let prev = select.value;
+        select.addEventListener('change', async () => {
+          const val = select.value;
+          try {
+            await saveField(item.id, 'awareness_level', val);
+            prev = val;
+          } catch (e) {
+            select.value = prev;
+          }
+        });
+        td.appendChild(select);
+      } else if (key === 'competition_level') {
+        const select = document.createElement('select');
+        ['', 'Low', 'Medium', 'High'].forEach(v => {
+          const o = document.createElement('option');
+          o.value = v;
+          o.textContent = v;
+          select.appendChild(o);
+        });
+        select.value = value || '';
+        select.style.width = '120px';
+        td.style.verticalAlign = 'middle';
+        let prev = select.value;
+        select.addEventListener('change', async () => {
+          const val = select.value;
+          try {
+            await saveField(item.id, 'competition_level', val);
+            prev = val;
+          } catch (e) {
+            select.value = prev;
+          }
+        });
+        td.appendChild(select);
       } else if (col.type === 'number' && value !== null && value !== undefined && value !== '') {
         let num = parseFloat(String(value).replace(/[^0-9.-]+/g, ''));
         if (isNaN(num)) {
@@ -680,7 +794,6 @@ function renderTable() {
     tbody.appendChild(tr);
   });
   currentPageIds = products.map(p => String(p.id));
-  updateResultsBadge(currentPageIds.length);
   if (window.refreshColumns) window.refreshColumns();
   if (window.applyColumnVisibility) window.applyColumnVisibility();
   updateMasterState();
@@ -696,7 +809,7 @@ function sortBy(field, type) {
   products.sort((a, b) => {
     let va;
     let vb;
-    if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'winner_score_v2_pct') {
+    if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'winner_score' || field === 'desire_text' || field === 'desire_magnitude' || field === 'awareness_level' || field === 'competition_level') {
       va = a[field];
       vb = b[field];
     } else if (weightFields.includes(field)) {
@@ -949,7 +1062,11 @@ document.getElementById('searchBtn').onclick = () => {
       visible++;
       return;
     }
-    const cells = Array.from(row.cells).map(td => td.textContent.toLowerCase());
+    const cells = Array.from(row.cells).map(td => {
+      const el = td.querySelector('input, select');
+      const txt = el ? el.value : td.textContent;
+      return txt.toLowerCase();
+    });
     const match = cells.some(text => text.includes(term));
     row.style.display = match ? '' : 'none';
     if (match) visible++;
@@ -1238,7 +1355,7 @@ async function loadTrends(){
   let html = '<h3>Tendencias</h3>';
   if(data.top_products && data.top_products.length){
     html += '<strong>Top productos por Winner Score:</strong><ol>';
-      data.top_products.forEach(item=>{ html += `<li>${item.name} (Winner Score: ${item.winner_score_v2_pct.toFixed(2)})</li>`; });
+      data.top_products.forEach(item=>{ html += `<li>${item.name} (Winner Score: ${item.winner_score.toFixed(2)})</li>`; });
     html += '</ol>';
   }
   cont.innerHTML = html;

--- a/product_research_app/static/js/filters.js
+++ b/product_research_app/static/js/filters.js
@@ -59,6 +59,7 @@ function applyFiltersFromState() {
   selection.clear();
   updateMasterState();
   renderTable();
+  if (typeof updateResultsBadge === 'function') updateResultsBadge(products.length);
 }
 
 function buildActiveChips(state) {


### PR DESCRIPTION
## Summary
- add desire_text, desire_magnitude, awareness_level and competition_level columns with null-reset
- expose paginated `/products` endpoint returning new qualitative fields
- support hot editing via `/products/update-field`
- replace obsolete frontend columns with Desire/Desire Magnitude/Awareness Level/Competition Level and enable inline editing

## Testing
- `python -m py_compile product_research_app/database.py product_research_app/web_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdaeadf1b8832896ea27bc8be26482