### PR TITLE
Add config API endpoints and persistent key storage

### DIFF
--- a/product_research_app/__init__.py
+++ b/product_research_app/__init__.py
@@ -1,1 +1,7 @@
 """Product Research Copilot package initializer."""
+from flask import Flask
+
+app = Flask(__name__)
+
+from .api_config import bp as config_bp
+app.register_blueprint(config_bp)

--- a/product_research_app/api_config.py
+++ b/product_research_app/api_config.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, jsonify, request
+from .config_store import read_config, write_config, get_api_key
+
+bp = Blueprint("config_api", __name__, url_prefix="/api/config")
+
+@bp.get("")
+def get_basic_config():
+    return jsonify({"has_api_key": bool(get_api_key())})
+
+@bp.post("/api-key")
+def set_api_key():
+    payload = request.get_json(silent=True) or {}
+    api_key = (payload.get("api_key") or "").strip()
+    if not api_key:
+        return jsonify({"ok": False, "error": "API key vacía"}), 400
+    cfg = read_config()
+    cfg["openai_api_key"] = api_key
+    write_config(cfg)
+    return jsonify({"ok": True})

--- a/product_research_app/config_store.py
+++ b/product_research_app/config_store.py
@@ -1,0 +1,31 @@
+import json, os
+from typing import Dict
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config.json")
+_DEFAULTS: Dict[str, str] = {
+    "openai_api_key": ""
+}
+
+def _ensure_file():
+    os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+    if not os.path.exists(CONFIG_PATH):
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            json.dump(_DEFAULTS, f, ensure_ascii=False, indent=2)
+
+def read_config() -> Dict[str, str]:
+    _ensure_file()
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        data = {}
+    return {**_DEFAULTS, **(data or {})}
+
+def write_config(data: Dict[str, str]) -> None:
+    _ensure_file()
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+def get_api_key() -> str:
+    cfg = read_config()
+    return (cfg.get("openai_api_key") or os.getenv("OPENAI_API_KEY") or "").strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4
 Pillow
 openpyxl
+flask


### PR DESCRIPTION
## Summary
- create config_store to persist OpenAI API key in config.json
- add /api/config and /api/config/api-key endpoints
- register new config blueprint
- include Flask in requirements

## Testing
- `python -m py_compile product_research_app/config_store.py product_research_app/api_config.py product_research_app/__init__.py`
- `python - <<'PY'
from product_research_app import app
client = app.test_client()
print('1', client.get('/api/config').json)
print('2', client.post('/api/config/api-key', json={}).status_code)
print('3', client.post('/api/config/api-key', json={'api_key': 'abc'}).json)
print('4', client.get('/api/config').json)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c08f885330832897caa7fbbb292409