### PR TITLE
Fix desire hot save and serialization

### DIFF
--- a/product_research_app/static/js/completar-ia.js
+++ b/product_research_app/static/js/completar-ia.js
@@ -48,11 +48,15 @@ function applyUpdates(product, updates) {
     applied[k] = nv;
   });
   if (Object.keys(applied).length) {
-    fetch(`/products/${product.id}`, {
-      method: 'PUT',
+    fetch(`/api/products/${product.id}`, {
+      method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(applied)
-    }).catch(() => {});
+    }).then(res => {
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    }).catch(err => {
+      toast?.error?.(`No se pudo guardar Desire: ${err.message}`);
+    });
     if (window.ecAutoFitColumns && window.gridRoot) ecAutoFitColumns(gridRoot);
   }
   return applied;

--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -294,7 +294,7 @@ def test_desire_serialization_and_logging(tmp_path, monkeypatch):
     p3 = next(p for p in resp if p["id"] == pid3)
     assert p1["desire"] == "Top"
     assert isinstance(p1["price"], (int, float))
-    assert p2["desire"] is None
+    assert p2["desire"] == "Extra"
     assert p2["extras"].get("desire") == "Extra"
     assert p3["desire"] is None
     log_text = web_app.LOG_PATH.read_text()

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -680,16 +680,16 @@ class RequestHandler(BaseHTTPRequestHandler):
                     dr = extra_dict.get("date_range")
                 price_val = rget(p, "price")
                 desire_db = rget(p, "desire")
-                if desire_db in (None, ""):
-                    _ensure_desire(p, extra_dict)
-                desire_val = desire_db or None
+                desire_val = (desire_db.strip() if isinstance(desire_db, str) else desire_db) or None
+                if desire_val is None:
+                    # _ensure_desire debe devolver el mejor candidato desde extras/AI
+                    desire_val = _ensure_desire(p, extra_dict) or None
                 row = {
                     "id": rget(p, "id"),
                     "name": rget(p, "name"),
                     "category": rget(p, "category"),
                     "price": price_val,
                     "image_url": rget(p, "image_url"),
-                    "desire": desire_val,
                     "desire_magnitude": rget(p, "desire_magnitude"),
                     "awareness_level": rget(p, "awareness_level"),
                     "competition_level": rget(p, "competition_level"),
@@ -701,6 +701,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                     "date_range": dr or "",
                     "extras": extra_dict,
                 }
+                row["desire"] = desire_val
                 if price_val is not None:
                     try:
                         row["price_display"] = round(float(price_val), 2)


### PR DESCRIPTION
## Summary
- use `/api/products/:id` PATCH for front-end autosave with error toast
- ensure desire field in product listing falls back to extras/AI when DB value empty
- update tests for desire fallback

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68c4b5c33bf8832888efb2f2d7cd7c49