### PR TITLE
feat: add slider extremes and continuous oldness control

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -39,7 +39,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "aiImageCostMaxUSD": 0.02,
     "weightsVersion": 0,
     "weightsUpdatedAt": 0,
-    "oldness_preference": "newer",
+    "oldness_preference_pct": 50,
 }
 
 
@@ -73,6 +73,11 @@ def load_config() -> Dict[str, Any]:
             changed = True
     if "weights_v2" in data:
         data.pop("weights_v2", None)
+        changed = True
+    if "oldness_preference_pct" not in data and "oldness_preference" in data:
+        val = str(data.get("oldness_preference") or "newer").lower()
+        data["oldness_preference_pct"] = 100 if val == "older" else 0
+        data.pop("oldness_preference", None)
         changed = True
     if _merge_defaults(data, DEFAULT_CONFIG):
         changed = True

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -653,6 +653,8 @@ body.dark .ws-slider{ accent-color:#7a53d6; }
 .ws-slider::-webkit-slider-thumb{ width:20px; height:20px; border-radius:50%; cursor:pointer; }
 .ws-slider::-moz-range-thumb{ width:20px; height:20px; border-radius:50%; cursor:pointer; }
 .ws-value{ width:40px; text-align:right; }
+.slider-row { margin-bottom:16px; }
+.slider-extremes { display:flex; justify-content:space-between; font-size:12px; opacity:.8; margin-top:4px; }
 
 /* Cabecera y celdas de la columna Desire */
 th.col-desire, td.col-desire { width: 360px; max-width: 360px; }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -105,15 +105,12 @@ body.dark pre { background:#2e315f; }
   <strong>Ponderaciones Winner Score</strong>
   <ul id="weightsList" style="list-style:none; margin-top:8px; padding:0;"></ul>
   <label class="field-label">Preferencia de Oldness</label>
-  <div class="segmented">
-    <label>
-      <input type="radio" name="oldness_preference" value="newer">
-      Prefiero recientes
-    </label>
-    <label>
-      <input type="radio" name="oldness_preference" value="older">
-      Prefiero antiguos
-    </label>
+  <div class="slider-row">
+    <input type="range" id="oldnessPref" min="0" max="100" step="1" value="50" />
+    <div class="slider-extremes">
+      <span>Más reciente</span>
+      <span>Más antiguo</span>
+    </div>
   </div>
   <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:6px;">
     <button id="resetWeights">Reset</button>
@@ -518,6 +515,15 @@ const WEIGHT_FIELDS = [
   { key: 'competition',  label: 'Competition' },
   { key: 'oldness',      label: 'Oldness (antigüedad)' }
 ];
+const EXTREMES = {
+  price:       { left: 'Más barato',        right: 'Más caro' },
+  rating:      { left: 'Peor rating',       right: 'Mejor rating' },
+  units_sold:  { left: 'Menos ventas',      right: 'Más ventas' },
+  revenue:     { left: 'Menores ingresos',  right: 'Mayores ingresos' },
+  desire:      { left: 'Menor deseo',       right: 'Mayor deseo' },
+  competition: { left: 'Menor competencia', right: 'Mayor competencia' },
+  oldness:     { left: 'Más reciente',      right: 'Más antiguo' },
+};
 const WEIGHT_KEYS = WEIGHT_FIELDS.map(f=>f.key);
 const ALIASES = { unitsSold:'units_sold', orders:'units_sold' };
 function normalizeKey(k){ return ALIASES[k] || k; }
@@ -525,7 +531,7 @@ const metricDefs = WEIGHT_FIELDS;
 const metricKeys = WEIGHT_KEYS;
 let weightValues = {};
 let weightOrder = [];
-let userConfig = { oldness_preference: 'newer' };
+let userConfig = { oldness_preference_pct: 50 };
 
 function debounce(fn, ms=150){
   let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args), ms); };
@@ -567,7 +573,7 @@ function renderWeights(){
     const li=document.createElement('li');
     li.className='metric-row';
     li.dataset.key=key;
-    li.innerHTML=`<span class="ws-handle">≡</span><span class="ws-name">${def.label}</span><div class="ws-slider-wrap"><input type="range" name="${key}" min="0" max="100" step="1" value="${Math.round(weightValues[key]||0)}" class="ws-slider"><span class="ws-value"><span class="weight-value"></span></span></div><span class="ws-status"></span>`;
+    li.innerHTML=`<span class="ws-handle">≡</span><span class="ws-name">${def.label}</span><div class="ws-slider-wrap"><div class="slider-row"><input type="range" name="${key}" min="0" max="100" step="1" value="${Math.round(weightValues[key]||0)}" class="ws-slider"><span class="ws-value"><span class="weight-value"></span></span><div class="slider-extremes"><span class="extreme-left">${EXTREMES[key].left}</span><span class="extreme-right">${EXTREMES[key].right}</span></div></div></div><span class="ws-status"></span>`;
     const range=li.querySelector('.ws-slider');
     range.addEventListener('input',e=>{
       const k=normalizeKey(e.target.name);
@@ -589,6 +595,12 @@ function resetWeights(){
   weightOrder=defaultOrder();
   renderWeights();
   for(const k in weightValues){ saveWeightDebounced(k, weightValues[k]); }
+  const prefRange=document.getElementById('oldnessPref');
+  if(prefRange){
+    prefRange.value=50;
+    userConfig.oldness_preference_pct=50;
+    fetch('/setconfig',{method:'POST',headers:{'Content-Type':'application/json'},body: JSON.stringify({ oldness_preference_pct: 50 })});
+  }
 }
 
 function stratifiedSample(list, n){
@@ -731,20 +743,24 @@ async function loadConfig() {
     if (input) input.value = '';
     if (saveBtn) saveBtn.disabled = true;
   }
-  userConfig.oldness_preference = cfg.oldness_preference || 'newer';
-  const prefEls = document.querySelectorAll('input[name="oldness_preference"]');
-  prefEls.forEach(el => {
-    el.checked = el.value === userConfig.oldness_preference;
-    el.addEventListener('change', e => {
-      const val = e.target.value;
-      userConfig.oldness_preference = val;
+  userConfig.oldness_preference_pct = Number(cfg.oldness_preference_pct ?? 50);
+  const prefRange = document.getElementById('oldnessPref');
+  if (prefRange) {
+    const update = val => {
       fetch('/setconfig', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({ oldness_preference: val })
+        body: JSON.stringify({ oldness_preference_pct: val })
       });
+    };
+    prefRange.value = userConfig.oldness_preference_pct;
+    prefRange.addEventListener('input', e => {
+      const val = Math.round(Number(e.target.value) || 0);
+      userConfig.oldness_preference_pct = val;
+      prefRange.value = val;
+      update(val);
     });
-  });
+  }
   await loadWeights();
 }
 

--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -371,7 +371,7 @@ def test_patch_winner_weights_persists(tmp_path, monkeypatch):
     data = winner_score.load_winner_weights_raw()
     assert data.get("weights", {}).get("rating") == 0.25
 
-def test_config_oldness_preference_roundtrip(tmp_path, monkeypatch):
+def test_config_oldness_preference_pct_roundtrip(tmp_path, monkeypatch):
     setup_env(tmp_path, monkeypatch)
 
     class DummyGet:
@@ -387,9 +387,9 @@ def test_config_oldness_preference_roundtrip(tmp_path, monkeypatch):
     g = DummyGet()
     web_app.RequestHandler.do_GET(g)
     resp = json.loads(g.wfile.getvalue().decode("utf-8"))
-    assert resp.get("oldness_preference") == "newer"
+    assert resp.get("oldness_preference_pct") == 50
 
-    body = json.dumps({"oldness_preference": "older"})
+    body = json.dumps({"oldness_preference_pct": 100})
 
     class DummyPost:
         def __init__(self, body):
@@ -404,7 +404,46 @@ def test_config_oldness_preference_roundtrip(tmp_path, monkeypatch):
     p = DummyPost(body)
     web_app.RequestHandler.handle_setconfig(p)
     assert p.status == 200
-    assert config.load_config().get("oldness_preference") == "older"
+    assert config.load_config().get("oldness_preference_pct") == 100
+
+    # legacy field still accepted
+    body2 = json.dumps({"oldness_preference": "newer"})
+    p2 = DummyPost(body2)
+    web_app.RequestHandler.handle_setconfig(p2)
+    assert config.load_config().get("oldness_preference_pct") == 0
+
+
+def test_oldness_preference_pct_affects_score(tmp_path, monkeypatch):
+    conn = setup_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(web_app, "ensure_db", lambda: conn)
+
+    pid = database.insert_product(
+        conn,
+        name="O",
+        description="",
+        category="",
+        price=None,
+        currency=None,
+        image_url="",
+        source="",
+        extra={"date_range": "2020-01-01~2020-02-01"},
+        product_id=1,
+    )
+
+    row = database.get_product(conn, pid)
+    winner_score.prepare_oldness_bounds([row])
+    weights = {k: 1.0 for k in winner_score.ALLOWED_FIELDS}
+
+    cfg = config.load_config()
+    cfg["oldness_preference_pct"] = 0
+    config.save_config(cfg)
+    score_new = winner_score.compute_winner_score_v2(row, weights)["score"]
+
+    cfg["oldness_preference_pct"] = 100
+    config.save_config(cfg)
+    score_old = winner_score.compute_winner_score_v2(row, weights)["score"]
+
+    assert score_new != score_old
 
 def test_get_endpoints_return_json(tmp_path, monkeypatch):
     setup_env(tmp_path, monkeypatch)

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -719,7 +719,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                 "model": cfg.get("model", "gpt-4o"),
                 "weights": config.get_weights(),
                 "has_api_key": bool(key),
-                "oldness_preference": cfg.get("oldness_preference", "newer"),
+                "oldness_preference_pct": int(cfg.get("oldness_preference_pct", 50)),
             }
             if key:
                 data["api_key_last4"] = key[-4:]
@@ -2160,10 +2160,16 @@ class RequestHandler(BaseHTTPRequestHandler):
             cfg['weights'] = winner_calc.sanitize_weights(data['weights'])
         if 'autoFillIAOnImport' in data:
             cfg['autoFillIAOnImport'] = bool(data['autoFillIAOnImport'])
+        if 'oldness_preference_pct' in data:
+            try:
+                val = int(float(data.get('oldness_preference_pct')))
+                cfg['oldness_preference_pct'] = max(0, min(100, val))
+            except Exception:
+                pass
         if 'oldness_preference' in data:
             pref = str(data.get('oldness_preference', '')).strip().lower()
-            if pref in ("older", "newer"):
-                cfg['oldness_preference'] = pref
+            cfg['oldness_preference_pct'] = 100 if pref == 'older' else 0
+            cfg.pop('oldness_preference', None)
         config.save_config(cfg)
         self._set_json()
         self.wfile.write(json.dumps({"status": "ok"}).encode('utf-8'))


### PR DESCRIPTION
## Summary
- show left/right labels for every weight slider
- replace oldness preference radios with a 0–100 slider defaulting to neutral 50
- expose `oldness_preference_pct` with new default through config API

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c54f33ffa0832886c75c2e5fdd7ca6