### PR TITLE
Force winner score v2

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -177,18 +177,12 @@ def get_weights() -> Dict[str, float]:
 def is_scoring_v2_enabled() -> bool:
     """Return whether Winner Score v2 flow is enabled.
 
-    The configuration may contain a nested structure like::
-
-        {"scoring": {"v2": {"enabled": true}}}
-
-    If the key is missing or invalid the flag defaults to ``True``.
+    Winner Score v2 is now the only supported scoring flow.  The function
+    remains for backward compatibility but always returns ``True`` so that the
+    v2 code path is active regardless of any user configuration.
     """
 
-    cfg = load_config()
-    try:
-        return bool(cfg.get("scoring", {}).get("v2", {}).get("enabled", True))
-    except Exception:
-        return True
+    return True
 
 # ---------------- Winner Score v2 weights -----------------
 

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -630,7 +630,9 @@ function recalculateWinnerScoreV2(){
       if(v!=null){ total+=w; score+=w*v; }
     });
     const raw = total>0 ? (score/total)*100 : 0;
-    p.winner_score = Math.max(0, Math.min(100, Math.round(raw)));
+    const sc = Math.max(0, Math.min(100, Math.round(raw)));
+    p.winner_score = sc;
+    p.winner_score_v2_pct = sc;
   });
   if(sortField==='winner_score'){
     sortProducts();
@@ -700,11 +702,10 @@ async function fetchProducts(preserve=true, bust=false) {
   const opts = bust ? {cache:'no-store'} : undefined;
   const prevSel = new Set(selection);
   const data = await fetchJson(url, opts);
-  allProducts = data.map(p => ({
-    ...p,
-    id: Number(p.id),
-    winner_score: p.winner_score != null ? Number(p.winner_score) : Number(p.winner_score_v2_pct)
-  }));
+  allProducts = data.map(p => {
+    const sc = p.winner_score != null ? Number(p.winner_score) : null;
+    return { ...p, id: Number(p.id), winner_score: sc, winner_score_v2_pct: sc };
+  });
   preprocessProducts(allProducts);
   allProducts.sort((a,b)=> (a.id||0) - (b.id||0));
   sortField = 'id';
@@ -1358,12 +1359,12 @@ document.getElementById('btnGenWinner').onclick = async () => {
       const map = new Map(res.rows.map(r => [Number(r.id), r.winner_score]));
       (window.allProducts||[]).forEach(p => {
         const ns = map.get(p.id);
-        if(ns != null){ p.winner_score = ns; }
+        if(ns != null){ p.winner_score = ns; p.winner_score_v2_pct = ns; }
       });
       if(Array.isArray(window.products)){
         window.products.forEach(p => {
           const ns = map.get(p.id);
-          if(ns != null){ p.winner_score = ns; }
+          if(ns != null){ p.winner_score = ns; p.winner_score_v2_pct = ns; }
         });
       }
       if(sortField==='winner_score') sortProducts();


### PR DESCRIPTION
## Summary
- Always enable scoring v2 so winner scores use the v2 algorithm
- GET /products returns `winner_score` backed by v2 and mirrors it in `winner_score_v2_pct`
- Redirect legacy `/scoring/*` routes to the v2 handlers with a deprecation log
- UI uses `winner_score` directly, keeps `winner_score_v2_pct` synced for compatibility, and updates scores live after generation

## Testing
- `python -m py_compile product_research_app/config.py product_research_app/web_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1bf0f2c6883289fb00eb96d146879