### PR TITLE
Store winner weights raw in DB

### DIFF
--- a/product_research_app/api/config.py
+++ b/product_research_app/api/config.py
@@ -1,16 +1,24 @@
 from flask import request, jsonify
 from . import app
 
-# GET /api/config/weights
-@app.route("/api/config/weights", methods=["GET"])
-def api_get_weights():
-    from product_research_app.services.config import get_winner_weights
-    return jsonify({"weights": get_winner_weights()})
+from product_research_app.services.config import (
+    get_winner_weights_raw,
+    set_winner_weights_raw,
+    compute_effective_int,
+)
 
-# PUT /api/config/weights
-@app.route("/api/config/weights", methods=["PUT"])
-def api_put_weights():
-    from product_research_app.services.config import set_winner_weights
+
+# GET /api/config/winner-weights
+@app.route("/api/config/winner-weights", methods=["GET"])
+def api_get_winner_weights():
+    raw = get_winner_weights_raw()
+    return jsonify({"weights": raw, "effective": {"int": compute_effective_int(raw)}})
+
+
+# PATCH /api/config/winner-weights
+@app.route("/api/config/winner-weights", methods=["PATCH"])
+def api_patch_winner_weights():
     data = request.get_json(force=True) or {}
-    saved = set_winner_weights(data.get("weights", {}))
-    return jsonify({"weights": saved})
+    raw_in = data.get("weights", {}) or {}
+    saved = set_winner_weights_raw(raw_in)
+    return jsonify({"weights": saved, "effective": {"int": compute_effective_int(saved)}})

--- a/product_research_app/services/config.py
+++ b/product_research_app/services/config.py
@@ -1,15 +1,18 @@
-import json, sqlite3, time
+import json, sqlite3, time, math
 from pathlib import Path
 
 ALLOWED_FIELDS = ("price","rating","units_sold","revenue","desire","competition","oldness")
-DEFAULT_WEIGHTS = {k: 50 for k in ALLOWED_FIELDS}  # 50 = neutro
+DEFAULT_WEIGHTS_RAW = {k: 50 for k in ALLOWED_FIELDS}  # 50 = neutro
 
 DB_PATH = Path(__file__).resolve().parents[1] / "data.sqlite3"
+KEY_WEIGHTS_RAW = "winner_weights_v2_raw"
+
 
 def _conn():
     cx = sqlite3.connect(DB_PATH)
     cx.execute("PRAGMA journal_mode=WAL;")
     return cx
+
 
 def init_app_config():
     with _conn() as cx:
@@ -18,48 +21,68 @@ def init_app_config():
             json_value TEXT NOT NULL,
             updated_at INTEGER NOT NULL
         )""")
-        row = cx.execute(
-            "SELECT 1 FROM app_config WHERE key='winner_weights_v2'"
-        ).fetchone()
+        row = cx.execute("SELECT 1 FROM app_config WHERE key=?", (KEY_WEIGHTS_RAW,)).fetchone()
         if not row:
             cx.execute(
                 "INSERT INTO app_config(key,json_value,updated_at) VALUES (?,?,?)",
-                ("winner_weights_v2", json.dumps(DEFAULT_WEIGHTS), int(time.time()))
+                (KEY_WEIGHTS_RAW, json.dumps(DEFAULT_WEIGHTS_RAW), int(time.time()))
             )
         cx.commit()
 
-def _sanitize_weights(data: dict) -> dict:
+
+def _clamp_int01(x, lo=0, hi=100):
+    try:
+        v = int(float(x))
+    except Exception:
+        v = 50
+    return max(lo, min(hi, v))
+
+
+def get_winner_weights_raw() -> dict:
+    with _conn() as cx:
+        row = cx.execute("SELECT json_value FROM app_config WHERE key=?", (KEY_WEIGHTS_RAW,)).fetchone()
+        if not row:
+            return DEFAULT_WEIGHTS_RAW.copy()
+        data = json.loads(row[0])
     out = {}
     for k in ALLOWED_FIELDS:
-        try:
-            v = int(float(data.get(k, DEFAULT_WEIGHTS[k])))
-        except Exception:
-            v = DEFAULT_WEIGHTS[k]
-        out[k] = max(0, min(100, v))
+        out[k] = _clamp_int01(data.get(k, 50))
     return out
 
-def get_winner_weights() -> dict:
-    with _conn() as cx:
-        row = cx.execute(
-            "SELECT json_value FROM app_config WHERE key='winner_weights_v2'"
-        ).fetchone()
-        if not row:
-            return DEFAULT_WEIGHTS.copy()
-        return _sanitize_weights(json.loads(row[0]))
 
-def set_winner_weights(weights: dict) -> dict:
-    current = get_winner_weights()
+def set_winner_weights_raw(weights: dict) -> dict:
+    current = get_winner_weights_raw()
     for k in ALLOWED_FIELDS:
         if k in weights:
-            try:
-                v = int(float(weights[k]))
-            except Exception:
-                continue
-            current[k] = max(0, min(100, v))
+            current[k] = _clamp_int01(weights[k])
     with _conn() as cx:
+        prev = cx.execute(
+            "SELECT updated_at FROM app_config WHERE key=?", (KEY_WEIGHTS_RAW,)
+        ).fetchone()
+        ts = int(time.time())
+        if prev and ts <= int(prev[0]):
+            ts = int(prev[0]) + 1
         cx.execute(
-            "UPDATE app_config SET json_value=?, updated_at=? WHERE key='winner_weights_v2'",
-            (json.dumps(current), int(time.time()))
+            "UPDATE app_config SET json_value=?, updated_at=? WHERE key=?",
+            (json.dumps(current), ts, KEY_WEIGHTS_RAW)
         )
         cx.commit()
     return current
+
+
+# Útil para logs/cálculo: normaliza a suma 100 con “largest remainder”
+def compute_effective_int(weights_raw: dict) -> dict:
+    vals = [max(0, float(weights_raw[k])) for k in ALLOWED_FIELDS]
+    s = sum(vals)
+    if s <= 0:
+        return {k: (100 // len(ALLOWED_FIELDS)) for k in ALLOWED_FIELDS}
+    shares = [v * 100.0 / s for v in vals]
+    floors = [int(math.floor(x)) for x in shares]
+    rem = 100 - sum(floors)
+    # reparte los decimales sobrantes a los mayores restos
+    order = sorted(range(len(shares)), key=lambda i: shares[i] - floors[i], reverse=True)
+    eff = floors[:]
+    for i in range(rem):
+        eff[order[i]] += 1
+    return {k: eff[i] for i, k in enumerate(ALLOWED_FIELDS)}
+

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -539,7 +539,7 @@ function saveWeightDebounced(key, value){
       fetch('/api/config/winner-weights', {
         method:'PATCH',
         headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({ key, value: val })
+        body: JSON.stringify({ weights: { [key]: val } })
       });
     },300);
   }

--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -46,8 +46,9 @@ def test_insert_score_normalizes_to_int():
 def test_weights_persist(tmp_path, monkeypatch):
     cfg_file = tmp_path / 'config.json'
     monkeypatch.setattr(config, 'CONFIG_FILE', cfg_file)
-    from product_research_app.services import winner_score
-    monkeypatch.setattr(winner_score, 'WINNER_WEIGHTS_FILE', tmp_path / 'winner_weights.json')
+    from product_research_app.services import config as cfg_service
+    monkeypatch.setattr(cfg_service, 'DB_PATH', tmp_path / 'data.sqlite3')
+    cfg_service.init_app_config()
     config.set_weights({'price': 2.0, 'rating': 1.0})
     w = config.get_weights()
     assert w['price'] > w['rating']


### PR DESCRIPTION
## Summary
- persist winner score weights as raw integers in SQLite app_config
- expose GET/PATCH endpoints returning raw and effective weights
- update config and web app to use new weight storage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5711316b48328b26e33b99cd63a04