### PR TITLE
Add Winner Score generation workflow

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -193,14 +193,16 @@ def is_scoring_v2_enabled() -> bool:
 # ---------------- Winner Score v2 weights -----------------
 
 SCORING_V2_DEFAULT_WEIGHTS: Dict[str, float] = {
-    "magnitud_deseo": 0.125,
-    "nivel_consciencia": 0.125,
-    "saturacion_mercado": 0.125,
-    "facilidad_anuncio": 0.125,
-    "facilidad_logistica": 0.125,
-    "escalabilidad": 0.125,
-    "engagement_shareability": 0.125,
-    "durabilidad_recurrencia": 0.125,
+    "magnitud_deseo": 1.0,
+    "nivel_consciencia_headroom": 1.0,
+    "evidencia_demanda": 1.0,
+    "tasa_conversion": 1.0,
+    "ventas_por_dia": 1.0,
+    "recencia_lanzamiento": 1.0,
+    "competition_level_invertido": 1.0,
+    "facilidad_anuncio": 1.0,
+    "escalabilidad": 1.0,
+    "durabilidad_recurrencia": 1.0,
 }
 
 

--- a/product_research_app/services/winner_v2.py
+++ b/product_research_app/services/winner_v2.py
@@ -77,16 +77,23 @@ def normalize_metric(name: str, value: Any, ranges: Dict[str, Dict[str,float]]) 
         return math.exp(-float(value)/180.0)
     return None
 
-def score_product(prod: Dict[str, Any], weights: Dict[str, float], ranges: Dict[str, Dict[str,float]] | None = None) -> float:
+def score_product(
+    prod: Dict[str, Any],
+    weights: Dict[str, float],
+    ranges: Dict[str, Dict[str, float]] | None = None,
+    missing: list[str] | None = None,
+) -> float:
     if ranges is None:
         ranges = compute_ranges([prod])
     total_w = 0.0
     score = 0.0
     for k, w in weights.items():
         val = normalize_metric(k, prod.get(k), ranges)
-        if val is None:
-            continue
         total_w += w
+        if val is None:
+            if missing is not None:
+                missing.append(k)
+            continue
         score += w * val
     if total_w <= 0:
         return 0.0

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -174,6 +174,7 @@ body.dark pre { background:#2e315f; }
   <button id="btnManageGroups" class="bar-btn" title="Gestionar grupos" aria-label="Gestionar grupos">Gestionar grupos</button>
   <button id="btnDelete" class="bar-btn" disabled title="Eliminar seleccionados" aria-label="Eliminar seleccionados">Eliminar</button>
   <button id="btnExport" class="bar-btn" disabled title="Exportar seleccionados" aria-label="Exportar seleccionados">Exportar</button>
+  <button id="btnGenWinner" class="bar-btn" disabled title="Generar Winner Score" aria-label="Generar Winner Score">Generar Winner Score</button>
   <button id="btnColumns" class="bar-btn" title="Gestionar columnas" aria-label="Gestionar columnas">Columnas</button>
 </div>
 <div id="legendPop" class="popover hidden">
@@ -624,7 +625,8 @@ function recalculateWinnerScoreV2(){
       const v=window.winnerV2.normalizeMetric(k, p[k], ranges);
       if(v!=null){ total+=w; score+=w*v; }
     });
-    p.winner_score_v2_pct = total>0 ? score/total : 0;
+    const raw = total>0 ? (score/total)*100 : 0;
+    p.winner_score_v2_pct = Math.max(0, Math.min(100, Math.round(raw)));
   });
   if(sortField==='winner_score_v2_pct'){
     sortProducts();
@@ -795,7 +797,7 @@ function renderTable() {
       if (key === 'winner_score_v2_pct') {
         const sc = parseFloat(value);
         if (!isNaN(sc)) {
-          td.innerHTML = '<span class="' + winnerScoreClass(sc*100) + '">' + sc.toFixed(3) + '</span>';
+          td.innerHTML = '<span class="' + winnerScoreClass(sc) + '">' + Math.round(sc) + '</span>';
           if (item.winner_score_v2_breakdown && item.winner_score_v2_breakdown.justifications) {
             const j = item.winner_score_v2_breakdown.justifications;
             const tooltip = Object.entries(j).map(([k,v])=>`${k}: ${v}`).join('\n');
@@ -1326,6 +1328,29 @@ document.getElementById('btnExport').onclick = async () => {
   } catch(err){ console.error(err); toast.error('Error al exportar'); }
 };
 
+// Generate Winner Score for selected products
+document.getElementById('btnGenWinner').onclick = async () => {
+  const ids = Array.from(selection, Number);
+  if(!ids.length){ toast.info('Selecciona productos'); return; }
+  startProgress();
+  try{
+    const res = await fetchJson('/scoring/v2/generate', {method:'POST', body: JSON.stringify({ids})});
+    if(res.error){ throw new Error(res.error); }
+    const scores = res.scores || {};
+    let count = 0;
+    Object.entries(scores).forEach(([id, sc]) => {
+      const prod = (allProducts || []).find(p => p.id === Number(id));
+      if(prod){ prod.winner_score_v2_pct = sc; count++; }
+    });
+    renderTable();
+    updateMasterState();
+    toast.success(`Winner Score generado para ${count} productos`);
+  }catch(err){
+    console.error(err);
+    toast.error('No se pudo generar el Winner Score');
+  }
+};
+
 // -------- Group management --------
 let currentGroupFilter = -1; // -1 indicates all products
 
@@ -1438,7 +1463,7 @@ async function loadTrends(){
   let html = '<h3>Tendencias</h3>';
   if(data.top_products && data.top_products.length){
     html += '<strong>Top productos por Winner Score:</strong><ol>';
-      data.top_products.forEach(item=>{ html += `<li>${item.name} (Winner Score: ${item.winner_score_v2_pct.toFixed(3)})</li>`; });
+      data.top_products.forEach(item=>{ html += `<li>${item.name} (Winner Score: ${Math.round(item.winner_score_v2_pct)})</li>`; });
     html += '</ol>';
   }
   cont.innerHTML = html;

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -32,9 +32,11 @@ function updateMasterState(){
   const btnDel = document.getElementById('btnDelete');
   const btnExp = document.getElementById('btnExport');
   const btnAdd = document.getElementById('btnAddToGroup');
+  const btnGen = document.getElementById('btnGenWinner');
   if(btnDel) btnDel.disabled = disable;
   if(btnExp) btnExp.disabled = disable;
   if(btnAdd) btnAdd.disabled = disable;
+  if(btnGen) btnGen.disabled = disable;
   if(bottomBar){
     const selEl = document.getElementById('selCount');
     if(selEl) selEl.textContent = `${selection.size} seleccionados`;


### PR DESCRIPTION
## Summary
- compute Winner Score on import using normalized configuration weights
- expose endpoint and UI button to generate Winner Score for selected products
- display Winner Score as 0-100 integer and treat missing metrics as zero

## Testing
- `python -m py_compile config.py services/winner_v2.py web_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0a6bfae7883288fd6a67beb1ea5c2