### PR TITLE
Fix desire persistence in product API

### DIFF
--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -296,7 +296,7 @@ def test_desire_serialization_and_logging(tmp_path, monkeypatch):
     assert isinstance(p1["price"], (int, float))
     assert p2["desire"] == "Extra"
     assert p2["extras"].get("desire") == "Extra"
-    assert p3["desire"] == ""
+    assert p3["desire"] is None
     log_text = web_app.LOG_PATH.read_text()
     assert f"desire_missing=true" in log_text and f"product={pid3}" in log_text
 

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -679,7 +679,10 @@ class RequestHandler(BaseHTTPRequestHandler):
                 if dr is None:
                     dr = extra_dict.get("date_range")
                 price_val = rget(p, "price")
-                desire_val = _ensure_desire(p, extra_dict)
+                desire_db = rget(p, "desire")
+                if desire_db in (None, ""):
+                    desire_db = _ensure_desire(p, extra_dict)
+                desire_val = (desire_db or "").strip() or None
                 row = {
                     "id": rget(p, "id"),
                     "name": rget(p, "name"),
@@ -1286,7 +1289,10 @@ class RequestHandler(BaseHTTPRequestHandler):
                     extra_dict = json.loads(rget(product, "extra") or "{}")
                 except Exception:
                     extra_dict = {}
-                product["desire"] = _ensure_desire(product, extra_dict)
+                desire_db = rget(product, "desire")
+                if desire_db in (None, ""):
+                    desire_db = _ensure_desire(product, extra_dict)
+                product["desire"] = (desire_db or "").strip() or None
                 self._set_json()
                 self.wfile.write(json.dumps(product).encode('utf-8'))
             else:


### PR DESCRIPTION
## Summary
- ensure GET `/products` populates and normalizes desire values
- update product PATCH/PUT to retain AI-derived desires when missing
- adjust tests for new desire serialization behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4b8c5006883288a70e156ffa76f89