### PR TITLE
Initialize app_config table before retrieving weights

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -223,8 +223,9 @@ def update_weight(key: str, value: float) -> None:
 
 
 def get_weights_version() -> int:
-    from .services.config import _conn, KEY_WEIGHTS_RAW  # lazy import
+    from .services.config import _conn, KEY_WEIGHTS_RAW, init_app_config  # lazy import
 
+    init_app_config()
     with _conn() as cx:
         row = cx.execute(
             "SELECT updated_at FROM app_config WHERE key=?", (KEY_WEIGHTS_RAW,)

--- a/product_research_app/services/config.py
+++ b/product_research_app/services/config.py
@@ -39,6 +39,7 @@ def _clamp_int01(x, lo=0, hi=100):
 
 
 def get_winner_weights_raw() -> dict:
+    init_app_config()
     with _conn() as cx:
         row = cx.execute("SELECT json_value FROM app_config WHERE key=?", (KEY_WEIGHTS_RAW,)).fetchone()
         if not row:


### PR DESCRIPTION
## Summary
- ensure app_config table exists before fetching or updating winner score weights
- initialize app_config when reading weights version

## Testing
- `pytest -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68c573dfbd808328bcd5dac0f884a032