### PR TITLE
Adjust winner score calculation to handle partial metrics

### DIFF
--- a/product_research_app/database.py
+++ b/product_research_app/database.py
@@ -95,13 +95,30 @@ def initialize_database(conn: sqlite3.Connection) -> None:
         cur.execute("ALTER TABLE products ADD COLUMN date_range TEXT")
     if "ai_columns_completed_at" not in cols:
         cur.execute("ALTER TABLE products ADD COLUMN ai_columns_completed_at TEXT")
+    metric_text_cols = [
+        "magnitud_deseo",
+        "nivel_consciencia_headroom",
+        "competition_level_invertido",
+        "facilidad_anuncio",
+        "escalabilidad",
+        "durabilidad_recurrencia",
+    ]
+    metric_real_cols = [
+        "evidencia_demanda",
+        "tasa_conversion",
+        "ventas_por_dia",
+        "recencia_lanzamiento",
+    ]
+    for col in metric_text_cols:
+        if col not in cols:
+            cur.execute(f"ALTER TABLE products ADD COLUMN {col} TEXT")
+    for col in metric_real_cols:
+        if col not in cols:
+            cur.execute(f"ALTER TABLE products ADD COLUMN {col} REAL")
     # drop obsolete columns if present
     for obsolete in [
-        "facilidad_anuncio",
         "facilidad_logistica",
-        "escalabilidad",
         "engagement_shareability",
-        "durabilidad_recurrencia",
     ]:
         if obsolete in cols:
             try:
@@ -428,6 +445,16 @@ def update_product(
         "competition_level",
         "date_range",
         "ai_columns_completed_at",
+        "magnitud_deseo",
+        "nivel_consciencia_headroom",
+        "evidencia_demanda",
+        "tasa_conversion",
+        "ventas_por_dia",
+        "recencia_lanzamiento",
+        "competition_level_invertido",
+        "facilidad_anuncio",
+        "escalabilidad",
+        "durabilidad_recurrencia",
     }
     data = {k: v for k, v in fields.items() if k in allowed_cols}
     if not data:
@@ -473,6 +500,8 @@ def insert_score(
     winner_score_v2_raw: Optional[float] = None,
     winner_score_v2_pct: Optional[float] = None,
     winner_score_v2_breakdown: Optional[Dict[str, Any]] = None,
+    *,
+    commit: bool = True,
 ) -> int:
     """Insert a new AI score for a product."""
 
@@ -517,7 +546,8 @@ def insert_score(
             json_dump(winner_score_v2_breakdown),
         ),
     )
-    conn.commit()
+    if commit:
+        conn.commit()
     return cur.lastrowid
 
 def remove_product_from_list(conn: sqlite3.Connection, list_id: int, product_id: int) -> None:

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -303,6 +303,54 @@ def _process_import_job(job_id: int, tmp_path: Path, filename: str) -> None:
             cat_col = find_key(headers, ["category", "categoria", "niche", "segment"])
             curr_col = find_key(headers, ["currency", "moneda"])
 
+            metric_names = [
+                "magnitud_deseo",
+                "nivel_consciencia_headroom",
+                "evidencia_demanda",
+                "tasa_conversion",
+                "ventas_por_dia",
+                "recencia_lanzamiento",
+                "competition_level_invertido",
+                "facilidad_anuncio",
+                "escalabilidad",
+                "durabilidad_recurrencia",
+            ]
+
+            def sanitize(name: str) -> str:
+                return "".join(ch for ch in name if ch.isalnum())
+
+            metric_cols = {m: find_key(headers, [sanitize(m)]) for m in metric_names}
+
+            def parse_number(val: Any) -> float | None:
+                if val in (None, ''):
+                    return None
+                s = str(val).strip()
+                if not s:
+                    return None
+                percent = '%' in s
+                s = s.replace('%', '').replace(' ', '').replace(',', '.')
+                s = re.sub(r'[^0-9.+-]', '', s)
+                try:
+                    num = float(s)
+                    if percent:
+                        num /= 100.0
+                    return num
+                except Exception:
+                    return None
+
+            def parse_text(val: Any) -> str | None:
+                if val is None:
+                    return None
+                s = str(val).strip()
+                return s or None
+
+            numeric_metrics = {
+                "evidencia_demanda",
+                "tasa_conversion",
+                "ventas_por_dia",
+                "recencia_lanzamiento",
+            }
+
             cur = conn.cursor()
             cur.execute("BEGIN")
             cur.execute("SELECT COUNT(*) FROM products")
@@ -330,6 +378,7 @@ def _process_import_job(job_id: int, tmp_path: Path, filename: str) -> None:
                 date_range = (row.get(range_col) or '').strip() if range_col else ''
 
                 extras = {}
+                metrics: dict[str, object] = {}
 
                 rating_val = None
                 if rating_col and row.get(rating_col) not in (None, ''):
@@ -382,6 +431,17 @@ def _process_import_job(job_id: int, tmp_path: Path, filename: str) -> None:
                 set_extra(conv_col, 'conversion_rate')
                 set_extra(launch_col, 'launch_date')
 
+                for m in metric_names:
+                    col = metric_cols.get(m)
+                    raw = row.get(col) if col else None
+                    if raw not in (None, ''):
+                        if m in numeric_metrics:
+                            val = parse_number(raw)
+                        else:
+                            val = parse_text(raw)
+                        if val is not None:
+                            metrics[m] = val
+
                 recognized = {
                     name_col,
                     desc_col,
@@ -396,14 +456,15 @@ def _process_import_job(job_id: int, tmp_path: Path, filename: str) -> None:
                     launch_col,
                     range_col,
                 }
+                recognized.update(c for c in metric_cols.values() if c)
                 for k, v in row.items():
                     if k not in recognized:
                         extras[k] = v
 
                 rows_validas.append(
-                    (name, description, category, price, currency, image_url, date_range, extras)
+                    (name, description, category, price, currency, image_url, date_range, extras, metrics)
                 )
-            for idx, (name, description, category, price, currency, image_url, date_range, extra_cols) in enumerate(rows_validas):
+            for idx, (name, description, category, price, currency, image_url, date_range, extra_cols, metrics) in enumerate(rows_validas):
                 row_id = base_id + idx
                 database.insert_product(
                     conn,
@@ -419,6 +480,8 @@ def _process_import_job(job_id: int, tmp_path: Path, filename: str) -> None:
                     commit=False,
                     product_id=row_id,
                 )
+                if metrics:
+                    database.update_product(conn, row_id, **metrics)
                 rows_imported += 1
                 inserted_ids.append(row_id)
             conn.commit()
@@ -448,23 +511,15 @@ def _process_import_job(job_id: int, tmp_path: Path, filename: str) -> None:
             if any((dict(sc).get("winner_score_v2_pct") or 0) > 0 for sc in existing):
                 skipped_scores += 1
                 continue
-            missing: list[str] = []
-            pct_val = winner_calc.score_product(prod, weights, ranges, missing)
-            if pct_val is None or math.isnan(pct_val) or len(missing) == len(weights):
+            pct_val = winner_calc.score_product(prod, weights, ranges)
+            if pct_val is None or math.isnan(pct_val):
                 logger.warning(
-                    "Winner Score fallback 50 for product %s: invalid metrics",
+                    "Winner Score fallback 50 for product %s: no valid metrics",
                     pid,
                 )
                 pct = 50
             else:
                 pct = max(0, min(100, round(pct_val * 100)))
-            if missing:
-                for m in missing:
-                    logger.warning(
-                        "Winner Score missing metric for product %s: %s",
-                        pid,
-                        m,
-                    )
             logger.debug(
                 "Winner Score import product %s: raw=%s final=%s",
                 pid,
@@ -485,8 +540,10 @@ def _process_import_job(job_id: int, tmp_path: Path, filename: str) -> None:
                 summary="",
                 explanations={},
                 winner_score_v2_pct=pct,
+                commit=False,
             )
             updated_scores += 1
+        conn.commit()
         logger.info(
             "Winner Score import/backfill: imported=%d updated=%d skipped=%d",
             len(inserted_ids),
@@ -2060,8 +2117,15 @@ class RequestHandler(BaseHTTPRequestHandler):
             ranges = winner_calc.compute_ranges(products_all)
             weights = {k: 1.0 for k in winner_calc.ALL_METRICS}
             for prod in products_all:
-                pct = winner_calc.score_product(prod, weights, ranges) * 100
-                pct = max(0, min(100, round(pct)))
+                pct_val = winner_calc.score_product(prod, weights, ranges)
+                if pct_val is None or math.isnan(pct_val):
+                    logger.warning(
+                        "Winner Score fallback 50 for product %s: no valid metrics",
+                        prod['id'],
+                    )
+                    pct = 50
+                else:
+                    pct = max(0, min(100, round(pct_val * 100)))
                 database.insert_score(
                     conn_ws,
                     product_id=prod['id'],
@@ -2076,7 +2140,9 @@ class RequestHandler(BaseHTTPRequestHandler):
                     summary='',
                     explanations={},
                     winner_score_v2_pct=pct,
+                    commit=False,
                 )
+            conn_ws.commit()
         pending = []
         cost_msg = None
         cost_est = None
@@ -2720,6 +2786,8 @@ class RequestHandler(BaseHTTPRequestHandler):
         updated: Dict[str, int] = {}
         skipped = 0
         details: list[dict[str, int | str]] = []
+        used_metrics: set[str] = set()
+        missing_metrics: set[str] = set()
         for prod in products_all:
             pid = prod["id"]
             if pid not in id_set:
@@ -2730,23 +2798,20 @@ class RequestHandler(BaseHTTPRequestHandler):
                 details.append({"id": pid, "reason": "already_scored"})
                 continue
             missing: list[str] = []
-            pct_val = winner_calc.score_product(prod, weights, ranges, missing)
+            used: list[str] = []
+            pct_val = winner_calc.score_product(prod, weights, ranges, missing, used)
             reason: str | None = None
-            if pct_val is None or math.isnan(pct_val) or len(missing) == len(weights):
+            if pct_val is None or math.isnan(pct_val):
                 logger.warning(
-                    "Winner Score fallback 50 for product %s: invalid metrics", pid
+                    "Winner Score fallback 50 for product %s: no valid metrics",
+                    pid,
                 )
                 pct = 50
-                reason = "invalid_metrics"
+                reason = "no_metrics"
             else:
                 pct = max(0, min(100, round(pct_val * 100)))
-            if missing:
-                for m in missing:
-                    logger.warning(
-                        "Winner Score missing metric for product %s: %s",
-                        pid,
-                        m,
-                    )
+            used_metrics.update(used)
+            missing_metrics.update(missing)
             logger.debug(
                 "Winner Score generate product %s: raw=%s final=%s",
                 pid,
@@ -2767,6 +2832,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                 summary="",
                 explanations={},
                 winner_score_v2_pct=pct,
+                commit=False,
             )
             updated[str(pid)] = pct
             if reason:
@@ -2787,6 +2853,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                 {
                     "updated": len(updated),
                     "skipped": skipped,
+                    "used_metrics": sorted(used_metrics),
+                    "missing_metrics": sorted(missing_metrics),
                     "details": details,
                 }
             ).encode("utf-8")


### PR DESCRIPTION
## Summary
- Allow winner score computation with any available metrics, rescaling weights and using a 50 fallback only when none are present
- Batch insert winner scores with a commit at the end and expose used/missing metrics for diagnostics
- Support optional database commit control for score inserts
- Parse XLSX import metrics to numbers or NULL, converting percentages to fractions and persisting them without phantom zeros
- Accept both percentage and fractional values for conversion rate normalization

## Testing
- `python -m py_compile product_research_app/services/winner_v2.py product_research_app/web_app.py product_research_app/database.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a60a8c3c8328a8a313e8c0f24897