### PR TITLE
Add BA GPT analysis for single product

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -78,6 +78,7 @@ body.dark .weight-slider {
     <button id="createListBtn">Crear</button>
     <textarea id="gptPrompt" rows="1" maxlength="2000" placeholder="Escribe consulta para GPT..." aria-label="Escribe consulta para GPT..."></textarea>
     <button id="sendPrompt">Enviar consulta a GPT</button>
+    <button id="btn-ba-gpt" disabled>BA (GPT)</button>
     <div id="searchRowRight">
       <div id="listMeta">0 resultados</div>
     </div>
@@ -1478,6 +1479,7 @@ window.renderTable = renderTable;
 window.startProgress = startProgress;
 window.parseDate = parseDate;
 </script>
+<script type="module" src="/static/js/ba-gpt.js"></script>
 <div id="chartTooltip" style="position:absolute; background:#fff; border:1px solid #333; padding:4px; font-size:12px; border-radius:4px; pointer-events:none; display:none; z-index:2000;"></div>
 <script src="/static/js/filters.js"></script>
 </body>

--- a/product_research_app/static/js/ba-gpt.js
+++ b/product_research_app/static/js/ba-gpt.js
@@ -1,0 +1,154 @@
+import { fetchJson } from '/static/js/net.js';
+
+const btn = document.getElementById('btn-ba-gpt');
+if (btn) {
+  btn.addEventListener('click', () => {
+    if (selection.size !== 1) return;
+    const id = Array.from(selection)[0];
+    const product = (window.products || []).find(p => String(p.id) === id);
+    if (!product) return;
+
+    const box = document.createElement('div');
+    box.style.padding = '20px';
+    box.innerHTML = `<h3>Análisis BA para producto ${product.id}</h3><p>Usará GPT y puede consumir saldo. ¿Continuar?</p>`;
+
+    let includeCb = null;
+    if (product.image_url) {
+      const label = document.createElement('label');
+      includeCb = document.createElement('input');
+      includeCb.type = 'checkbox';
+      includeCb.checked = true;
+      label.appendChild(includeCb);
+      label.appendChild(document.createTextNode(' Incluir imagen'));
+      box.appendChild(label);
+    }
+
+    const actions = document.createElement('div');
+    actions.style.marginTop = '15px';
+    actions.style.display = 'flex';
+    actions.style.gap = '8px';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.textContent = 'Cancelar';
+    const runBtn = document.createElement('button');
+    runBtn.textContent = 'Analizar';
+    actions.appendChild(cancelBtn);
+    actions.appendChild(runBtn);
+    box.appendChild(actions);
+
+    const handle = window.modalManager.open(box, { returnFocus: btn });
+    cancelBtn.onclick = () => handle.close();
+    runBtn.onclick = async () => {
+      runBtn.classList.add('loading');
+      runBtn.textContent = 'Pensando…';
+      runBtn.disabled = true;
+      btn.disabled = true;
+      const payload = {
+        id: product.id,
+        name: product.name,
+        category: product.category,
+        price: product.price,
+        rating: product.rating,
+        units_sold: product.units_sold,
+        revenue: product.revenue,
+        conversion_rate: product.conversion_rate,
+        launch_date: product.launch_date,
+        date_range: product.date_range,
+        image_url: product.image_url,
+        desire: product.desire,
+        desire_magnitude: product.desire_magnitude,
+        awareness_level: product.awareness_level,
+        competition_level: product.competition_level
+      };
+      if (!includeCb || !includeCb.checked) payload.image_url = null;
+      const modelSel = document.getElementById('modelSelect');
+      const model = modelSel ? modelSel.value : undefined;
+      try {
+        const resp = await fetchJson('/api/ba/insights', {
+          method: 'POST',
+          body: JSON.stringify({ product: payload, model })
+        });
+        Object.assign(product, resp.grid_updates);
+        renderTable();
+        try {
+          await fetchJson(`/products/${product.id}`, {
+            method: 'PUT',
+            body: JSON.stringify(resp.grid_updates)
+          });
+        } catch (e) {}
+        handle.close();
+        showResults(resp);
+      } catch (e) {
+        handle.close();
+      } finally {
+        btn.disabled = selection.size !== 1;
+      }
+    };
+  });
+}
+
+function showResults(data) {
+  const { grid_updates: gu, ba_insights: ba } = data;
+  const box = document.createElement('div');
+  box.style.maxWidth = '600px';
+  box.style.padding = '20px';
+  box.innerHTML = '<h3>Resultados BA</h3>';
+  const chips = document.createElement('div');
+  ['awareness_level', 'desire_magnitude', 'competition_level'].forEach(k => {
+    const v = gu[k];
+    if (v) {
+      const chip = document.createElement('span');
+      chip.className = 'chip';
+      chip.textContent = v;
+      chips.appendChild(chip);
+    }
+  });
+  box.appendChild(chips);
+  if (gu.desire) {
+    const p = document.createElement('p');
+    p.innerHTML = '<strong>Desire:</strong> ' + gu.desire;
+    box.appendChild(p);
+  }
+  const acc = document.createElement('div');
+  addSection(acc, 'Ángulos', ba.angles);
+  addSection(acc, 'Titulares', ba.headlines);
+  addSection(acc, 'Hooks UGC', ba.hooks_ugc);
+  if (Array.isArray(ba.objections_and_answers)) {
+    const det = document.createElement('details');
+    const sum = document.createElement('summary');
+    sum.textContent = 'Objeciones y respuestas';
+    det.appendChild(sum);
+    const ul = document.createElement('ul');
+    ba.objections_and_answers.forEach(o => {
+      const li = document.createElement('li');
+      li.innerHTML = `<strong>${o.objection}</strong>: ${o.answer}`;
+      ul.appendChild(li);
+    });
+    det.appendChild(ul);
+    acc.appendChild(det);
+  }
+  addSection(acc, 'CTAs', ba.cta_options);
+  box.appendChild(acc);
+  window.modalManager.open(box, { returnFocus: btn });
+}
+
+function addSection(container, title, items) {
+  if (!items) return;
+  const det = document.createElement('details');
+  const sum = document.createElement('summary');
+  sum.textContent = title;
+  det.appendChild(sum);
+  if (Array.isArray(items)) {
+    const ul = document.createElement('ul');
+    items.forEach(it => {
+      const li = document.createElement('li');
+      li.textContent = it;
+      ul.appendChild(li);
+    });
+    det.appendChild(ul);
+  } else {
+    const p = document.createElement('p');
+    p.textContent = items;
+    det.appendChild(p);
+  }
+  container.appendChild(det);
+}

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -32,9 +32,11 @@ function updateMasterState(){
   const btnDel = document.getElementById('btnDelete');
   const btnExp = document.getElementById('btnExport');
   const btnAdd = document.getElementById('btnAddToGroup');
+  const btnBa = document.getElementById('btn-ba-gpt');
   if(btnDel) btnDel.disabled = disable;
   if(btnExp) btnExp.disabled = disable;
   if(btnAdd) btnAdd.disabled = disable;
+  if(btnBa) btnBa.disabled = selection.size !== 1;
   if(bottomBar){
     const selEl = document.getElementById('selCount');
     if(selEl) selEl.textContent = `${selection.size} seleccionados`;


### PR DESCRIPTION
## Summary
- add backend endpoint `/api/ba/insights` that calls OpenAI to generate Breakthrough Advertising insights and recommended grid values
- include new `BA (GPT)` button with modal and results panel to analyse a single selected product
- update table selection logic to enable the new button only when exactly one product is selected

## Testing
- `python -m py_compile product_research_app/gpt.py product_research_app/web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68be2206f0c88328ab66d12046c2f0d9