### PR TITLE
Enable interactive winner score sliders

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -627,7 +627,7 @@ th.ec-col-competition,   td.ec-col-competition   { width: var(--ec-w-competition
 #weightsCard{ overflow-x:hidden; }
 .ws-row{ display:grid; grid-template-columns:18px minmax(140px,auto) 480px 44px; gap:8px; align-items:center; }
 .ws-name{ white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.ws-slider{ width:100%; height:12px; cursor:pointer; accent-color:#0077cc; }
+.ws-slider{ width:100%; height:12px; cursor:pointer; accent-color:#0077cc; pointer-events:auto; }
 body.dark .ws-slider{ accent-color:#7a53d6; }
 .ws-slider::-webkit-slider-thumb{ width:20px; height:20px; border-radius:50%; cursor:pointer; }
 .ws-slider::-moz-range-thumb{ width:20px; height:20px; border-radius:50%; cursor:pointer; }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -95,7 +95,7 @@ body.dark pre { background:#2e315f; }
 </div>
 <div id="weightsCard" class="card" style="display:none;">
   <strong>Ponderaciones Winner Score</strong>
-  <ul id="weightsList" style="list-style:none; margin-top:8px; padding:0;"></ul>
+  <ul id="ws-list" style="list-style:none; margin-top:8px; padding:0;"></ul>
   <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:6px;">
     <button id="resetWeights">Reset</button>
     <button id="aiWeights">Ajustar pesos con IA</button>
@@ -507,7 +507,7 @@ function loadWinnerOrderV2(){ try{ return JSON.parse(localStorage.getItem(ORDER_
 function saveWinnerOrderV2(order){ localStorage.setItem(ORDER_KEY, JSON.stringify(order)); }
 
 function renderWeights(){
-  const list=document.getElementById('weightsList');
+  const list=document.querySelector('#ws-list');
   if(!list) return;
   list.innerHTML='';
   state.winnerOrderV2.forEach(key=>{
@@ -520,8 +520,15 @@ function renderWeights(){
     li.innerHTML=`<span class="ws-handle">≡</span><span class="ws-name">${def.label}</span><input type="range" min="0" max="100" step="1" value="${state.winnerWeightsV2[key]||0}" class="ws-slider" data-metric="${key}"><span class="ws-value">${state.winnerWeightsV2[key]||0}</span>`;
     list.appendChild(li);
   });
-  Sortable.create(list,{ handle:'.ws-handle', filter:'.ws-slider', preventOnFilter:true, animation:150, onEnd:()=>{ state.winnerOrderV2=Array.from(list.children).map(li=>li.dataset.key); saveWinnerOrderV2(state.winnerOrderV2); }});
-  attachWeightSliderListeners();
+  if (window._wsSortable) window._wsSortable.destroy?.();
+  window._wsSortable = new Sortable(list, {
+    handle: '.ws-handle',
+    animation: 150,
+    filter: '.ws-slider',
+    preventOnFilter: true,
+    onEnd:()=>{ state.winnerOrderV2=Array.from(list.children).map(li=>li.dataset.key); saveWinnerOrderV2(state.winnerOrderV2); }
+  });
+  attachWSListeners();
 }
 
 function resetWeights(){
@@ -533,32 +540,31 @@ function resetWeights(){
   recalculateWinnerScoreV2();
 }
 
-function attachWeightSliderListeners(){
+function attachWSListeners(){
   document.querySelectorAll('.ws-slider').forEach(sl=>{
     sl.removeAttribute('disabled');
     sl.removeAttribute('readonly');
-    sl.style.pointerEvents = 'auto';
-    sl.addEventListener('input', onWeightInput, {passive:true});
-    sl.addEventListener('change', onWeightChange, {passive:true});
     sl.addEventListener('mousedown', e=>e.stopPropagation());
     sl.addEventListener('touchstart', e=>e.stopPropagation(), {passive:true});
+    sl.addEventListener('input', onWeightInput, {passive:true});
+    sl.addEventListener('change', onWeightChange, {passive:true});
   });
 }
 
+document.addEventListener('DOMContentLoaded', attachWSListeners);
+
 function onWeightInput(e){
-  const metric = e.target.dataset.metric;
-  const val = Number(e.target.value);
-  state.winnerWeightsV2[metric] = val;
+  const k = e.target.dataset.metric;
+  const v = Number(e.target.value);
+  state.winnerWeightsV2[k] = v;
   const li = e.target.closest('.ws-row');
-  if(li){ const span = li.querySelector('.ws-value'); if(span) span.textContent = String(val); }
+  if(li){ const span = li.querySelector('.ws-value'); if(span) span.textContent = String(v); }
   saveWinnerWeightsV2(state.winnerWeightsV2);
   if (window._wsRAF) cancelAnimationFrame(window._wsRAF);
   window._wsRAF = requestAnimationFrame(recalculateWinnerScoreV2);
 }
 
-function onWeightChange(e){
-  onWeightInput(e);
-}
+function onWeightChange(e){ onWeightInput(e); }
 
 function chunkProductsForAI(list, size=30){
   const byCat={};


### PR DESCRIPTION
## Summary
- Ensure winner score sliders stay interactive and can be reordered only via handles
- Persist slider weight changes instantly and recalc scores on input

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c06c7595788328aa6a9b2be8f8ec13