### PR TITLE
Sanitize winner score weights

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -183,9 +183,6 @@ SCORING_DEFAULT_WEIGHTS: Dict[str, float] = {
     "units_sold": 1.0,
     "revenue": 1.0,
     "review_count": 1.0,
-    "image_count": 1.0,
-    "shipping_days": 1.0,
-    "profit_margin": 1.0,
     "desire": 1.0,
     "competition": 1.0,
 }
@@ -196,22 +193,7 @@ def get_weights() -> Dict[str, float]:
 
     from .services import winner_score  # lazy import to avoid circular
 
-    stored = winner_score.load_winner_weights()
-    weights: Dict[str, float] = {}
-    total = 0.0
-    for key, default in SCORING_DEFAULT_WEIGHTS.items():
-        try:
-            val = float(stored.get(key, default))
-            if val < 0:
-                val = 0.0
-        except Exception:
-            val = default
-        weights[key] = val
-        total += val
-    if total <= 0:
-        total = sum(SCORING_DEFAULT_WEIGHTS.values())
-        return {k: v / total for k, v in SCORING_DEFAULT_WEIGHTS.items()}
-    return {k: v / total for k, v in weights.items()}
+    return winner_score.load_winner_weights()
 
 
 def set_weights(weights: Dict[str, float]) -> None:
@@ -219,7 +201,7 @@ def set_weights(weights: Dict[str, float]) -> None:
 
     from .services import winner_score  # lazy import
 
-    winner_score.set_winner_weights(weights)
+    winner_score.set_winner_weights(winner_score.sanitize_weights(weights))
 
 
 def update_weight(key: str, value: float) -> None:

--- a/product_research_app/gpt.py
+++ b/product_research_app/gpt.py
@@ -910,10 +910,7 @@ def evaluate_winner_score(
         "revenue",
         "desire",
         "competition",
-        "profit_margin",
         "review_count",
-        "image_count",
-        "shipping_days",
     ]
     missing = [k for k in required if metrics.get(k) is None]
     if missing:

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -475,8 +475,8 @@ function preprocessProducts(list){
   dupMap.forEach(arr => { if (arr.length > 1) arr.forEach(it => it.isDuplicate = true); });
 }
 
-const WEIGHT_KEYS = ['price','rating','units_sold','revenue','desire','competition','review_count','image_count','profit_margin','shipping_days'];
-const ALIASES = { unitsSold:'units_sold', orders:'units_sold', reviews:'review_count', imgs:'image_count', ship_days:'shipping_days' };
+const WEIGHT_KEYS = ['price','rating','units_sold','revenue','desire','competition','review_count'];
+const ALIASES = { unitsSold:'units_sold', orders:'units_sold', reviews:'review_count' };
 function normalizeKey(k){ return ALIASES[k] || k; }
 const metricDefs = [
   {key:'price',label:'Price'},
@@ -485,10 +485,7 @@ const metricDefs = [
   {key:'revenue',label:'Revenue'},
   {key:'desire',label:'Desire'},
   {key:'competition',label:'Competition'},
-  {key:'review_count',label:'Review Count'},
-  {key:'image_count',label:'Image Count'},
-  {key:'profit_margin',label:'Profit Margin'},
-  {key:'shipping_days',label:'Shipping Days'}
+  {key:'review_count',label:'Review Count'}
 ];
 const metricKeys = metricDefs.map(m=>m.key);
 let weightValues = {};

--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from product_research_app import web_app, database, config
+from product_research_app.services import winner_score
 from product_research_app.utils.db import row_to_dict
 
 def setup_env(tmp_path, monkeypatch):
@@ -609,7 +610,7 @@ def test_logging_and_explain_endpoint(tmp_path, monkeypatch):
 
     log_text = web_app.LOG_PATH.read_text()
     assert "review_count" in log_text
-    assert "effective_weights={'rating': 1.0}" in log_text
+    assert "effective_weights={'price': 0.0, 'rating': 1.0" in log_text
 
     parsed = urlparse(f"/api/winner-score/explain?ids={pid}")
 
@@ -626,7 +627,8 @@ def test_logging_and_explain_endpoint(tmp_path, monkeypatch):
     info = resp[str(pid)]
     assert "rating" in info["present"]
     assert "review_count" in info["missing"]
-    assert info["effective_weights"] == {"rating": 1.0}
+    expected = {k: (1.0 if k == "rating" else 0.0) for k in winner_score.ALLOWED_FIELDS}
+    assert info["effective_weights"] == expected
 
 
 def test_weights_eff_stable_when_touching_missing_metric(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- restrict Winner Score to seven core metrics and normalize weights via `sanitize_weights`
- ignore legacy weight keys in configuration and AI weight helpers
- drop deprecated metrics from UI and GPT helpers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c546f0d6188328bd85d82601060d49