### PR TITLE
Add batch AI column completion

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -78,7 +78,7 @@ body.dark .weight-slider {
     <button id="createListBtn">Crear</button>
     <textarea id="gptPrompt" rows="1" maxlength="2000" placeholder="Escribe consulta para GPT..." aria-label="Escribe consulta para GPT..."></textarea>
     <button id="sendPrompt">Enviar consulta a GPT</button>
-    <button id="btn-completar-ia" disabled>Completar columnas (IA)</button>
+    <button id="btn-completar-ia">Completar columnas (IA)</button>
     <div id="searchRowRight">
       <div id="listMeta">0 resultados</div>
     </div>

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -32,11 +32,9 @@ function updateMasterState(){
   const btnDel = document.getElementById('btnDelete');
   const btnExp = document.getElementById('btnExport');
   const btnAdd = document.getElementById('btnAddToGroup');
-  const btnIA = document.getElementById('btn-completar-ia');
   if(btnDel) btnDel.disabled = disable;
   if(btnExp) btnExp.disabled = disable;
   if(btnAdd) btnAdd.disabled = disable;
-  if(btnIA) btnIA.disabled = disable;
   if(bottomBar){
     const selEl = document.getElementById('selCount');
     if(selEl) selEl.textContent = `${selection.size} seleccionados`;


### PR DESCRIPTION
## Summary
- Add always-enabled "Completar columnas (IA)" button
- Batch AI requests for visible products and persist desire-related fields
- Expose `/api/ia/batch-columns` endpoint using OpenAI JSON output

## Testing
- `pytest`
- `python -m py_compile product_research_app/gpt.py product_research_app/web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68beb0a170948328b0235f333cbae9a9