### PR TITLE
Unlock sliders and add Winner Score button

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -625,14 +625,17 @@ th.ec-col-competition,   td.ec-col-competition   { width: var(--ec-w-competition
 /* Winner Score slider styles */
 .ws-handle{ cursor:grab; padding-inline:4px; }
 #weightsCard{ overflow-x:hidden; }
-.ws-row{ display:grid; grid-template-columns:18px minmax(140px,auto) 1fr 44px; gap:8px; align-items:center; }
+.ws-row{ display:grid; grid-template-columns:18px minmax(140px,auto) 480px 44px; gap:8px; align-items:center; }
 .ws-name{ white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .ws-slider{ width:100%; height:12px; cursor:pointer; accent-color:#0077cc; }
 body.dark .ws-slider{ accent-color:#7a53d6; }
 .ws-slider::-webkit-slider-thumb{ width:20px; height:20px; border-radius:50%; cursor:pointer; }
 .ws-slider::-moz-range-thumb{ width:20px; height:20px; border-radius:50%; cursor:pointer; }
 .ws-value{ text-align:right; }
+@media (max-width:1200px){
+  .ws-row{ grid-template-columns:18px minmax(140px,auto) 420px 44px; }
+}
 @media (max-width:768px){
-  .ws-row{ grid-template-columns:16px minmax(120px,auto) 1fr 40px; gap:6px; }
+  .ws-row{ grid-template-columns:16px minmax(120px,auto) 300px 40px; }
 }
 

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -71,6 +71,7 @@ body.dark pre { background:#2e315f; }
     <button id="createListBtn">Crear</button>
     <textarea id="gptPrompt" rows="1" maxlength="2000" placeholder="Escribe consulta para GPT..." aria-label="Escribe consulta para GPT..."></textarea>
     <button id="sendPrompt">Enviar consulta a GPT</button>
+    <button id="btnRecalcWinnerTop">Generar Winner Score</button>
     <div id="searchRowRight">
       <div id="listMeta">0 resultados</div>
     </div>
@@ -502,7 +503,7 @@ function renderWeights(){
     const li=document.createElement('li');
     li.className='ws-row';
     li.dataset.key=key;
-    li.draggable=false;
+    li.removeAttribute('draggable');
     li.style.pointerEvents='auto';
     li.innerHTML=`<span class="ws-handle">≡</span><span class="ws-name">${def.label}</span><input type="range" min="0" max="100" step="1" value="${state.winnerWeightsV2[key]||0}" class="ws-slider" data-metric="${key}"><span class="ws-value">${state.winnerWeightsV2[key]||0}</span>`;
     list.appendChild(li);
@@ -527,9 +528,8 @@ function attachWeightSliderListeners(){
     sl.style.pointerEvents = 'auto';
     sl.addEventListener('input', onWeightInput, {passive:true});
     sl.addEventListener('change', onWeightChange, {passive:true});
-    ['mousedown','touchstart'].forEach(ev=>{
-      sl.addEventListener(ev, e=>e.stopPropagation(), {passive:true});
-    });
+    sl.addEventListener('mousedown', e=>e.stopPropagation());
+    sl.addEventListener('touchstart', e=>e.stopPropagation(), {passive:true});
   });
 }
 
@@ -1214,6 +1214,7 @@ document.getElementById('searchBtn').onclick = () => {
 };
 const gptField = document.getElementById('gptPrompt');
 const sendPromptBtn = document.getElementById('sendPrompt');
+const btnRecalcWinnerTop = document.getElementById('btnRecalcWinnerTop');
 
 function autoGrow(el){
   el.style.height = 'auto';
@@ -1268,6 +1269,9 @@ async function sendPromptHandler(){
 }
 
 sendPromptBtn.onclick = sendPromptHandler;
+if(btnRecalcWinnerTop){
+  btnRecalcWinnerTop.addEventListener('click', ()=>{ recalculateWinnerScoreV2(); });
+}
 document.getElementById('darkToggle').onclick = () => {
   document.body.classList.toggle('dark');
 };


### PR DESCRIPTION
## Summary
- Enable Winner Score sliders with proper drag-handle interactions and event listeners
- Standardize slider bar width across breakpoints
- Add sticky toolbar button to recalculate Winner Score

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c0680a15fc832883766a6d3003cbf4