### PR TITLE
Adjust winner score calculation to handle partial metrics

### DIFF
--- a/product_research_app/database.py
+++ b/product_research_app/database.py
@@ -473,6 +473,8 @@ def insert_score(
     winner_score_v2_raw: Optional[float] = None,
     winner_score_v2_pct: Optional[float] = None,
     winner_score_v2_breakdown: Optional[Dict[str, Any]] = None,
+    *,
+    commit: bool = True,
 ) -> int:
     """Insert a new AI score for a product."""
 
@@ -517,7 +519,8 @@ def insert_score(
             json_dump(winner_score_v2_breakdown),
         ),
     )
-    conn.commit()
+    if commit:
+        conn.commit()
     return cur.lastrowid
 
 def remove_product_from_list(conn: sqlite3.Connection, list_id: int, product_id: int) -> None:

--- a/product_research_app/services/winner_v2.py
+++ b/product_research_app/services/winner_v2.py
@@ -82,19 +82,24 @@ def score_product(
     weights: Dict[str, float],
     ranges: Dict[str, Dict[str, float]] | None = None,
     missing: list[str] | None = None,
-) -> float:
+    used: list[str] | None = None,
+) -> float | None:
     if ranges is None:
         ranges = compute_ranges([prod])
     total_w = 0.0
     score = 0.0
     for k, w in weights.items():
+        if w <= 0:
+            continue
         val = normalize_metric(k, prod.get(k), ranges)
-        total_w += w
         if val is None or (isinstance(val, float) and math.isnan(val)):
             if missing is not None:
                 missing.append(k)
             continue
+        if used is not None:
+            used.append(k)
         score += w * val
+        total_w += w
     if total_w <= 0:
-        return 0.0
+        return None
     return score / total_w


### PR DESCRIPTION
## Summary
- Allow winner score computation with any available metrics, rescaling weights and using a 50 fallback only when none are present
- Batch insert winner scores with a commit at the end and expose used/missing metrics for diagnostics
- Support optional database commit control for score inserts

## Testing
- `python -m py_compile product_research_app/services/winner_v2.py product_research_app/web_app.py product_research_app/database.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1a60a8c3c8328a8a313e8c0f24897