### PR TITLE
Ensure winner score is stored and UI updates

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -1364,7 +1364,11 @@ document.getElementById('btnGenWinner').onclick = async () => {
     window.allProducts = allProducts;
     renderTable();
     updateMasterState();
-    toast.success(`Winner Score generado para ${res.updated} productos`);
+    if(res.skipped>0){
+      toast.error(`Winner Score generado parcialmente: ${res.updated} actualizados, ${res.skipped} omitidos`);
+    } else {
+      toast.success(`Winner Score generado para ${res.updated} productos`);
+    }
   }catch(err){
     console.error(err);
     toast.error('No se pudo generar el Winner Score');


### PR DESCRIPTION
## Summary
- Normalize winner score generation with uniform weight fallback
- Persist computed scores as integers and log skipped items
- Surface partial updates and errors on the Winner Score button

## Testing
- `python -m py_compile product_research_app/web_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c19b9164e48328b1c3d9167a9397af