### PR TITLE
feat: add desire fields to table

### DIFF
--- a/product_research_app/migrations/add_desire_fields.sql
+++ b/product_research_app/migrations/add_desire_fields.sql
@@ -1,13 +1,5 @@
--- Migration for desire/awareness/competition fields
--- Rename existing Spanish columns if present
-ALTER TABLE products RENAME COLUMN magnitud_deseo TO desire_magnitude;
-ALTER TABLE products RENAME COLUMN nivel_consciencia TO awareness_level;
-ALTER TABLE products RENAME COLUMN saturacion_mercado TO competition_level;
--- Add new desire column
-ALTER TABLE products ADD COLUMN desire TEXT;
--- Drop obsolete columns if they exist
-ALTER TABLE products DROP COLUMN facilidad_anuncio;
-ALTER TABLE products DROP COLUMN facilidad_logistica;
-ALTER TABLE products DROP COLUMN escalabilidad;
-ALTER TABLE products DROP COLUMN engagement_shareability;
-ALTER TABLE products DROP COLUMN durabilidad_recurrencia;
+-- Idempotent migration for desire/awareness/competition fields
+ALTER TABLE products ADD COLUMN IF NOT EXISTS desire TEXT;
+ALTER TABLE products ADD COLUMN IF NOT EXISTS desire_magnitude TEXT;
+ALTER TABLE products ADD COLUMN IF NOT EXISTS awareness_level TEXT;
+ALTER TABLE products ADD COLUMN IF NOT EXISTS competition_level TEXT;

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -308,14 +308,10 @@ const columns = [
   { key: 'Creator Conversion Ratio', label: 'Tasa Conversión', type: 'string' },
   { key: 'Launch Date', label: 'Fecha Lanzamiento', type: 'string' },
   { key: 'Date Range', label: 'Rango Fechas', type: 'string' },
-  { key: 'magnitud_deseo', label: 'Magnitud deseo', type: 'number' },
-  { key: 'nivel_consciencia', label: 'Nivel consciencia', type: 'number' },
-  { key: 'saturacion_mercado', label: 'Saturación mercado', type: 'number' },
-  { key: 'facilidad_anuncio', label: 'Facilidad anuncio', type: 'number' },
-  { key: 'facilidad_logistica', label: 'Facilidad logística', type: 'number' },
-  { key: 'escalabilidad', label: 'Escalabilidad', type: 'number' },
-  { key: 'engagement_shareability', label: 'Engagement/shareability', type: 'number' },
-  { key: 'durabilidad_recurrencia', label: 'Durabilidad/recurrencia', type: 'number' },
+  { key: 'desire', label: 'Desire', type: 'string' },
+  { key: 'desire_magnitude', label: 'Desire magnetitude', type: 'string' },
+  { key: 'awareness_level', label: 'Awerness Level', type: 'string' },
+  { key: 'competition_level', label: 'Competition level', type: 'string' },
   { key: 'winner_score_v2_pct', label: 'Winner Score', type: 'number' },
 ];
 
@@ -360,16 +356,7 @@ function preprocessProducts(list){
   dupMap.forEach(arr => { if (arr.length > 1) arr.forEach(it => it.isDuplicate = true); });
 }
 
-const weightFields = [
-  'magnitud_deseo',
-  'nivel_consciencia',
-  'saturacion_mercado',
-  'facilidad_anuncio',
-  'facilidad_logistica',
-  'escalabilidad',
-  'engagement_shareability',
-  'durabilidad_recurrencia'
-];
+const weightFields = [];
 const WEIGHTS_LS_KEY = 'winnerScoreWeights:v1';
 let weightStore = {};
 let persistTimer;
@@ -377,12 +364,14 @@ let backendWeightsEnabled = true;
 
 function defaultWeights(){
   const w = {};
+  if(weightFields.length === 0) return w;
   const v = 1 / weightFields.length;
   weightFields.forEach(k => w[k] = v);
   return w;
 }
 
 function normalizeWeights(obj){
+  if(weightFields.length === 0) return {};
   let total = 0;
   weightFields.forEach(k => { total += parseFloat(obj[k]) || 0; });
   if(total <= 0) return defaultWeights();
@@ -395,6 +384,7 @@ function renderWeights(weights){
   const container = document.getElementById('weightsContainer');
   if (!container) return;
   container.innerHTML = '';
+  if(weightFields.length === 0) return;
   weightFields.forEach(key => {
     const row = document.createElement('div');
     row.style.display = 'flex';
@@ -527,6 +517,17 @@ async function fetchProducts() {
   renderTable();
 }
 
+function patchProductField(id, data){
+  const t1 = allProducts.find(p => p.id === id);
+  if(t1) Object.assign(t1, data);
+  const t2 = products.find(p => p.id === id);
+  if(t2) Object.assign(t2, data);
+  fetchJson(`/products/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data)
+  }).catch(()=>{});
+}
+
 function renderTable() {
   const headerRow = document.getElementById('headerRow');
   const tbody = document.querySelector('#productTable tbody');
@@ -582,13 +583,7 @@ function renderTable() {
       const key = col.key;
       td.setAttribute('data-key', key);
       let value = '';
-      if (weightFields.includes(key)) {
-        value = item.winner_score_v2_breakdown && item.winner_score_v2_breakdown.scores ? item.winner_score_v2_breakdown.scores[key] : '';
-        if (item.winner_score_v2_breakdown && item.winner_score_v2_breakdown.justifications) {
-          const j = item.winner_score_v2_breakdown.justifications[key];
-          if (j) td.title = 'Justificación: ' + j;
-        }
-      } else if (['id','name','category','price','image_url','winner_score_v2_pct'].includes(key)) {
+      if (['id','name','category','price','image_url','winner_score_v2_pct','desire','desire_magnitude','awareness_level','competition_level'].includes(key)) {
         value = item[key];
       } else {
         value = item.extras ? item.extras[key] : '';
@@ -646,6 +641,65 @@ function renderTable() {
           };
           td.appendChild(btnCopy);
         }
+      } else if (key === 'desire') {
+        td.style.minWidth = '280px';
+        td.style.maxWidth = '360px';
+        td.style.width = '300px';
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.value = value || '';
+        input.addEventListener('change', () => {
+          patchProductField(item.id, { desire: input.value || null });
+        });
+        td.appendChild(input);
+      } else if (key === 'desire_magnitude') {
+        td.style.minWidth = '180px';
+        td.style.maxWidth = '220px';
+        td.style.width = '200px';
+        const select = document.createElement('select');
+        ['', 'Low', 'Medium', 'High'].forEach(opt => {
+          const o = document.createElement('option');
+          o.value = opt;
+          o.textContent = opt;
+          select.appendChild(o);
+        });
+        select.value = value || '';
+        select.addEventListener('change', () => {
+          patchProductField(item.id, { desire_magnitude: select.value || null });
+        });
+        td.appendChild(select);
+      } else if (key === 'awareness_level') {
+        td.style.minWidth = '180px';
+        td.style.maxWidth = '220px';
+        td.style.width = '200px';
+        const select = document.createElement('select');
+        ['', 'Unaware', 'Problem-Aware', 'Solution-Aware', 'Product-Aware', 'Most Aware'].forEach(opt => {
+          const o = document.createElement('option');
+          o.value = opt;
+          o.textContent = opt;
+          select.appendChild(o);
+        });
+        select.value = value || '';
+        select.addEventListener('change', () => {
+          patchProductField(item.id, { awareness_level: select.value || null });
+        });
+        td.appendChild(select);
+      } else if (key === 'competition_level') {
+        td.style.minWidth = '180px';
+        td.style.maxWidth = '220px';
+        td.style.width = '200px';
+        const select = document.createElement('select');
+        ['', 'Low', 'Medium', 'High'].forEach(opt => {
+          const o = document.createElement('option');
+          o.value = opt;
+          o.textContent = opt;
+          select.appendChild(o);
+        });
+        select.value = value || '';
+        select.addEventListener('change', () => {
+          patchProductField(item.id, { competition_level: select.value || null });
+        });
+        td.appendChild(select);
       } else if (col.type === 'number' && value !== null && value !== undefined && value !== '') {
         let num = parseFloat(String(value).replace(/[^0-9.-]+/g, ''));
         if (isNaN(num)) {
@@ -696,7 +750,7 @@ function sortBy(field, type) {
   products.sort((a, b) => {
     let va;
     let vb;
-    if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'winner_score_v2_pct') {
+    if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'winner_score_v2_pct' || field === 'desire' || field === 'desire_magnitude' || field === 'awareness_level' || field === 'competition_level') {
       va = a[field];
       vb = b[field];
     } else if (weightFields.includes(field)) {


### PR DESCRIPTION
## Summary
- replace placeholder columns with Desire, Desire magnetitude, Awerness Level, and Competition level
- allow inline editing with partial backend updates
- add idempotent migration for new desire/awareness fields

## Testing
- `python -m py_compile product_research_app/database.py product_research_app/web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdba042f3c8328bb5268ca5a645f1b