### PR TITLE
Normalize oldness using global min-max and preference

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -39,7 +39,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "aiImageCostMaxUSD": 0.02,
     "weightsVersion": 0,
     "weightsUpdatedAt": 0,
-    "oldness_preference": "newer",
+    "oldness_preference_pct": 50,
 }
 
 
@@ -75,6 +75,14 @@ def load_config() -> Dict[str, Any]:
         data.pop("weights_v2", None)
         changed = True
     if _merge_defaults(data, DEFAULT_CONFIG):
+        changed = True
+    if "oldness_preference_pct" not in data and isinstance(data.get("oldness_preference"), str):
+        pref = data.get("oldness_preference", "newer").lower()
+        if pref == "older":
+            data["oldness_preference_pct"] = 100
+        elif pref == "newer":
+            data["oldness_preference_pct"] = 0
+        data.pop("oldness_preference", None)
         changed = True
     if changed:
         save_config(data)

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -652,6 +652,7 @@ th.ec-col-competition,   td.ec-col-competition   { width: var(--ec-w-competition
   margin-bottom: 16px;
   width: 100%;
 }
+.oldness-pref-row { margin-top: -6px; }
 
 /* Icono drag y valor a la derecha consistentes */
 .weight-drag { text-align: center; opacity: .9; cursor: grab; }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -546,6 +546,14 @@ function saveWeightDebounced(key, value){
   saveFns[key](value);
 }
 
+const saveOldnessPref = debounce(val=>{
+  fetch('/api/config', {
+    method:'PUT',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({ oldness_preference_pct: val })
+  });
+},300);
+
 function updateSliderLabel(el) {
   const num = Math.round(Number(el.value) || 0);
   el.closest('.weight-row')?.querySelector('.weight-value')?.replaceChildren(document.createTextNode(String(num)));
@@ -572,8 +580,24 @@ function renderWeights(){
     });
     ['mousedown','touchstart'].forEach(ev=>{ range.addEventListener(ev,e=>{ e.stopPropagation(); }); });
     list.appendChild(li);
+    if(key==='oldness'){
+      const pref=document.createElement('li');
+      const val=userConfig.oldness_preference_pct ?? 50;
+      pref.className='weight-row oldness-pref-row';
+      pref.innerHTML=`<div class="weight-drag" aria-hidden></div><div class="weight-slider"><input class="weight-range" type="range" min="0" max="100" step="1" value="${val}"/><div class="slider-extremes"><span>Más reciente</span><span>Más antiguo</span></div></div><div class="weight-value">${val}</div>`;
+      const prange=pref.querySelector('.weight-range');
+      prange.addEventListener('input',e=>{
+        const v=Math.round(parseFloat(e.target.value));
+        e.target.value=v;
+        userConfig.oldness_preference_pct=v;
+        updateSliderLabel(prange);
+        saveOldnessPref(v);
+      });
+      ['mousedown','touchstart'].forEach(ev=>{ prange.addEventListener(ev,e=>{ e.stopPropagation(); }); });
+      list.appendChild(pref);
+    }
   });
-  Sortable.create(list,{ handle:'.weight-drag', animation:150, onEnd:()=>{ weightOrder=Array.from(list.children).map(li=>li.dataset.key); }});
+  Sortable.create(list,{ handle:'.weight-drag', animation:150, onEnd:()=>{ weightOrder=Array.from(list.children).map(li=>li.dataset.key).filter(Boolean); }});
 }
 
 function resetWeights(){
@@ -687,6 +711,13 @@ async function loadWeights(){
       if(metricKeys.includes(k)) weightValues[k] = Math.round(weights[k]);
     }
     weightOrder = defaultOrder();
+    try{
+      const prefRes = await fetch('/api/config');
+      const cfg = await prefRes.json();
+      userConfig.oldness_preference_pct = Number(cfg.oldness_preference_pct ?? 50);
+    }catch(_err){
+      userConfig.oldness_preference_pct = 50;
+    }
     renderWeights();
     document.getElementById('resetWeights').onclick = resetWeights;
     const aiBtn=document.getElementById('aiWeights');

--- a/product_research_app/static/js/types.ts
+++ b/product_research_app/static/js/types.ts
@@ -1,0 +1,4 @@
+export type AppConfig = {
+  weights: Record<string, number>;
+  oldness_preference_pct: number; // 0..100
+};

--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -376,7 +376,7 @@ def test_config_oldness_preference_roundtrip(tmp_path, monkeypatch):
 
     class DummyGet:
         def __init__(self):
-            self.path = "/config"
+            self.path = "/api/config"
             self.headers = {}
             self.rfile = io.BytesIO()
             self.wfile = io.BytesIO()
@@ -387,13 +387,13 @@ def test_config_oldness_preference_roundtrip(tmp_path, monkeypatch):
     g = DummyGet()
     web_app.RequestHandler.do_GET(g)
     resp = json.loads(g.wfile.getvalue().decode("utf-8"))
-    assert resp.get("oldness_preference") == "newer"
+    assert resp.get("oldness_preference_pct") == 50
 
-    body = json.dumps({"oldness_preference": "older"})
+    body = json.dumps({"oldness_preference_pct": 70})
 
-    class DummyPost:
+    class DummyPut:
         def __init__(self, body):
-            self.path = "/setconfig"
+            self.path = "/api/config"
             self.headers = {"Content-Length": str(len(body))}
             self.rfile = io.BytesIO(body.encode("utf-8"))
             self.wfile = io.BytesIO()
@@ -401,10 +401,10 @@ def test_config_oldness_preference_roundtrip(tmp_path, monkeypatch):
         def _set_json(self, code=200):
             self.status = code
 
-    p = DummyPost(body)
-    web_app.RequestHandler.handle_setconfig(p)
+    p = DummyPut(body)
+    web_app.RequestHandler.do_PUT(p)
     assert p.status == 200
-    assert config.load_config().get("oldness_preference") == "older"
+    assert config.load_config().get("oldness_preference_pct") == 70
 
 def test_get_endpoints_return_json(tmp_path, monkeypatch):
     setup_env(tmp_path, monkeypatch)


### PR DESCRIPTION
## Summary
- add utilities to parse dates, min-max normalize and compute oldness days
- compute dataset-wide normalization and apply user preference for old vs new products
- ensure weight scaling only among available metrics
- expose oldness preference slider and API to persist `oldness_preference_pct`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c55a9e5f388328908d93bc36068a4d