### PR TITLE
feat: support continuous oldness preference

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -39,7 +39,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "aiImageCostMaxUSD": 0.02,
     "weightsVersion": 0,
     "weightsUpdatedAt": 0,
-    "oldness_preference": "newer",
+    "oldness_preference_pct": 0,
 }
 
 
@@ -73,6 +73,11 @@ def load_config() -> Dict[str, Any]:
             changed = True
     if "weights_v2" in data:
         data.pop("weights_v2", None)
+        changed = True
+    if "oldness_preference_pct" not in data and "oldness_preference" in data:
+        val = str(data.get("oldness_preference") or "newer").lower()
+        data["oldness_preference_pct"] = 100 if val == "older" else 0
+        data.pop("oldness_preference", None)
         changed = True
     if _merge_defaults(data, DEFAULT_CONFIG):
         changed = True

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -105,15 +105,9 @@ body.dark pre { background:#2e315f; }
   <strong>Ponderaciones Winner Score</strong>
   <ul id="weightsList" style="list-style:none; margin-top:8px; padding:0;"></ul>
   <label class="field-label">Preferencia de Oldness</label>
-  <div class="segmented">
-    <label>
-      <input type="radio" name="oldness_preference" value="newer">
-      Prefiero recientes
-    </label>
-    <label>
-      <input type="radio" name="oldness_preference" value="older">
-      Prefiero antiguos
-    </label>
+  <div style="display:flex; align-items:center; gap:6px;">
+    <input type="range" id="oldnessPref" min="0" max="100" value="0" />
+    <span id="oldnessPrefLabel">0</span>
   </div>
   <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:6px;">
     <button id="resetWeights">Reset</button>
@@ -525,7 +519,7 @@ const metricDefs = WEIGHT_FIELDS;
 const metricKeys = WEIGHT_KEYS;
 let weightValues = {};
 let weightOrder = [];
-let userConfig = { oldness_preference: 'newer' };
+let userConfig = { oldness_preference_pct: 0 };
 
 function debounce(fn, ms=150){
   let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args), ms); };
@@ -731,20 +725,27 @@ async function loadConfig() {
     if (input) input.value = '';
     if (saveBtn) saveBtn.disabled = true;
   }
-  userConfig.oldness_preference = cfg.oldness_preference || 'newer';
-  const prefEls = document.querySelectorAll('input[name="oldness_preference"]');
-  prefEls.forEach(el => {
-    el.checked = el.value === userConfig.oldness_preference;
-    el.addEventListener('change', e => {
-      const val = e.target.value;
-      userConfig.oldness_preference = val;
+  userConfig.oldness_preference_pct = Number(cfg.oldness_preference_pct || 0);
+  const prefRange = document.getElementById('oldnessPref');
+  const prefLabel = document.getElementById('oldnessPrefLabel');
+  if (prefRange && prefLabel) {
+    const update = val => {
+      prefLabel.textContent = String(val);
       fetch('/setconfig', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({ oldness_preference: val })
+        body: JSON.stringify({ oldness_preference_pct: val })
       });
+    };
+    prefRange.value = userConfig.oldness_preference_pct;
+    prefLabel.textContent = String(userConfig.oldness_preference_pct);
+    prefRange.addEventListener('input', e => {
+      const val = Math.round(Number(e.target.value) || 0);
+      userConfig.oldness_preference_pct = val;
+      prefRange.value = val;
+      update(val);
     });
-  });
+  }
   await loadWeights();
 }
 


### PR DESCRIPTION
## Summary
- add `oldness_preference_pct` slider support with fallback to legacy radio option
- mix old/new preference into oldness normalization for winner score
- expose `oldness_preference_pct` through config endpoints and UI

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c54f33ffa0832886c75c2e5fdd7ca6