### PR TITLE
Expose per-product scores in Winner Score API

### DIFF
--- a/product_research_app/database.py
+++ b/product_research_app/database.py
@@ -325,7 +325,7 @@ def insert_product(
         The product ID (auto‑generated or explicit).
     """
     cur = conn.cursor()
-    import_date = datetime.utcnow().isoformat()
+    import_date = datetime.now(datetime.UTC).isoformat()
     if desire is not None and len(desire) > 180:
         desire = desire[:180]
     allowed_tri = {"Low", "Medium", "High"}
@@ -506,7 +506,7 @@ def insert_score(
     """Insert a new AI score for a product."""
 
     cur = conn.cursor()
-    created_at = datetime.utcnow().isoformat()
+    created_at = datetime.now(datetime.UTC).isoformat()
     if winner_score_v2_pct is not None:
         try:
             pct = int(round(float(winner_score_v2_pct)))
@@ -739,7 +739,7 @@ def delete_product(conn: sqlite3.Connection, product_id: int) -> None:
 
 def create_import_job(conn: sqlite3.Connection, temp_path: str) -> int:
     """Create a new pending import job and return its ID."""
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(datetime.UTC).isoformat()
     cur = conn.cursor()
     cur.execute(
         """
@@ -756,7 +756,7 @@ def complete_import_job(
     conn: sqlite3.Connection, job_id: int, rows: int, winner_score_updated: int = 0
 ) -> None:
     """Mark an import job as completed."""
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(datetime.UTC).isoformat()
     cur = conn.cursor()
     cur.execute(
         """
@@ -771,7 +771,7 @@ def complete_import_job(
 
 def fail_import_job(conn: sqlite3.Connection, job_id: int, error: str) -> None:
     """Mark an import job as failed."""
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(datetime.UTC).isoformat()
     cur = conn.cursor()
     cur.execute(
         """
@@ -785,7 +785,7 @@ def fail_import_job(conn: sqlite3.Connection, job_id: int, error: str) -> None:
 
 
 def start_import_job_ai(conn: sqlite3.Connection, job_id: int, total: int) -> None:
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(datetime.UTC).isoformat()
     cur = conn.cursor()
     cur.execute(
         """
@@ -799,7 +799,7 @@ def start_import_job_ai(conn: sqlite3.Connection, job_id: int, total: int) -> No
 
 
 def update_import_job_ai_progress(conn: sqlite3.Connection, job_id: int, done: int) -> None:
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(datetime.UTC).isoformat()
     cur = conn.cursor()
     cur.execute(
         "UPDATE import_jobs SET ai_done=?, updated_at=? WHERE id=?",
@@ -809,7 +809,7 @@ def update_import_job_ai_progress(conn: sqlite3.Connection, job_id: int, done: i
 
 
 def set_import_job_ai_error(conn: sqlite3.Connection, job_id: int, error: str) -> None:
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(datetime.UTC).isoformat()
     cur = conn.cursor()
     cur.execute(
         "UPDATE import_jobs SET ai_error=?, updated_at=? WHERE id=?",
@@ -821,7 +821,7 @@ def set_import_job_ai_error(conn: sqlite3.Connection, job_id: int, error: str) -
 def set_import_job_ai_counts(
     conn: sqlite3.Connection, job_id: int, counts: Dict[str, Any], pending_ids: List[int]
 ) -> None:
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(datetime.UTC).isoformat()
     cur = conn.cursor()
     cur.execute(
         "UPDATE import_jobs SET ai_counts=?, ai_pending=?, updated_at=? WHERE id=?",
@@ -851,7 +851,7 @@ def get_import_job(conn: sqlite3.Connection, job_id: int) -> Optional[sqlite3.Ro
 
 def mark_stale_pending_imports(conn: sqlite3.Connection, minutes: int) -> None:
     """Mark pending imports older than X minutes as errored after restart."""
-    cutoff = (datetime.utcnow() - timedelta(minutes=minutes)).isoformat()
+    cutoff = (datetime.now(datetime.UTC) - timedelta(minutes=minutes)).isoformat()
     cur = conn.cursor()
     cur.execute(
         "SELECT id, temp_path FROM import_jobs WHERE status='pending' AND created_at <= ?",
@@ -861,7 +861,7 @@ def mark_stale_pending_imports(conn: sqlite3.Connection, minutes: int) -> None:
     for row in rows:
         cur.execute(
             "UPDATE import_jobs SET status='error', updated_at=?, error='server restarted' WHERE id=?",
-            (datetime.utcnow().isoformat(), row["id"]),
+            (datetime.now(datetime.UTC).isoformat(), row["id"]),
         )
         if row["temp_path"]:
             try:

--- a/product_research_app/services/ai_columns.py
+++ b/product_research_app/services/ai_columns.py
@@ -230,7 +230,7 @@ def fill_ai_columns(
     to_process: List[Dict[str, Any]] = []
     selected_ids: List[int] = []
     records: Dict[str, Any] = {}
-    now_ts = datetime.utcnow().isoformat()
+    now_ts = datetime.now(datetime.UTC).isoformat()
 
     for pid in product_ids:
         rec = database.get_product(conn, pid)
@@ -427,12 +427,12 @@ def fill_ai_columns(
     errors = 0
     for pid, apply in updates_final.items():
         if apply:
-            apply["ai_columns_completed_at"] = datetime.utcnow().isoformat()
+            apply["ai_columns_completed_at"] = datetime.now(datetime.UTC).isoformat()
             database.update_product(conn, int(pid), **apply)
             applied_ok[pid] = {k: v for k, v in apply.items() if k != "ai_columns_completed_at"}
             success += 1
         else:
-            database.update_product(conn, int(pid), ai_columns_completed_at=datetime.utcnow().isoformat())
+            database.update_product(conn, int(pid), ai_columns_completed_at=datetime.now(datetime.UTC).isoformat())
             ko_all[pid] = ko_all.get(pid, "existing")
             errors += 1
 

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -278,7 +278,7 @@ async function pollImportStatus(id) {
     } else {
       localStorage.removeItem(IMPORT_TASK_LS_KEY);
       if (data.status === 'done') {
-        await fetchProducts();
+        await fetchProducts(true, true);
         toast.success(data.message || 'Winner Score actualizado tras importar');
         const n = data.imported || data.rows_imported || 0;
         const ws = data.winner_score_updated || 0;
@@ -300,7 +300,7 @@ async function pollImportStatus(id) {
             actionText: 'Reintentar IA ahora',
             onAction: async () => {
               await window.handleCompletarIA({ ids: data.pending_ids });
-              fetchProducts();
+              fetchProducts(true, true);
             }
           });
         }
@@ -438,7 +438,7 @@ const columns = [
   { key: 'desire_magnitude', label: 'Desire magnetitude', type: 'string', headerClass: 'ec-col ec-col-desire-mag', cellClass: 'ec-col ec-col-desire-mag', dataEcCol: 'desire_magnitude' },
   { key: 'awareness_level', label: 'Awerness Level', type: 'string', headerClass: 'ec-col ec-col-awareness', cellClass: 'ec-col ec-col-awareness', dataEcCol: 'awareness_level' },
   { key: 'competition_level', label: 'Competition level', type: 'string', headerClass: 'ec-col ec-col-competition', cellClass: 'ec-col ec-col-competition', dataEcCol: 'competition_level' },
-  { key: 'winner_score_v2_pct', label: 'Winner Score', type: 'number' },
+  { key: 'winner_score', label: 'Winner Score', type: 'number' },
 ];
 
 let trendingWords = [];
@@ -630,9 +630,9 @@ function recalculateWinnerScoreV2(){
       if(v!=null){ total+=w; score+=w*v; }
     });
     const raw = total>0 ? (score/total)*100 : 0;
-    p.winner_score_v2_pct = Math.max(0, Math.min(100, Math.round(raw)));
+    p.winner_score = Math.max(0, Math.min(100, Math.round(raw)));
   });
-  if(sortField==='winner_score_v2_pct'){
+  if(sortField==='winner_score'){
     sortProducts();
   }
   renderTable();
@@ -694,12 +694,19 @@ function isTrending(name) {
   return words.some(w => trendingWords.includes(w));
 }
 
-async function fetchProducts(preserve=true) {
+async function fetchProducts(preserve=true, bust=false) {
+  if (typeof preserve !== 'boolean') preserve = true;
+  const url = bust ? `/products?ts=${Date.now()}` : '/products';
+  const opts = bust ? {cache:'no-store'} : undefined;
   const prevSel = new Set(selection);
-  const data = await fetchJson('/products');
-  allProducts = data;
+  const data = await fetchJson(url, opts);
+  allProducts = data.map(p => ({
+    ...p,
+    id: Number(p.id),
+    winner_score: p.winner_score != null ? Number(p.winner_score) : Number(p.winner_score_v2_pct)
+  }));
   preprocessProducts(allProducts);
-  allProducts.sort((a,b)=> (Number(a.id)||0) - (Number(b.id)||0));
+  allProducts.sort((a,b)=> (a.id||0) - (b.id||0));
   sortField = 'id';
   sortDir = 1;
   sortType = 'number';
@@ -711,7 +718,7 @@ async function fetchProducts(preserve=true) {
   } else {
     renderTable();
   }
-  const visibleIds = new Set(products.map(p => String(p.id)));
+  const visibleIds = new Set(products.map(p => p.id));
   selection.clear();
   for (const id of prevSel) {
     if (visibleIds.has(id)) selection.add(id);
@@ -744,7 +751,7 @@ function renderTable() {
       if (col.width) th.style.width = col.width + 'px';
       if (col.minWidth) th.style.minWidth = col.minWidth + 'px';
       if (col.maxWidth) th.style.maxWidth = col.maxWidth + 'px';
-      if (col.key === 'winner_score_v2_pct') th.title = 'Suma ponderada de 10 métricas normalizadas (v2)';
+      if (col.key === 'winner_score') th.title = 'Suma ponderada de 10 métricas normalizadas (v2)';
       th.onclick = () => sortBy(col.key, col.type);
       headerRow.appendChild(th);
     });
@@ -765,12 +772,13 @@ function renderTable() {
     const cb = document.createElement('input');
     cb.type = 'checkbox';
     cb.classList.add('rowCheck');
-    const rowId = String(item.id);
+    const rowId = item.id;
+    tr.dataset.id = rowId;
     cb.dataset.id = rowId;
     cb.checked = selection.has(rowId);
     tr.classList.toggle('selected', cb.checked);
     cb.addEventListener('change', () => {
-      const id = cb.dataset.id;
+      const id = Number(cb.dataset.id);
       if (cb.checked) selection.add(id); else selection.delete(id);
       tr.classList.toggle('selected', cb.checked);
       updateMasterState();
@@ -793,15 +801,16 @@ function renderTable() {
           const j = item.winner_score_v2_breakdown.justifications[key];
           if (j) td.title = 'Justificación: ' + j;
         }
-      } else if (['id','name','category','price','image_url','winner_score_v2_pct','desire','desire_magnitude','awareness_level','competition_level','date_range'].includes(key)) {
+      } else if (['id','name','category','price','image_url','winner_score','desire','desire_magnitude','awareness_level','competition_level','date_range'].includes(key)) {
         value = item[key];
       } else {
         value = item.extras ? item.extras[key] : '';
       }
-      if (key === 'winner_score_v2_pct') {
-        const sc = parseFloat(value);
-        if (!isNaN(sc)) {
-          const scInt = Math.round(sc);
+      if (key === 'winner_score') {
+        if (value == null || value === '') {
+          td.textContent = '—';
+        } else {
+          const scInt = Math.round(Number(value));
           td.innerHTML = '<span class="' + winnerScoreClass(scInt) + '">' + scInt.toLocaleString(undefined,{maximumFractionDigits:0}) + '</span>';
           if (item.winner_score_v2_breakdown && item.winner_score_v2_breakdown.justifications) {
             const j = item.winner_score_v2_breakdown.justifications;
@@ -944,7 +953,7 @@ function renderTable() {
     tr.appendChild(tdDel);
     tbody.appendChild(tr);
   });
-  currentPageIds = products.map(p => String(p.id));
+  currentPageIds = products.map(p => p.id);
   updateResultsBadge(currentPageIds.length);
   if (window.refreshColumns) window.refreshColumns();
   if (window.applyColumnVisibility) window.applyColumnVisibility();
@@ -962,7 +971,7 @@ function sortProducts(){
   const type = sortType;
   products.sort((a,b)=>{
     let va; let vb;
-    if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'winner_score_v2_pct' || field === 'desire' || field === 'desire_magnitude' || field === 'awareness_level' || field === 'competition_level') {
+  if (field === 'id' || field === 'name' || field === 'category' || field === 'price' || field === 'image_url' || field === 'winner_score' || field === 'desire' || field === 'desire_magnitude' || field === 'awareness_level' || field === 'competition_level') {
       va = a[field];
       vb = b[field];
     } else if (metricKeys.includes(field)) {
@@ -1335,7 +1344,7 @@ document.getElementById('btnExport').onclick = async () => {
 
 // Generate Winner Score for selected products
 document.getElementById('btnGenWinner').onclick = async () => {
-  const ids = Array.from(selection, Number);
+  const ids = Array.from(selection);
   if(!ids.length){
     toast.error('Selecciona al menos un producto');
     return;
@@ -1345,9 +1354,23 @@ document.getElementById('btnGenWinner').onclick = async () => {
   startProgress();
   try{
     const res = await fetchJson('/scoring/v2/generate', {method:'POST', body: JSON.stringify({ids})});
-    await fetchProducts();
+    if(Array.isArray(res.rows)){
+      const map = new Map(res.rows.map(r => [Number(r.id), r.winner_score]));
+      (window.allProducts||[]).forEach(p => {
+        const ns = map.get(p.id);
+        if(ns != null){ p.winner_score = ns; }
+      });
+      if(Array.isArray(window.products)){
+        window.products.forEach(p => {
+          const ns = map.get(p.id);
+          if(ns != null){ p.winner_score = ns; }
+        });
+      }
+      if(sortField==='winner_score') sortProducts();
+      renderTable();
+    }
+    const processed = res.processed || 0;
     const updated = res.updated || 0;
-    const skipped = res.skipped || 0;
     const withPartial = res.with_partial || 0;
     const fallbackOnly = res.fallback_only || 0;
     if(withPartial > 0){
@@ -1356,10 +1379,10 @@ document.getElementById('btnGenWinner').onclick = async () => {
     if(fallbackOnly > 0){
       toast.warn(`${fallbackOnly} productos sin datos suficientes (score=50)`);
     }
-    if(updated === 0){
+    if(processed === 0){
+      toast.info('No se procesó ningún producto.');
+    } else if(updated === 0){
       toast.info('No se actualizó ningún producto.');
-    } else if(skipped > 0){
-      toast.warn(`Winner Score actualizado en ${updated} productos, ${skipped} omitidos`);
     } else {
       toast.success(`Winner Score actualizado en ${updated} productos`);
     }
@@ -1483,7 +1506,7 @@ async function loadTrends(){
   let html = '<h3>Tendencias</h3>';
   if(data.top_products && data.top_products.length){
     html += '<strong>Top productos por Winner Score:</strong><ol>';
-        data.top_products.forEach(item=>{ const sc = Math.round(item.winner_score_v2_pct || 0); html += `<li>${item.name} (Winner Score: ${sc.toLocaleString(undefined,{maximumFractionDigits:0})})</li>`; });
+        data.top_products.forEach(item=>{ const sc = Math.round(item.winner_score || 0); html += `<li>${item.name} (Winner Score: ${sc.toLocaleString(undefined,{maximumFractionDigits:0})})</li>`; });
     html += '</ol>';
   }
   cont.innerHTML = html;

--- a/product_research_app/static/js/add-group.js
+++ b/product_research_app/static/js/add-group.js
@@ -33,9 +33,9 @@ import * as groupsService from './groups-service.js';
           const scoreMap = {};
           ids.forEach(pid => {
             const prod = (window.allProducts || []).find(p => p.id === pid);
-            if(prod && prod.winner_score_v2_pct!=null) scoreMap[pid] = prod.winner_score_v2_pct;
+            if(prod && prod.winner_score!=null) scoreMap[pid] = prod.winner_score;
           });
-          await fetchJson('/add_to_list', {method:'POST', body: JSON.stringify({id, ids, winner_score_v2_pct: scoreMap})});
+          await fetchJson('/add_to_list', {method:'POST', body: JSON.stringify({id, ids, winner_score: scoreMap})});
           toast.success(`${ids.length} añadidos a ${groupName}`);
           hide();
           loadLists();

--- a/product_research_app/static/js/completar-ia.js
+++ b/product_research_app/static/js/completar-ia.js
@@ -18,7 +18,7 @@ function isEditing(pid, field) {
   const tr = active.closest('tr');
   if (!tr) return false;
   const cb = tr.querySelector('input.rowCheck');
-  if (!cb || cb.dataset.id !== String(pid)) return false;
+  if (!cb || Number(cb.dataset.id) !== Number(pid)) return false;
   const td = active.closest('td[data-key]');
   if (!td) return false;
   return td.dataset.key === field;
@@ -78,7 +78,7 @@ async function processBatch(items) {
   const okMap = data.ok || {};
   const koMap = data.ko || {};
   Object.keys(okMap).forEach(id => {
-    const product = (window.products || []).find(p => String(p.id) === String(id));
+    const product = (window.products || []).find(p => p.id === Number(id));
     if (product) {
       applyUpdates(product, okMap[id]);
       ok++;

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -13,8 +13,8 @@ function ensureMaster(){
     master = document.getElementById('selectAll');
     if(master){
       master.addEventListener('change', ()=>{
-        if(master.checked){ currentPageIds.forEach(id=>selection.add(String(id))); }
-        else { currentPageIds.forEach(id=>selection.delete(String(id))); }
+        if(master.checked){ currentPageIds.forEach(id=>selection.add(Number(id))); }
+        else { currentPageIds.forEach(id=>selection.delete(Number(id))); }
         renderTable();
         updateMasterState();
       });
@@ -39,8 +39,8 @@ function updateMasterState(){
   if(btnGen){
     const ap = window.allProducts || [];
     const needs = Array.from(selection).some(id => {
-      const prod = ap.find(p => String(p.id)===String(id));
-      const val = prod ? Number(prod.winner_score_v2_pct) : 0;
+      const prod = ap.find(p => p.id===id);
+      const val = prod ? Number(prod.winner_score) : 0;
       return !val;
     });
     btnGen.disabled = noneSelected || !needs;


### PR DESCRIPTION
## Summary
- Bind table column to `winner_score` and format missing scores as dashes
- Refresh product list in-memory after scoring and post-import with cache busting
- Normalize numeric product IDs across UI helpers
- Use timezone-aware `datetime.now(datetime.UTC)` throughout to avoid deprecation warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1b47f7ce08328883bd504bcd6b837