### PR TITLE
Improve configuration modal, AI weight parsing, and winner score recalculation

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -366,15 +366,22 @@ body.dark .bottombar {
   border: 1px solid #34456B;
   border-radius: 16px;
   box-shadow: 0 8px 24px rgba(0,0,0,0.45);
-  width: 90%;
-  max-width: 420px;
+  width: 90vw;
+  max-width: min(900px, 96vw);
+  max-height: min(88vh, 980px);
   margin: 24px;
-  max-height: 80vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   transform: scale(0.9);
   opacity: 0;
   transition: opacity 0.16s ease, transform 0.16s ease;
+}
+
+@media (min-width:1200px){
+  .modal-overlay .modal {
+    max-width: min(1024px, 96vw);
+  }
 }
 .modal-overlay.open .modal {
   transform: scale(1);
@@ -386,6 +393,10 @@ body.dark .bottombar {
   justify-content: space-between;
   padding: 16px 20px 8px;
   margin-bottom: 12px;
+  position: sticky;
+  top: 0;
+  background: #0F1424;
+  z-index: 1;
 }
 .modal-header h2 {
   margin: 0;
@@ -407,6 +418,7 @@ body.dark .bottombar {
 .modal-body {
   padding: 0 20px 16px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   flex: 1 1 auto;
 }
 .modal-body input {
@@ -612,11 +624,11 @@ th.ec-col-competition,   td.ec-col-competition   { width: var(--ec-w-competition
 
 /* Winner Score slider styles */
 .ws-handle{ cursor:grab; padding-inline:4px; }
-.metric-row{ display:flex; align-items:center; gap:8px; }
-.ws-name{ flex:0 0 120px; }
-.ws-slider-wrap{ display:flex; align-items:center; flex:1; gap:8px; }
-.ws-endcap-left, .ws-endcap-right{ font-size:11px; white-space:nowrap; }
-.ws-slider{ flex:1; width:100%; min-width:160px; padding-inline:8px; height:12px; cursor:pointer; accent-color:#0077cc; }
+#weightsCard{ overflow-x:hidden; }
+.metric-row{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.ws-name{ flex:0 0 140px; }
+.ws-slider-wrap{ display:flex; align-items:center; flex:1 1 200px; gap:8px; min-width:0; }
+.ws-slider{ flex:1; width:100%; padding:4px 8px; height:12px; cursor:pointer; accent-color:#0077cc; }
 body.dark .ws-slider{ accent-color:#7a53d6; }
 .ws-slider::-webkit-slider-thumb{ width:20px; height:20px; border-radius:50%; cursor:pointer; }
 .ws-slider::-moz-range-thumb{ width:20px; height:20px; border-radius:50%; cursor:pointer; }

--- a/product_research_app/static/css/toast.css
+++ b/product_research_app/static/css/toast.css
@@ -1,4 +1,4 @@
-#toast-container{ position: fixed; right:16px; top:16px; display:flex; flex-direction:column; gap:8px; z-index:2100 }
+#toast-container{ position: fixed; right:24px; bottom:24px; display:flex; flex-direction:column; gap:8px; z-index:2100 }
 .toast{ min-width:260px; max-width:420px; background:#131A2E; border:1px solid #34456B; color:#E8ECF7; padding:10px 12px; border-radius:10px; box-shadow:0 8px 16px rgba(0,0,0,.35); display:flex; justify-content:space-between; align-items:center; gap:12px; opacity:0; transform: translateY(8px); animation: toast-in .2s forwards }
 .toast.success{ border-color:#1f6c4a } .toast.error{ border-color:#7a2d2d } .toast.info{ border-color:#34456B }
 .toast .action{ background:#34456B; border:1px solid #A9B4D0; color:#E8ECF7; cursor:pointer; padding:4px 8px; border-radius:6px; font-weight:600 }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -92,7 +92,7 @@ body.dark pre { background:#2e315f; }
     <input type="password" id="apiKey" />
   </div>
 </div>
-<div id="weightsCard" class="card" style="display:none; max-width:420px;">
+<div id="weightsCard" class="card" style="display:none;">
   <strong>Ponderaciones Winner Score</strong>
   <ul id="weightsList" style="list-style:none; margin-top:8px; padding:0;"></ul>
   <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:6px;">
@@ -223,6 +223,7 @@ body.dark pre { background:#2e315f; }
 <script type="module" src="/static/js/add-group.js"></script>
 <script type="module" src="/static/js/manage-groups.js"></script>
 <script src="/static/js/winner_v2.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script type="module">
 import { fetchJson } from "/static/js/net.js";
 import * as groupsService from "/static/js/groups-service.js";
@@ -261,7 +262,8 @@ async function pollImportStatus(id) {
     } else {
       localStorage.removeItem(IMPORT_TASK_LS_KEY);
       if (data.status === 'done') {
-        fetchProducts();
+        await fetchProducts();
+        toast.success('Winner Score actualizado tras importar');
         const n = data.rows_imported || 0;
         toast.success(`Importación completada: ${n} filas nuevas. IDs desde 0 si era la primera importación.`);
         const counts = data.ai_counts || {};
@@ -469,6 +471,11 @@ const ORDER_KEY = 'winnerOrderV2';
 let weightValues = {};
 let weightOrder = [];
 
+function debounce(fn, ms=150){
+  let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args), ms); };
+}
+const debouncedRecalc = debounce(() => recalculateWinnerScoreV2(), 150);
+
 function defaultWeights(){ return { ...window.winnerV2.getDefaultWeightsV2().lanzamiento }; }
 function defaultOrder(){ return metricDefs.map(m=>m.key); }
 
@@ -484,21 +491,21 @@ function renderWeights(){
     const li=document.createElement('li');
     li.className='metric-row';
     li.dataset.key=key;
-    li.innerHTML=`<span class="ws-handle">≡</span><span class="ws-name">${def.label}</span><div class="ws-slider-wrap"><span class="ws-endcap-left">Menor importancia (0)</span><input type="range" min="0" max="100" step="1" value="${weightValues[key]||0}" class="ws-slider"><span class="ws-endcap-right">Mayor importancia (100)</span></div><span class="ws-value">${weightValues[key]||0}</span>`;
+    li.innerHTML=`<span class="ws-handle">≡</span><span class="ws-name">${def.label}</span><div class="ws-slider-wrap"><input type="range" min="0" max="100" step="1" value="${weightValues[key]||0}" class="ws-slider"></div><span class="ws-value">${weightValues[key]||0}</span>`;
     const range=li.querySelector('.ws-slider');
     const val=li.querySelector('.ws-value');
     range.addEventListener('input',()=>{ weightValues[key]=Number(range.value); val.textContent=range.value; saveState(); });
-    ['mousedown','touchstart'].forEach(ev=>{ range.addEventListener(ev,e=>{ e.stopPropagation(); e.stopImmediatePropagation(); }); });
-    const handle=li.querySelector('.ws-handle');
-    handle.draggable=true;
-    handle.addEventListener('dragstart',e=>{ e.dataTransfer.setData('text/plain',key); });
-    li.addEventListener('dragover',e=>{ e.preventDefault(); });
-    li.addEventListener('drop',e=>{ e.preventDefault(); const k=e.dataTransfer.getData('text/plain'); const idx=weightOrder.indexOf(k); const idx2=weightOrder.indexOf(key); weightOrder.splice(idx,1); weightOrder.splice(idx2,0,k); renderWeights(); saveState(); });
+    ['mousedown','touchstart'].forEach(ev=>{ range.addEventListener(ev,e=>{ e.stopPropagation(); }); });
     list.appendChild(li);
   });
+  Sortable.create(list,{ handle:'.ws-handle', animation:150, onEnd:()=>{ weightOrder=Array.from(list.children).map(li=>li.dataset.key); saveState(); }});
 }
 
-function saveState(){ localStorage.setItem(WEIGHT_KEY, JSON.stringify(weightValues)); localStorage.setItem(ORDER_KEY, JSON.stringify(weightOrder)); recalculateWinnerScoreV2(); }
+function saveState(){
+  localStorage.setItem(WEIGHT_KEY, JSON.stringify(weightValues));
+  localStorage.setItem(ORDER_KEY, JSON.stringify(weightOrder));
+  debouncedRecalc();
+}
 
 function resetWeights(){ weightValues=defaultWeights(); weightOrder=defaultOrder(); saveState(); renderWeights(); }
 
@@ -526,47 +533,57 @@ function stratifiedSample(list, n){
 async function adjustWeightsAI(){
   try{
     let sample=stratifiedSample(allProducts||[],30);
-    let payload=sample.map(p=>({name:p.name, category:p.category, price:p.price, units:p.units_sold||(p.extras&&p.extras['Item Sold'])||0, ingresos:p.revenue||(p.extras&&p.extras['Revenue($)'])||0, conversion:p.extras&&p.extras['Creator Conversion Ratio'], fecha:p.extras&&p.extras['date_range'], desire:p.desire_magnitude, awareness:p.awareness_level, competition:p.competition_level}));
+    let payload=sample.map(p=>({name:p.name,category:p.category,price:p.price,units:p.units_sold||(p.extras&&p.extras['Item Sold'])||0,ingresos:p.revenue||(p.extras&&p.extras['Revenue($)'])||0,conversion:p.extras&&p.extras['Creator Conversion Ratio'],fecha:p.extras&&p.extras['date_range'],desire:p.desire_magnitude,awareness:p.awareness_level,competition:p.competition_level}));
     let tokenEstimate=JSON.stringify(payload).length/4;
     const maxTokens=0.30/0.002*1000;
     while(tokenEstimate>maxTokens && sample.length>1){
       const ratio=maxTokens/tokenEstimate;
       const newN=Math.max(1,Math.floor(sample.length*ratio));
       sample=stratifiedSample(allProducts||[],newN);
-      payload=sample.map(p=>({name:p.name, category:p.category, price:p.price, units:p.units_sold||(p.extras&&p.extras['Item Sold'])||0, ingresos:p.revenue||(p.extras&&p.extras['Revenue($)'])||0, conversion:p.extras&&p.extras['Creator Conversion Ratio'], fecha:p.extras&&p.extras['date_range'], desire:p.desire_magnitude, awareness:p.awareness_level, competition:p.competition_level}));
+      payload=sample.map(p=>({name:p.name,category:p.category,price:p.price,units:p.units_sold||(p.extras&&p.extras['Item Sold'])||0,ingresos:p.revenue||(p.extras&&p.extras['Revenue($)'])||0,conversion:p.extras&&p.extras['Creator Conversion Ratio'],fecha:p.extras&&p.extras['date_range'],desire:p.desire_magnitude,awareness:p.awareness_level,competition:p.competition_level}));
       tokenEstimate=JSON.stringify(payload).length/4;
     }
     const cost=tokenEstimate/1000*0.002;
-    toast.info(`Coste estimado: $${cost.toFixed(3)}`);
-    const prompt=`Dado este listado de productos ${JSON.stringify(payload)}\nDevuelve un JSON con pesos 0-100 para las métricas: ${metricKeys.join(', ')}.`;
-    let res=await fetch('/custom_gpt',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt})});
+    toast.info(`Analizando ${sample.length} productos (~$${cost.toFixed(2)})`);
+    const instruction='Devuelve SOLO un JSON plano con pesos 0-100 para estas 10 claves exactas, sin texto adicional:\n["magnitud_deseo","nivel_consciencia_headroom","evidencia_demanda","tasa_conversion","ventas_por_dia","recencia_lanzamiento","competition_level_invertido","facilidad_anuncio","escalabilidad","durabilidad_recurrencia"]';
+    const prompt=`Basado en estos productos ${JSON.stringify(payload)}\n${instruction}`;
+    let res=await fetch('/custom_gpt',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt,response_format:{type:'json_object'}})});
     if(!res.ok){
-      if(res.status===401||res.status===403){ toast.error('Configura tu API key'); return; }
-      if(res.status===429||res.status===503){ toast.error('Límite de tasa; inténtalo luego'); return; }
-      toast.error('Error IA'); return;
+      toast.error('No se pudo ajustar por IA. Revisa tu API Key o inténtalo más tarde.');
+      return;
     }
-    let data=await res.json();
-    let weights;
-    try{ weights=JSON.parse(data.response||''); }
-    catch(e){
-      res=await fetch('/custom_gpt',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt,response_format:{type:'json_object'}})});
-      if(!res.ok){ toast.error('Error IA'); return; }
-      data=await res.json();
-      try{ weights=JSON.parse(data.response||''); } catch(e2){ toast.error('Respuesta IA inválida'); return; }
+    const data=await res.json();
+    let raw=data.response||'';
+    console.debug('IA raw:', raw);
+    let obj;
+    if(typeof raw==='string'){
+      try{ obj=JSON.parse(raw); }
+      catch(e){
+        const m=raw.match(/\{[\s\S]*\}/);
+        if(m){ try{ obj=JSON.parse(m[0]); } catch(e2){} }
+      }
+    }else if(typeof raw==='object'){
+      obj=raw;
     }
+    console.debug('IA parsed:', obj);
+    if(!obj || typeof obj!=='object'){
+      toast.error('No se pudo ajustar por IA. Revisa tu API Key o inténtalo más tarde.');
+      return;
+    }
+    const newWeights={};
     for(const k of metricKeys){
-      const v=Number(weights[k]);
-      if(isNaN(v)||v<0||v>100){ toast.error('Respuesta IA inválida'); return; }
-      weightValues[k]=v;
+      let v=Number(obj[k]);
+      if(isNaN(v)) v=Number(weightValues[k])||0;
+      if(v<0) v=0; if(v>100) v=100;
+      newWeights[k]=v;
     }
+    weightValues=newWeights;
     saveState();
     renderWeights();
     toast.success('Pesos ajustados por IA');
-    toast.success('Winner Score actualizado');
   }catch(err){
     console.error(err);
-    if(err.message && err.message.toLowerCase().includes('api')) toast.error('Configura tu API key');
-    else toast.error('Error al ajustar pesos');
+    toast.error('No se pudo ajustar por IA. Revisa tu API Key o inténtalo más tarde.');
   }
 }
 
@@ -574,12 +591,19 @@ function initWeights(){ loadWeights(); loadOrder(); renderWeights(); document.ge
 
 function recalculateWinnerScoreV2(){
   if(!Array.isArray(allProducts)) return;
-  const ranges = window.winnerV2.computeRanges(allProducts);
-  const weights={};
+  let stored={};
+  try{ stored=JSON.parse(localStorage.getItem(WEIGHT_KEY)||'{}'); }catch(e){ stored={}; }
+  stored={ ...defaultWeights(), ...stored };
   let sum=0;
-  metricKeys.forEach(k=>{ const w=Number(weightValues[k])||0; weights[k]=w; sum+=w; });
+  metricKeys.forEach(k=>{ sum+=Number(stored[k])||0; });
+  if(sum<=0){
+    stored=defaultWeights();
+    sum=0; metricKeys.forEach(k=>{ sum+=Number(stored[k])||0; });
+  }
   const normWeights={};
-  metricKeys.forEach(k=>{ normWeights[k]= sum>0 ? weights[k]/sum : 0; });
+  metricKeys.forEach(k=>{ normWeights[k]= sum>0 ? (Number(stored[k])||0)/sum : 0; });
+  weightValues=stored;
+  const ranges=window.winnerV2.computeRanges(allProducts);
   allProducts.forEach(p=>{
     let total=0; let score=0;
     metricKeys.forEach(k=>{
@@ -589,7 +613,9 @@ function recalculateWinnerScoreV2(){
     });
     p.winner_score_v2_pct = total>0 ? score/total : 0;
   });
-  products.sort((a,b)=>b.winner_score_v2_pct - a.winner_score_v2_pct);
+  if(sortField==='winner_score_v2_pct'){
+    sortProducts();
+  }
   renderTable();
 }
 


### PR DESCRIPTION
## Summary
- Debounce slider saves and recalc winner score from localStorage
- Robust AI weight adjustment with cost estimate and JSON parsing
- Recalculate Winner Score after imports with toast feedback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c05c8f902c832895b6e59ecf7a260a