### PR TITLE
Return raw winner weight values

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 
+const API_WEIGHTS = "/api/config/winner-weights";
+
 // Order matters - used to render sliders
 const FIELDS = [
   { key: "price", label: "Price" },
@@ -29,7 +31,7 @@ export default function SettingsModal() {
   // CARGA (RAW)
   useEffect(() => {
     let alive = true;
-    fetch("/api/config/winner-weights")
+    fetch(API_WEIGHTS)
       .then((r) => r.json())
       .then((d) => {
         if (!alive) return;
@@ -49,7 +51,7 @@ export default function SettingsModal() {
   function patchWeights(next: Record<string, number>, immediate = false) {
     if (!loadedRef.current) return;
     const send = () => {
-      fetch("/api/config/winner-weights", {
+      fetch(API_WEIGHTS, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ weights: next }),
@@ -61,7 +63,7 @@ export default function SettingsModal() {
       send();
     } else {
       if (saveDebounced.current) clearTimeout(saveDebounced.current);
-      saveDebounced.current = setTimeout(send, 300);
+      saveDebounced.current = setTimeout(send, 250);
     }
   }
 
@@ -80,13 +82,12 @@ export default function SettingsModal() {
 
   // Flush si se cierra rápido el modal
   useEffect(() => {
-    const flush = () => {
+    return () => {
       if (saveDebounced.current) {
         clearTimeout(saveDebounced.current);
         patchWeights(weights, true);
       }
     };
-    return () => flush();
   }, [weights]);
 
   return (

--- a/product_research_app/api/config.py
+++ b/product_research_app/api/config.py
@@ -1,18 +1,14 @@
 from flask import request, jsonify
 from . import app
 
-from product_research_app.services.config import (
-    get_winner_weights_raw,
-    set_winner_weights_raw,
-    compute_effective_int,
-)
+from product_research_app.services.config import get_winner_weights_raw, set_winner_weights_raw
 
 
 # GET /api/config/winner-weights
 @app.route("/api/config/winner-weights", methods=["GET"])
 def api_get_winner_weights():
     raw = get_winner_weights_raw()
-    return jsonify({"weights": raw, "effective": {"int": compute_effective_int(raw)}})
+    return jsonify({"weights": raw})
 
 
 # PATCH /api/config/winner-weights
@@ -21,4 +17,4 @@ def api_patch_winner_weights():
     data = request.get_json(force=True) or {}
     raw_in = data.get("weights", {}) or {}
     saved = set_winner_weights_raw(raw_in)
-    return jsonify({"weights": saved, "effective": {"int": compute_effective_int(saved)}})
+    return jsonify({"weights": saved})

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -604,9 +604,8 @@ class RequestHandler(BaseHTTPRequestHandler):
             from .services.config import get_winner_weights_raw, compute_effective_int
 
             raw = get_winner_weights_raw()
-            eff_int = compute_effective_int(raw)
-            logger.info("weights_effective_int=%s", eff_int)
-            resp = {"weights": raw, "effective": {"int": eff_int}}
+            logger.info("weights_effective_int=%s", compute_effective_int(raw))
+            resp = {"weights": raw}
             self._set_json()
             self.wfile.write(json.dumps(resp).encode("utf-8"))
             return
@@ -1373,7 +1372,8 @@ class RequestHandler(BaseHTTPRequestHandler):
 
             saved = set_winner_weights_raw(raw_in)
             winner_score.invalidate_weights_cache()
-            resp = {"weights": saved, "effective": {"int": compute_effective_int(saved)}}
+            logger.info("weights_effective_int=%s", compute_effective_int(saved))
+            resp = {"weights": saved}
             self._set_json()
             self.wfile.write(json.dumps(resp).encode('utf-8'))
             return


### PR DESCRIPTION
## Summary
- Serve winner weight configuration endpoints with raw values only.
- Log normalized weights server-side without exposing them in responses.
- Update settings modal to load and patch raw weights with debounced saves.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5754ca99c83289e6572e9ed0851d5