### PR TITLE
Add settings page route

### DIFF
--- a/product_research_app/__init__.py
+++ b/product_research_app/__init__.py
@@ -1,7 +1,14 @@
 """Product Research Copilot package initializer."""
-from flask import Flask
+from flask import Flask, render_template
 
 app = Flask(__name__)
+
+
+@app.get("/settings")
+def settings_page() -> str:
+    """Render the advanced settings page."""
+    return render_template("settings.html")
+
 
 from .api_config import bp as config_bp
 app.register_blueprint(config_bp)

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -979,36 +979,9 @@ window.onload = () => {
     pollImportStatus(tid);
   }
 };
-// Toggle config panel
+// Open settings page
 document.getElementById('configBtn').onclick = () => {
-  const cfg = document.getElementById('config');
-  const wcard = document.getElementById('weightsCard');
-  if(!cfg || !wcard || !window.modalManager) return;
-  const btn = document.getElementById('configBtn');
-  const modal = document.createElement('div');
-  modal.className = 'modal';
-  modal.setAttribute('role','dialog');
-  modal.setAttribute('aria-modal','true');
-  modal.innerHTML = '<header class="modal-header"><h3 id="configModalTitle">Configuración</h3><button type="button" class="modal-close" aria-label="Cerrar">✕</button></header><div class="modal-body"></div>';
-  modal.setAttribute('aria-labelledby','configModalTitle');
-  const body = modal.querySelector('.modal-body');
-  const cfgParent = cfg.parentElement;
-  const wParent = wcard.parentElement;
-  const cfgNext = cfg.nextSibling;
-  const wNext = wcard.nextSibling;
-  body.appendChild(cfg);
-  body.appendChild(wcard);
-  cfg.style.display = 'block';
-  wcard.style.display = 'block';
-  const handle = modalManager.open(modal, {returnFocus: btn, closeOnBackdrop:false, onClose: () => {
-    cfg.style.display = 'none';
-    wcard.style.display = 'none';
-    cfgParent.insertBefore(cfg, cfgNext);
-    wParent.insertBefore(wcard, wNext);
-  }});
-  modal.querySelector('.modal-close').addEventListener('click', () => handle.close());
-  const first = modal.querySelector('input,select,textarea,button');
-  if(first) first.focus();
+  window.location.href = '/settings';
 };
 
 


### PR DESCRIPTION
## Summary
- add Flask route that renders settings template
- link config button to new /settings page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c09661e3388328a9e5aa41096d0a90