### PR TITLE
Improve configuration modal and toast positioning

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -366,15 +366,22 @@ body.dark .bottombar {
   border: 1px solid #34456B;
   border-radius: 16px;
   box-shadow: 0 8px 24px rgba(0,0,0,0.45);
-  width: 90%;
-  max-width: 420px;
+  width: 90vw;
+  max-width: min(900px, 96vw);
+  max-height: min(88vh, 980px);
   margin: 24px;
-  max-height: 80vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   transform: scale(0.9);
   opacity: 0;
   transition: opacity 0.16s ease, transform 0.16s ease;
+}
+
+@media (min-width:1200px){
+  .modal-overlay .modal {
+    max-width: min(1024px, 96vw);
+  }
 }
 .modal-overlay.open .modal {
   transform: scale(1);
@@ -386,6 +393,10 @@ body.dark .bottombar {
   justify-content: space-between;
   padding: 16px 20px 8px;
   margin-bottom: 12px;
+  position: sticky;
+  top: 0;
+  background: #0F1424;
+  z-index: 1;
 }
 .modal-header h2 {
   margin: 0;
@@ -407,6 +418,7 @@ body.dark .bottombar {
 .modal-body {
   padding: 0 20px 16px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   flex: 1 1 auto;
 }
 .modal-body input {
@@ -612,11 +624,11 @@ th.ec-col-competition,   td.ec-col-competition   { width: var(--ec-w-competition
 
 /* Winner Score slider styles */
 .ws-handle{ cursor:grab; padding-inline:4px; }
-.metric-row{ display:flex; align-items:center; gap:8px; }
-.ws-name{ flex:0 0 120px; }
-.ws-slider-wrap{ display:flex; align-items:center; flex:1; gap:8px; }
-.ws-endcap-left, .ws-endcap-right{ font-size:11px; white-space:nowrap; }
-.ws-slider{ flex:1; width:100%; min-width:160px; padding-inline:8px; height:12px; cursor:pointer; accent-color:#0077cc; }
+#weightsCard{ overflow-x:hidden; }
+.metric-row{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.ws-name{ flex:0 0 140px; }
+.ws-slider-wrap{ display:flex; align-items:center; flex:1 1 200px; gap:8px; min-width:0; }
+.ws-slider{ flex:1; width:100%; padding:4px 8px; height:12px; cursor:pointer; accent-color:#0077cc; }
 body.dark .ws-slider{ accent-color:#7a53d6; }
 .ws-slider::-webkit-slider-thumb{ width:20px; height:20px; border-radius:50%; cursor:pointer; }
 .ws-slider::-moz-range-thumb{ width:20px; height:20px; border-radius:50%; cursor:pointer; }

--- a/product_research_app/static/css/toast.css
+++ b/product_research_app/static/css/toast.css
@@ -1,4 +1,4 @@
-#toast-container{ position: fixed; right:16px; top:16px; display:flex; flex-direction:column; gap:8px; z-index:2100 }
+#toast-container{ position: fixed; right:24px; bottom:24px; display:flex; flex-direction:column; gap:8px; z-index:2100 }
 .toast{ min-width:260px; max-width:420px; background:#131A2E; border:1px solid #34456B; color:#E8ECF7; padding:10px 12px; border-radius:10px; box-shadow:0 8px 16px rgba(0,0,0,.35); display:flex; justify-content:space-between; align-items:center; gap:12px; opacity:0; transform: translateY(8px); animation: toast-in .2s forwards }
 .toast.success{ border-color:#1f6c4a } .toast.error{ border-color:#7a2d2d } .toast.info{ border-color:#34456B }
 .toast .action{ background:#34456B; border:1px solid #A9B4D0; color:#E8ECF7; cursor:pointer; padding:4px 8px; border-radius:6px; font-weight:600 }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -92,7 +92,7 @@ body.dark pre { background:#2e315f; }
     <input type="password" id="apiKey" />
   </div>
 </div>
-<div id="weightsCard" class="card" style="display:none; max-width:420px;">
+<div id="weightsCard" class="card" style="display:none;">
   <strong>Ponderaciones Winner Score</strong>
   <ul id="weightsList" style="list-style:none; margin-top:8px; padding:0;"></ul>
   <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:6px;">
@@ -223,6 +223,7 @@ body.dark pre { background:#2e315f; }
 <script type="module" src="/static/js/add-group.js"></script>
 <script type="module" src="/static/js/manage-groups.js"></script>
 <script src="/static/js/winner_v2.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script type="module">
 import { fetchJson } from "/static/js/net.js";
 import * as groupsService from "/static/js/groups-service.js";
@@ -484,18 +485,14 @@ function renderWeights(){
     const li=document.createElement('li');
     li.className='metric-row';
     li.dataset.key=key;
-    li.innerHTML=`<span class="ws-handle">≡</span><span class="ws-name">${def.label}</span><div class="ws-slider-wrap"><span class="ws-endcap-left">Menor importancia (0)</span><input type="range" min="0" max="100" step="1" value="${weightValues[key]||0}" class="ws-slider"><span class="ws-endcap-right">Mayor importancia (100)</span></div><span class="ws-value">${weightValues[key]||0}</span>`;
+    li.innerHTML=`<span class="ws-handle">≡</span><span class="ws-name">${def.label}</span><div class="ws-slider-wrap"><input type="range" min="0" max="100" step="1" value="${weightValues[key]||0}" class="ws-slider"></div><span class="ws-value">${weightValues[key]||0}</span>`;
     const range=li.querySelector('.ws-slider');
     const val=li.querySelector('.ws-value');
     range.addEventListener('input',()=>{ weightValues[key]=Number(range.value); val.textContent=range.value; saveState(); });
-    ['mousedown','touchstart'].forEach(ev=>{ range.addEventListener(ev,e=>{ e.stopPropagation(); e.stopImmediatePropagation(); }); });
-    const handle=li.querySelector('.ws-handle');
-    handle.draggable=true;
-    handle.addEventListener('dragstart',e=>{ e.dataTransfer.setData('text/plain',key); });
-    li.addEventListener('dragover',e=>{ e.preventDefault(); });
-    li.addEventListener('drop',e=>{ e.preventDefault(); const k=e.dataTransfer.getData('text/plain'); const idx=weightOrder.indexOf(k); const idx2=weightOrder.indexOf(key); weightOrder.splice(idx,1); weightOrder.splice(idx2,0,k); renderWeights(); saveState(); });
+    ['mousedown','touchstart'].forEach(ev=>{ range.addEventListener(ev,e=>{ e.stopPropagation(); }); });
     list.appendChild(li);
   });
+  Sortable.create(list,{ handle:'.ws-handle', animation:150, onEnd:()=>{ weightOrder=Array.from(list.children).map(li=>li.dataset.key); saveState(); }});
 }
 
 function saveState(){ localStorage.setItem(WEIGHT_KEY, JSON.stringify(weightValues)); localStorage.setItem(ORDER_KEY, JSON.stringify(weightOrder)); recalculateWinnerScoreV2(); }


### PR DESCRIPTION
## Summary
- Expand settings modal with sticky header and internal scrolling
- Simplify weight sliders and enable drag-and-drop with SortableJS
- Move toast notifications to bottom-right above modal overlay

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c05c8f902c832895b6e59ecf7a260a