### PR TITLE
feat: reset all weights

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -73,7 +73,9 @@ export default function SettingsModal() {
   };
 
   const onReset = () => {
-    const next = { ...DEFAULTS_50 };
+    const next: Record<string, number> = Object.fromEntries(
+      Object.keys(weights || {}).map((k) => [k, 50])
+    );
     setWeights(next);
     patchWeights(next, true);
   };


### PR DESCRIPTION
## Summary
- ensure Reset button sets all weight sliders to 50 and persists immediately

## Testing
- `python -m pytest -q`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c577d6ce748328aea6501f6dde73e7