### PR TITLE
Fix Winner Score generation flow

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -309,6 +309,12 @@ body.dark #gptPrompt {
   gap: 8px;
 }
 
+#gptActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: nowrap;
+}
+
 #listMeta { white-space: nowrap; }
 
 #groupSelect { min-width: 120px; }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -70,7 +70,10 @@ body.dark pre { background:#2e315f; }
     <input type="text" id="newListName" placeholder="Nombre del grupo" style="padding:4px; min-width:120px;">
     <button id="createListBtn">Crear</button>
     <textarea id="gptPrompt" rows="1" maxlength="2000" placeholder="Escribe consulta para GPT..." aria-label="Escribe consulta para GPT..."></textarea>
-    <button id="sendPrompt">Enviar consulta a GPT</button>
+    <div id="gptActions">
+      <button id="sendPrompt">Enviar consulta a GPT</button>
+      <button id="btnGenWinner" class="bar-btn" disabled title="Generar Winner Score" aria-label="Generar Winner Score">Generar Winner Score</button>
+    </div>
     <div id="searchRowRight">
       <div id="listMeta">0 resultados</div>
     </div>
@@ -174,7 +177,6 @@ body.dark pre { background:#2e315f; }
   <button id="btnManageGroups" class="bar-btn" title="Gestionar grupos" aria-label="Gestionar grupos">Gestionar grupos</button>
   <button id="btnDelete" class="bar-btn" disabled title="Eliminar seleccionados" aria-label="Eliminar seleccionados">Eliminar</button>
   <button id="btnExport" class="bar-btn" disabled title="Exportar seleccionados" aria-label="Exportar seleccionados">Exportar</button>
-  <button id="btnGenWinner" class="bar-btn" disabled title="Generar Winner Score" aria-label="Generar Winner Score">Generar Winner Score</button>
   <button id="btnColumns" class="bar-btn" title="Gestionar columnas" aria-label="Gestionar columnas">Columnas</button>
 </div>
 <div id="legendPop" class="popover hidden">
@@ -1331,20 +1333,38 @@ document.getElementById('btnExport').onclick = async () => {
 // Generate Winner Score for selected products
 document.getElementById('btnGenWinner').onclick = async () => {
   const ids = Array.from(selection, Number);
-  if(!ids.length){ toast.info('Selecciona productos'); return; }
+  const pending = ids.filter(id => {
+    const prod = (allProducts || []).find(p => p.id === id);
+    const val = prod ? Number(prod.winner_score_v2_pct) : 0;
+    return !val;
+  });
+  if(!pending.length){
+    toast.info('No se actualizó ningún producto. Revisa que tengan métricas y que el campo Winner Score esté vacío o 0.');
+    return;
+  }
   startProgress();
   try{
-    const res = await fetchJson('/scoring/v2/generate', {method:'POST', body: JSON.stringify({ids})});
+    const res = await fetchJson('/scoring/v2/generate', {method:'POST', body: JSON.stringify({ids: pending})});
     if(res.error){ throw new Error(res.error); }
     const scores = res.scores || {};
-    let count = 0;
-    Object.entries(scores).forEach(([id, sc]) => {
-      const prod = (allProducts || []).find(p => p.id === Number(id));
-      if(prod){ prod.winner_score_v2_pct = sc; count++; }
+    const idsWithScore = Object.keys(scores);
+    if((res.updated||0) === 0 || idsWithScore.length === 0){
+      toast.info('No se actualizó ningún producto. Revisa que tengan métricas y que el campo Winner Score esté vacío o 0.');
+      updateMasterState();
+      return;
+    }
+    allProducts = allProducts.map(p => {
+      const sc = scores[String(p.id)];
+      return sc != null ? {...p, winner_score_v2_pct: sc} : p;
     });
+    products = products.map(p => {
+      const sc = scores[String(p.id)];
+      return sc != null ? {...p, winner_score_v2_pct: sc} : p;
+    });
+    window.allProducts = allProducts;
     renderTable();
     updateMasterState();
-    toast.success(`Winner Score generado para ${count} productos`);
+    toast.success(`Winner Score generado para ${res.updated} productos`);
   }catch(err){
     console.error(err);
     toast.error('No se pudo generar el Winner Score');

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -28,20 +28,28 @@ function updateMasterState(){
   const selectedOnPage = currentPageIds.filter(id => selection.has(id)).length;
   master.indeterminate = selectedOnPage>0 && selectedOnPage<currentPageIds.length;
   master.checked = selectedOnPage===currentPageIds.length && currentPageIds.length>0;
-  const disable = selection.size===0;
+  const noneSelected = selection.size===0;
   const btnDel = document.getElementById('btnDelete');
   const btnExp = document.getElementById('btnExport');
   const btnAdd = document.getElementById('btnAddToGroup');
   const btnGen = document.getElementById('btnGenWinner');
-  if(btnDel) btnDel.disabled = disable;
-  if(btnExp) btnExp.disabled = disable;
-  if(btnAdd) btnAdd.disabled = disable;
-  if(btnGen) btnGen.disabled = disable;
+  if(btnDel) btnDel.disabled = noneSelected;
+  if(btnExp) btnExp.disabled = noneSelected;
+  if(btnAdd) btnAdd.disabled = noneSelected;
+  if(btnGen){
+    const ap = window.allProducts || [];
+    const needs = Array.from(selection).some(id => {
+      const prod = ap.find(p => String(p.id)===String(id));
+      const val = prod ? Number(prod.winner_score_v2_pct) : 0;
+      return !val;
+    });
+    btnGen.disabled = noneSelected || !needs;
+  }
   if(bottomBar){
     const selEl = document.getElementById('selCount');
     if(selEl) selEl.textContent = `${selection.size} seleccionados`;
-    bottomBar.classList.toggle('hidden', disable);
-    if(!disable){
+    bottomBar.classList.toggle('hidden', noneSelected);
+    if(!noneSelected){
       document.body.style.paddingBottom = bottomBar.offsetHeight + 'px';
     } else {
       document.body.style.paddingBottom = '';

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -2654,6 +2654,13 @@ class RequestHandler(BaseHTTPRequestHandler):
         products_all = [dict(r) for r in database.list_products(conn)]
         ranges = winner_calc.compute_ranges(products_all)
         weights = config.get_scoring_v2_weights()
+        total_w = sum(weights.values())
+        if total_w <= 0:
+            logger.warning("Winner Score generation aborted: weight sum <= 0")
+            self._set_json()
+            self.wfile.write(json.dumps({"updated": 0, "scores": {}}).encode("utf-8"))
+            return
+        weights = {k: v / total_w for k, v in weights.items()}
         updated: Dict[str, int] = {}
         for prod in products_all:
             pid = prod["id"]
@@ -2686,7 +2693,9 @@ class RequestHandler(BaseHTTPRequestHandler):
                 explanations={},
                 winner_score_v2_pct=pct,
             )
-            updated[str(pid)] = pct
+            saved = database.get_scores_for_product(conn, pid)
+            if saved:
+                updated[str(pid)] = int(saved[0].get("winner_score_v2_pct") or 0)
 
         self._set_json()
         self.wfile.write(json.dumps({"updated": len(updated), "scores": updated}).encode("utf-8"))


### PR DESCRIPTION
## Summary
- Move "Generar Winner Score" next to "Enviar consulta a GPT" in top toolbar
- Disable winner score button unless selected rows need scoring and update scores immutably
- Validate and normalize weights on server; persist and return saved scores

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0a9ce22e08328baf106ca5112ee39