### PR TITLE
Fix desire persistence in product API

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -231,8 +231,9 @@ body.dark pre { background:#2e315f; }
 <script src="/static/js/winner_score.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script type="module">
-import { fetchJson } from "/static/js/net.js";
+import * as api from "/static/js/net.js";
 import * as groupsService from "/static/js/groups-service.js";
+const { fetchJson } = api;
 window.fetchJson = fetchJson;
 window.groupsService = groupsService;
 const IMPORT_TASK_LS_KEY = 'last_import_task';
@@ -810,13 +811,18 @@ function renderTable() {
       if (col.maxWidth) td.style.maxWidth = col.maxWidth + 'px';
       if (col.align) td.style.textAlign = col.align;
       let value = '';
-      if (metricKeys.includes(key)) {
+      if (key === 'desire') {
+        // La columna textual "Desire" NUNCA debe tratarse como métrica
+        value = typeof item.desire === 'string' ? item.desire.trim() : (item.desire ?? '');
+      } else if (metricKeys.includes(key)) {
         value = item.winner_score_breakdown && item.winner_score_breakdown.scores ? item.winner_score_breakdown.scores[key] : '';
         if (item.winner_score_breakdown && item.winner_score_breakdown.justifications) {
           const j = item.winner_score_breakdown.justifications[key];
           if (j) td.title = 'Justificación: ' + j;
         }
-      } else if (['id','name','category','price','image_url','winner_score','desire','desire_magnitude','awareness_level','competition_level','date_range'].includes(key)) {
+      } else if (key === 'desire_magnitude') {
+        value = item.desire_magnitude;
+      } else if (['id','name','category','price','image_url','winner_score','awareness_level','competition_level','date_range'].includes(key)) {
         value = item[key];
       } else {
         value = item.extras ? item.extras[key] : '';
@@ -887,7 +893,7 @@ function renderTable() {
         td.title = fullVal;
         input.addEventListener('blur', async () => {
           const val = input.value.trim() || null;
-          try { await fetchJson(`/products/${item.id}`, {method:'PUT', body: JSON.stringify({desire: val})}); } catch(e) {}
+          try { await api.updateProductField(item.id, { desire: val }); } catch(e) {}
           item.desire = val;
           ecAutoFitColumns(gridRoot);
         });
@@ -903,7 +909,7 @@ function renderTable() {
         });
         select.addEventListener('change', async () => {
           const val = select.value || null;
-          try { await fetchJson(`/products/${item.id}`, {method:'PUT', body: JSON.stringify({desire_magnitude: val})}); } catch(e) {}
+          try { await api.updateProductField(item.id, { desire_magnitude: val }); } catch(e) {}
           item.desire_magnitude = val;
         });
         td.appendChild(select);
@@ -918,7 +924,7 @@ function renderTable() {
         });
         select.addEventListener('change', async () => {
           const val = select.value || null;
-          try { await fetchJson(`/products/${item.id}`, {method:'PUT', body: JSON.stringify({awareness_level: val})}); } catch(e) {}
+          try { await api.updateProductField(item.id, { awareness_level: val }); } catch(e) {}
           item.awareness_level = val;
         });
         td.appendChild(select);
@@ -933,7 +939,7 @@ function renderTable() {
         });
         select.addEventListener('change', async () => {
           const val = select.value || null;
-          try { await fetchJson(`/products/${item.id}`, {method:'PUT', body: JSON.stringify({competition_level: val})}); } catch(e) {}
+          try { await api.updateProductField(item.id, { competition_level: val }); } catch(e) {}
           item.competition_level = val;
         });
         td.appendChild(select);

--- a/product_research_app/static/js/net.js
+++ b/product_research_app/static/js/net.js
@@ -32,3 +32,10 @@ export async function fetchJson(url, opts, timeoutMs = 25000) {
     clearTimeout(id);
   }
 }
+
+export async function updateProductField(id, data, timeoutMs = 25000) {
+  return fetchJson(`/api/products/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  }, timeoutMs);
+}

--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -296,7 +296,7 @@ def test_desire_serialization_and_logging(tmp_path, monkeypatch):
     assert isinstance(p1["price"], (int, float))
     assert p2["desire"] == "Extra"
     assert p2["extras"].get("desire") == "Extra"
-    assert p3["desire"] == ""
+    assert p3["desire"] is None
     log_text = web_app.LOG_PATH.read_text()
     assert f"desire_missing=true" in log_text and f"product={pid3}" in log_text
 

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -679,7 +679,10 @@ class RequestHandler(BaseHTTPRequestHandler):
                 if dr is None:
                     dr = extra_dict.get("date_range")
                 price_val = rget(p, "price")
-                desire_val = _ensure_desire(p, extra_dict)
+                desire_db = rget(p, "desire")
+                if desire_db in (None, ""):
+                    desire_db = _ensure_desire(p, extra_dict)
+                desire_val = (desire_db or "").strip() or None
                 row = {
                     "id": rget(p, "id"),
                     "name": rget(p, "name"),
@@ -1286,7 +1289,10 @@ class RequestHandler(BaseHTTPRequestHandler):
                     extra_dict = json.loads(rget(product, "extra") or "{}")
                 except Exception:
                     extra_dict = {}
-                product["desire"] = _ensure_desire(product, extra_dict)
+                desire_db = rget(product, "desire")
+                if desire_db in (None, ""):
+                    desire_db = _ensure_desire(product, extra_dict)
+                product["desire"] = (desire_db or "").strip() or None
                 self._set_json()
                 self.wfile.write(json.dumps(product).encode('utf-8'))
             else:


### PR DESCRIPTION
## Summary
- ensure GET `/products` populates and normalizes desire values
- update product PATCH/PUT to retain AI-derived desires when missing
- adjust tests for new desire serialization behavior
- prevent frontend desire column from treating text as a metric and send updates via unified PATCH helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4b8c5006883288a70e156ffa76f89