### PR TITLE
Normalize XLSX import metrics and update progress banner

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -34,8 +34,8 @@ tbody tr:hover {
   transform: translateY(-2px);
   transition: box-shadow 0.2s, transform 0.2s;
 }
-#importBanner { background:#fff8e1; color:#665c00; }
-body.dark #importBanner { background:#665c00; color:#fff; }
+#importBanner { background:rgba(122,83,214,0.2); color:#7a53d6; border:1px solid rgba(122,83,214,0.3); }
+body.dark #importBanner { background:rgba(122,83,214,0.2); color:#c9b9f3; border:1px solid rgba(122,83,214,0.4); }
 /* History & Details */
 #history details { margin-bottom:8px; }
 details summary { cursor:pointer; font-weight:600; color:#0062ff; }
@@ -235,7 +235,7 @@ window.groupsService = groupsService;
 const IMPORT_TASK_LS_KEY = 'last_import_task';
 let importPollTimer = null;
 
-function showImportBanner(msg = 'Importando… puedes cerrar esta ventana; seguiremos procesando.') {
+function showImportBanner(msg = 'Importando productos, espera…') {
   const b = document.getElementById('importBanner');
   if (!b) return;
   b.textContent = msg;
@@ -592,15 +592,28 @@ function isTrending(name) {
   return words.some(w => trendingWords.includes(w));
 }
 
-async function fetchProducts() {
+async function fetchProducts(preserve=true) {
+  const prevSel = new Set(selection);
   const data = await fetchJson('/products');
-  // keep a copy of all products for filtering
   allProducts = data;
   preprocessProducts(allProducts);
+  allProducts.sort((a,b)=> (Number(a.id)||0) - (Number(b.id)||0));
+  sortField = 'id';
+  sortDir = 1;
   products = [...allProducts];
   window.allProducts = allProducts;
   window.products = products;
+  if (typeof filtersState !== 'undefined' && preserve) {
+    applyFiltersFromState();
+  } else {
+    renderTable();
+  }
+  const visibleIds = new Set(products.map(p => String(p.id)));
   selection.clear();
+  for (const id of prevSel) {
+    if (visibleIds.has(id)) selection.add(id);
+  }
+  updateMasterState();
   renderTable();
 }
 


### PR DESCRIPTION
## Summary
- Map and normalize Rating, Units Sold, and Revenue columns from XLSX imports; auto-calculate revenue when missing
- Sort table by numeric ID after import while preserving filters and selections
- Style import banner with themed purple and update text to “Importando productos, espera…”

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bebeadbb688328b168469e6aee1d05