### PR TITLE
Add SQLite-backed winner weight configuration and API

### DIFF
--- a/product_research_app/__main__.py
+++ b/product_research_app/__main__.py
@@ -1,0 +1,7 @@
+from product_research_app.services.config import init_app_config
+from product_research_app.api import app
+
+init_app_config()
+
+if __name__ == "__main__":
+    app.run()

--- a/product_research_app/api/__init__.py
+++ b/product_research_app/api/__init__.py
@@ -1,0 +1,5 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+from . import config  # noqa: E402,F401

--- a/product_research_app/api/config.py
+++ b/product_research_app/api/config.py
@@ -1,0 +1,16 @@
+from flask import request, jsonify
+from . import app
+
+# GET /api/config/weights
+@app.route("/api/config/weights", methods=["GET"])
+def api_get_weights():
+    from product_research_app.services.config import get_winner_weights
+    return jsonify({"weights": get_winner_weights()})
+
+# PUT /api/config/weights
+@app.route("/api/config/weights", methods=["PUT"])
+def api_put_weights():
+    from product_research_app.services.config import set_winner_weights
+    data = request.get_json(force=True) or {}
+    saved = set_winner_weights(data.get("weights", {}))
+    return jsonify({"weights": saved})

--- a/product_research_app/services/config.py
+++ b/product_research_app/services/config.py
@@ -1,0 +1,65 @@
+import json, sqlite3, time
+from pathlib import Path
+
+ALLOWED_FIELDS = ("price","rating","units_sold","revenue","desire","competition","oldness")
+DEFAULT_WEIGHTS = {k: 50 for k in ALLOWED_FIELDS}  # 50 = neutro
+
+DB_PATH = Path(__file__).resolve().parents[1] / "data.sqlite3"
+
+def _conn():
+    cx = sqlite3.connect(DB_PATH)
+    cx.execute("PRAGMA journal_mode=WAL;")
+    return cx
+
+def init_app_config():
+    with _conn() as cx:
+        cx.execute("""CREATE TABLE IF NOT EXISTS app_config (
+            key TEXT PRIMARY KEY,
+            json_value TEXT NOT NULL,
+            updated_at INTEGER NOT NULL
+        )""")
+        row = cx.execute(
+            "SELECT 1 FROM app_config WHERE key='winner_weights_v2'"
+        ).fetchone()
+        if not row:
+            cx.execute(
+                "INSERT INTO app_config(key,json_value,updated_at) VALUES (?,?,?)",
+                ("winner_weights_v2", json.dumps(DEFAULT_WEIGHTS), int(time.time()))
+            )
+        cx.commit()
+
+def _sanitize_weights(data: dict) -> dict:
+    out = {}
+    for k in ALLOWED_FIELDS:
+        try:
+            v = int(float(data.get(k, DEFAULT_WEIGHTS[k])))
+        except Exception:
+            v = DEFAULT_WEIGHTS[k]
+        out[k] = max(0, min(100, v))
+    return out
+
+def get_winner_weights() -> dict:
+    with _conn() as cx:
+        row = cx.execute(
+            "SELECT json_value FROM app_config WHERE key='winner_weights_v2'"
+        ).fetchone()
+        if not row:
+            return DEFAULT_WEIGHTS.copy()
+        return _sanitize_weights(json.loads(row[0]))
+
+def set_winner_weights(weights: dict) -> dict:
+    current = get_winner_weights()
+    for k in ALLOWED_FIELDS:
+        if k in weights:
+            try:
+                v = int(float(weights[k]))
+            except Exception:
+                continue
+            current[k] = max(0, min(100, v))
+    with _conn() as cx:
+        cx.execute(
+            "UPDATE app_config SET json_value=?, updated_at=? WHERE key='winner_weights_v2'",
+            (json.dumps(current), int(time.time()))
+        )
+        cx.commit()
+    return current


### PR DESCRIPTION
## Summary
- store winner weight configuration in SQLite with defaults and sanitization
- expose GET and PUT /api/config/weights endpoints via Flask
- initialize app configuration at startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c567e6c5548328a65f10b95884abf5