### PR TITLE
feat: replace review count with oldness metric

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -39,6 +39,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "aiImageCostMaxUSD": 0.02,
     "weightsVersion": 0,
     "weightsUpdatedAt": 0,
+    "oldness_preference": "newer",
 }
 
 
@@ -182,9 +183,9 @@ SCORING_DEFAULT_WEIGHTS: Dict[str, float] = {
     "rating": 1.0,
     "units_sold": 1.0,
     "revenue": 1.0,
-    "review_count": 1.0,
     "desire": 1.0,
     "competition": 1.0,
+    "oldness": 1.0,
 }
 
 

--- a/product_research_app/gpt.py
+++ b/product_research_app/gpt.py
@@ -910,7 +910,7 @@ def evaluate_winner_score(
         "revenue",
         "desire",
         "competition",
-        "review_count",
+        "oldness",
     ]
     missing = [k for k in required if metrics.get(k) is None]
     if missing:

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -475,6 +475,26 @@ function preprocessProducts(list){
   dupMap.forEach(arr => { if (arr.length > 1) arr.forEach(it => it.isDuplicate = true); });
 }
 
+function computeOldnessDays(p){
+  const dr = p.date_range || p['Date Range'];
+  let start=null;
+  if(typeof dr==='string'){
+    const m=dr.match(/(\d{4}-\d{2}-\d{2})\s*~\s*(\d{4}-\d{2}-\d{2})/);
+    if(m) start=new Date(m[1]);
+  }
+  if(!start){
+    const keys=['first_seen','created_at','createdAt'];
+    for(const k of keys){
+      const v=p[k];
+      if(v){ try{ start=new Date(String(v).slice(0,10)); break; }catch(e){} }
+    }
+  }
+  if(!start) return 0;
+  const today=new Date();
+  const diff=Math.floor((today-start)/(1000*60*60*24));
+  return diff>0?diff:0;
+}
+
 const WEIGHT_FIELDS = [
   { key: 'price',        label: 'Price' },
   { key: 'rating',       label: 'Rating' },
@@ -482,10 +502,10 @@ const WEIGHT_FIELDS = [
   { key: 'revenue',      label: 'Revenue' },
   { key: 'desire',       label: 'Desire' },
   { key: 'competition',  label: 'Competition' },
-  { key: 'review_count', label: 'Review Count' }
+  { key: 'oldness',      label: 'Oldness' }
 ];
 const WEIGHT_KEYS = WEIGHT_FIELDS.map(f=>f.key);
-const ALIASES = { unitsSold:'units_sold', orders:'units_sold', reviews:'review_count' };
+const ALIASES = { unitsSold:'units_sold', orders:'units_sold' };
 function normalizeKey(k){ return ALIASES[k] || k; }
 const metricDefs = WEIGHT_FIELDS;
 const metricKeys = WEIGHT_KEYS;
@@ -587,7 +607,7 @@ async function adjustWeightsAI(){
       revenue:p.revenue||(p.extras&&p.extras['Revenue($)'])||0,
       desire:p.desire_magnitude,
       competition:p.competition_level,
-      review_count:p.review_count||(p.extras&&p.extras.reviews)||0
+      oldness:computeOldnessDays(p)
     }));
     let tokenEstimate=JSON.stringify(payload).length/4;
     const maxTokens=0.30/0.002*1000;
@@ -602,13 +622,13 @@ async function adjustWeightsAI(){
         revenue:p.revenue||(p.extras&&p.extras['Revenue($)'])||0,
         desire:p.desire_magnitude,
         competition:p.competition_level,
-        review_count:p.review_count||(p.extras&&p.extras.reviews)||0
+        oldness:computeOldnessDays(p)
       }));
       tokenEstimate=JSON.stringify(payload).length/4;
     }
     const cost=tokenEstimate/1000*0.002;
     toast.info(`Analizando ${sample.length} productos (~$${cost.toFixed(2)})`);
-    const instruction='Devuelve SOLO un JSON plano con pesos 0-100 para estas 7 claves exactas, sin texto adicional:\n["price","rating","units_sold","revenue","desire","competition","review_count"]';
+    const instruction='Devuelve SOLO un JSON plano con pesos 0-100 para estas 7 claves exactas, sin texto adicional:\n["price","rating","units_sold","revenue","desire","competition","oldness"]';
     const prompt=`Basado en estos productos ${JSON.stringify(payload)}\n${instruction}`;
     let res=await fetch('/custom_gpt',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt,response_format:{type:'json_object'}})});
     if(!res.ok){

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -2590,6 +2590,8 @@ class RequestHandler(BaseHTTPRequestHandler):
         else:
             rows = database.list_products(conn)
 
+        winner_calc.prepare_oldness_bounds(rows)
+
         data: Dict[str, Any] = {}
         for row in rows:
             res = winner_calc.compute_winner_score_v2(row, weights)


### PR DESCRIPTION
## Summary
- switch Winner Score feature set from review_count to oldness
- compute product age from available date fields and weight it with configurable preference
- expose oldness preference default in config and update tests/UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c54bb46d68832886233ab344e80b86