### PR TITLE
Reestructura modal de configuración y pesos

### DIFF
--- a/product_research_app/api/config.py
+++ b/product_research_app/api/config.py
@@ -3,9 +3,8 @@ from . import app
 
 from product_research_app.services.config import (
     get_winner_weights_raw,
-    set_winner_weights_raw,
     get_winner_order_raw,
-    set_winner_order_raw,
+    update_winner_settings,
     compute_effective_int,
 )
 
@@ -15,25 +14,31 @@ from product_research_app.services.config import (
 def api_get_winner_weights():
     raw = get_winner_weights_raw()
     order = get_winner_order_raw()
-    return jsonify({
+    resp = jsonify({
         "weights": raw,
         "order": order,
         "effective": {"int": compute_effective_int(raw, order)},
     })
+    resp.headers["Cache-Control"] = "no-store"
+    return resp
 
 
 # PATCH /api/config/winner-weights
 @app.route("/api/config/winner-weights", methods=["PATCH"])
 def api_patch_winner_weights():
     data = request.get_json(force=True) or {}
-    raw_in = data.get("weights", {}) or {}
-    order_in = data.get("order")
-    saved_weights = set_winner_weights_raw(raw_in)
-    if order_in is None:
-        order_in = list(saved_weights.keys())
-    saved_order = set_winner_order_raw(order_in)
-    return jsonify({
+    raw_in = data.get("winner_weights") or data.get("weights") or {}
+    order_in = data.get("winner_order") or data.get("order")
+    saved_weights, saved_order = update_winner_settings(raw_in, order_in)
+    app.logger.info(
+        "settings_saved winner_weights=%s winner_order_len=%s",
+        len(saved_weights),
+        len(saved_order),
+    )
+    resp = jsonify({
         "weights": saved_weights,
         "order": saved_order,
         "effective": {"int": compute_effective_int(saved_weights, saved_order)},
     })
+    resp.headers["Cache-Control"] = "no-store"
+    return resp

--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -223,16 +223,8 @@ def update_weight(key: str, value: float) -> None:
 
 
 def get_weights_version() -> int:
-    from .services.config import _conn, KEY_WEIGHTS_RAW, init_app_config  # lazy import
-
-    init_app_config()
-    with _conn() as cx:
-        row = cx.execute(
-            "SELECT updated_at FROM app_config WHERE key=?", (KEY_WEIGHTS_RAW,)
-        ).fetchone()
-        if row and row[0]:
-            try:
-                return int(row[0])
-            except Exception:
-                return 0
-    return 0
+    cfg = load_config()
+    try:
+        return int(cfg.get("weightsUpdatedAt", 0))
+    except Exception:
+        return 0

--- a/product_research_app/services/config.py
+++ b/product_research_app/services/config.py
@@ -1,127 +1,103 @@
-import json, sqlite3, time, math
+import time
 from pathlib import Path
+from typing import Dict, List, Tuple
 
-ALLOWED_FIELDS = ("price","rating","units_sold","revenue","desire","competition","oldness")
-DEFAULT_WEIGHTS_RAW = {k: 50 for k in ALLOWED_FIELDS}  # 50 = neutro
-DEFAULT_ORDER = list(ALLOWED_FIELDS)
+from ..config import load_config, save_config
 
+ALLOWED_FIELDS = ("price", "rating", "units_sold", "revenue", "desire", "competition", "oldness")
+DEFAULT_WEIGHTS_RAW: Dict[str, int] = {k: 50 for k in ALLOWED_FIELDS}
+DEFAULT_ORDER: List[str] = list(ALLOWED_FIELDS)
+
+# Compatibility placeholder; not used but kept for tests that monkeypatch it
 DB_PATH = Path(__file__).resolve().parents[1] / "data.sqlite3"
-KEY_WEIGHTS_RAW = "winner_weights_v2_raw"
-KEY_ORDER = "winner_weights_v2_order"
 
 
-def _conn():
-    cx = sqlite3.connect(DB_PATH)
-    cx.execute("PRAGMA journal_mode=WAL;")
-    return cx
-
-
-def init_app_config():
-    with _conn() as cx:
-        cx.execute("""CREATE TABLE IF NOT EXISTS app_config (
-            key TEXT PRIMARY KEY,
-            json_value TEXT NOT NULL,
-            updated_at INTEGER NOT NULL
-        )""")
-        row = cx.execute("SELECT 1 FROM app_config WHERE key=?", (KEY_WEIGHTS_RAW,)).fetchone()
-        if not row:
-            cx.execute(
-                "INSERT INTO app_config(key,json_value,updated_at) VALUES (?,?,?)",
-                (KEY_WEIGHTS_RAW, json.dumps(DEFAULT_WEIGHTS_RAW), int(time.time()))
-            )
-        row = cx.execute("SELECT 1 FROM app_config WHERE key=?", (KEY_ORDER,)).fetchone()
-        if not row:
-            cx.execute(
-                "INSERT INTO app_config(key,json_value,updated_at) VALUES (?,?,?)",
-                (KEY_ORDER, json.dumps(DEFAULT_ORDER), int(time.time()))
-            )
-        cx.commit()
-
-
-def _clamp_int01(x, lo=0, hi=100):
-    try:
-        v = int(float(x))
-    except Exception:
-        v = 50
-    return max(lo, min(hi, v))
-
-
-def get_winner_weights_raw() -> dict:
-    init_app_config()
-    with _conn() as cx:
-        row = cx.execute("SELECT json_value FROM app_config WHERE key=?", (KEY_WEIGHTS_RAW,)).fetchone()
-        if not row:
-            return DEFAULT_WEIGHTS_RAW.copy()
-        data = json.loads(row[0])
-    out = {}
-    for k in ALLOWED_FIELDS:
-        out[k] = _clamp_int01(data.get(k, 50))
+def _coerce_weights(raw: Dict[str, object] | None) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    for k, v in (raw or {}).items():
+        try:
+            iv = int(round(float(v)))
+        except Exception:
+            iv = 0
+        out[k] = max(0, min(100, iv))
     return out
 
 
-def get_winner_order_raw() -> list:
+def _normalize_order(order, weights: Dict[str, int]) -> List[str]:
+    seen: set[str] = set()
+    out: List[str] = [k for k in (order or []) if k in weights and not (k in seen or seen.add(k))]
+    out += [k for k in weights.keys() if k not in out]
+    return out
+
+
+def init_app_config() -> None:
+    cfg = load_config()
+    changed = False
+    if "winner_weights" not in cfg:
+        cfg["winner_weights"] = DEFAULT_WEIGHTS_RAW.copy()
+        changed = True
+    if "winner_order" not in cfg:
+        cfg["winner_order"] = DEFAULT_ORDER.copy()
+        changed = True
+    if "weightsUpdatedAt" not in cfg:
+        cfg["weightsUpdatedAt"] = int(time.time())
+        changed = True
+    if changed:
+        save_config(cfg)
+
+
+def _load() -> Tuple[Dict[str, int], List[str]]:
+    cfg = load_config()
+    weights = cfg.get("winner_weights")
+    if not isinstance(weights, dict) or not weights:
+        weights = DEFAULT_WEIGHTS_RAW.copy()
+    weights = _coerce_weights(weights)
+    order = _normalize_order(cfg.get("winner_order"), weights)
+    return weights, order
+
+
+def update_winner_settings(weights_in=None, order_in=None) -> Tuple[Dict[str, int], List[str]]:
     init_app_config()
-    with _conn() as cx:
-        row = cx.execute("SELECT json_value FROM app_config WHERE key=?", (KEY_ORDER,)).fetchone()
-        if row:
-            try:
-                data = json.loads(row[0])
-                if isinstance(data, list):
-                    cleaned = [k for k in data if k in ALLOWED_FIELDS]
-                    for k in ALLOWED_FIELDS:
-                        if k not in cleaned:
-                            cleaned.append(k)
-                    return cleaned
-            except Exception:
-                pass
-    return list(DEFAULT_ORDER)
+    cfg = load_config()
+    weights = cfg.get("winner_weights", DEFAULT_WEIGHTS_RAW.copy())
+    order = cfg.get("winner_order", DEFAULT_ORDER.copy())
+    weights = _coerce_weights(weights)
+    order = _normalize_order(order, weights)
+    if weights_in is not None:
+        wi = _coerce_weights(weights_in)
+        weights.update(wi)
+    if order_in is not None:
+        order = _normalize_order(order_in, weights)
+    cfg["winner_weights"] = weights
+    cfg["winner_order"] = order
+    cfg["weightsUpdatedAt"] = int(time.time())
+    save_config(cfg)
+    return weights, order
 
 
-def set_winner_weights_raw(weights: dict) -> dict:
-    current = get_winner_weights_raw()
-    for k in ALLOWED_FIELDS:
-        if k in weights:
-            current[k] = _clamp_int01(weights[k])
-    with _conn() as cx:
-        prev = cx.execute(
-            "SELECT updated_at FROM app_config WHERE key=?", (KEY_WEIGHTS_RAW,)
-        ).fetchone()
-        ts = int(time.time())
-        if prev and ts <= int(prev[0]):
-            ts = int(prev[0]) + 1
-        cx.execute(
-            "UPDATE app_config SET json_value=?, updated_at=? WHERE key=?",
-            (json.dumps(current), ts, KEY_WEIGHTS_RAW)
-        )
-        cx.commit()
-    return current
+def get_winner_weights_raw() -> Dict[str, int]:
+    weights, _ = _load()
+    return weights
 
 
-def set_winner_order_raw(order: list[str]) -> list[str]:
-    current = get_winner_order_raw()
-    cleaned = [k for k in order if k in ALLOWED_FIELDS]
-    for k in ALLOWED_FIELDS:
-        if k not in cleaned:
-            cleaned.append(k)
-    with _conn() as cx:
-        prev = cx.execute(
-            "SELECT updated_at FROM app_config WHERE key=?", (KEY_ORDER,)
-        ).fetchone()
-        ts = int(time.time())
-        if prev and ts <= int(prev[0]):
-            ts = int(prev[0]) + 1
-        cx.execute(
-            "UPDATE app_config SET json_value=?, updated_at=? WHERE key=?",
-            (json.dumps(cleaned), ts, KEY_ORDER)
-        )
-        cx.commit()
-    return cleaned
+def get_winner_order_raw() -> List[str]:
+    _, order = _load()
+    return order
+
+
+def set_winner_weights_raw(weights: Dict[str, object]) -> Dict[str, int]:
+    weights, _ = update_winner_settings(weights_in=weights, order_in=None)
+    return weights
+
+
+def set_winner_order_raw(order: List[str]) -> List[str]:
+    _, order = update_winner_settings(weights_in=None, order_in=order)
+    return order
 
 
 # Útil para logs/cálculo: pesos efectivos enteros 0..100 considerando prioridad
-def compute_effective_int(weights_raw: dict, order: list[str] | None = None) -> dict:
+def compute_effective_int(weights_raw: Dict[str, int], order: List[str] | None = None) -> Dict[str, int]:
     from . import winner_score  # lazy to avoid circular import
 
     eff = winner_score.compute_effective_weights(weights_raw, order or list(weights_raw.keys()))
     return {k: int(round(v * 100)) for k, v in eff.items()}
-

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -443,6 +443,10 @@ body.dark .bottombar {
   overscroll-behavior: contain;
   flex: 1 1 auto;
 }
+.config-modal .modal-body {
+  max-height: none;
+  overflow: visible;
+}
 .modal-body input {
   width: 100%;
   padding: 8px;
@@ -694,7 +698,8 @@ body.dark .weight-range{ accent-color:#7a53d6; }
 input[type="range"].weight-range { width: 100% !important; }
 
 .legend {
-  margin-top: 8px;
+  margin: 6px 0;
+  padding: 8px;
   font-size: 14px;
   opacity: .85;
 }
@@ -703,25 +708,29 @@ input[type="range"].weight-range { width: 100% !important; }
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+@media (max-width: 991px), (max-height: 699px){
+  .weights-list { grid-template-columns:1fr; }
 }
 
 .weight-card {
   display: grid;
   grid-template-columns: 40px 1fr 24px;
   align-items: center;
-  gap: 12px;
-  padding: 12px;
+  gap: 10px;
+  padding: 10px;
   border-radius: 12px;
 }
 .weight-card:nth-child(odd) { background: rgba(0,0,0,0.03); }
 body.dark .weight-card:nth-child(odd) { background: rgba(255,255,255,0.03); }
+.weights-list .weight-card:nth-child(odd){ margin-bottom:0; }
 
 .priority-badge {
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   background: #7a53d6;
   color: #fff;
@@ -729,6 +738,7 @@ body.dark .weight-card:nth-child(odd) { background: rgba(255,255,255,0.03); }
   align-items: center;
   justify-content: center;
   font-weight: 600;
+  font-size: 14px;
 }
 
 .drag-handle {
@@ -738,16 +748,11 @@ body.dark .weight-card:nth-child(odd) { background: rgba(255,255,255,0.03); }
   opacity: .7;
 }
 
-.meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 8px;
-  font-size: 12px;
-}
+.weight-card .label{ margin-bottom:2px; }
+.weight-card .scale{ margin-top:2px; }
+.weight-card .meta{ display:none; }
 
-.weight-badge,
-.effective-badge {
+.weight-badge {
   display: inline-flex;
   align-items: center;
   padding: 2px 8px;
@@ -756,21 +761,20 @@ body.dark .weight-card:nth-child(odd) { background: rgba(255,255,255,0.03); }
   background: #e0f0ff;
   color: #0077cc;
 }
-body.dark .weight-badge,
-body.dark .effective-badge {
+body.dark .weight-badge {
   border: 1px solid #34456B;
   background: #1F2A44;
   color: #E5EAF5;
 }
 
-.weights-footer {
+.config-footer {
   position: sticky;
-  bottom: -16px;
+  bottom: 0;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  padding-top: 12px;
-  margin-top: 12px;
+  padding: 8px 0;
+  margin-top: 8px;
   background: inherit;
   box-shadow: 0 -2px 4px rgba(0,0,0,0.2);
 }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -105,7 +105,7 @@ body.dark pre { background:#2e315f; }
   <strong>Ponderaciones Winner Score</strong>
   <div class="legend">ℹ️ Arrastra para reordenar. Más arriba = mayor prioridad. El número (0–100) es el peso.</div>
   <ul id="weightsList" class="weights-list"></ul>
-  <div class="weights-footer">
+  <div class="config-footer">
     <button id="resetWeights">Reset</button>
     <button id="saveWeights">Guardar</button>
     <button id="aiWeights">Ajustar pesos con IA</button>
@@ -530,34 +530,31 @@ function defaultFactors(){
   return WEIGHT_FIELDS.map(f=>({ ...f, weight:50 }));
 }
 
-function toWeightMap(){ const o={}; factors.forEach(f=>o[f.key]=f.weight); return o; }
-function toOrder(){ return factors.map(f=>f.key); }
+function clampWeight(v){ return Math.max(0, Math.min(100, Math.round(v))); }
+let saveTimer=null, dirty=false;
+function enableSaveButton(){ const b=document.getElementById('saveWeights'); if(b) b.disabled=false; }
+function disableSaveButton(){ const b=document.getElementById('saveWeights'); if(b) b.disabled=true; }
+function markDirty(){ dirty=true; enableSaveButton(); clearTimeout(saveTimer); saveTimer=setTimeout(saveIfDirty,700); }
+function clearDirty(){ dirty=false; disableSaveButton(); clearTimeout(saveTimer); }
+async function saveIfDirty(){ if(!dirty) return; await saveSettings(); }
 
 function renderFactors(){
   const list=document.getElementById('weightsList');
   if(!list) return;
   list.innerHTML='';
-  const n=factors.length;
-  const sumRanks=n*(n+1)/2;
   factors.forEach((f,idx)=>{
     const priority=idx+1;
-    const priorityWeight=n-idx;
-    const priorityFactor=priorityWeight/(sumRanks/n);
-    const effective=Math.round(f.weight*priorityFactor);
     const li=document.createElement('li');
     li.className='weight-card';
     li.dataset.key=f.key;
-    li.innerHTML=`<div class="priority-badge">#${priority}</div><div class="content"><label for="weight-${f.key}">${f.label}</label><input id="weight-${f.key}" class="weight-range" type="range" min="0" max="100" step="1" value="${f.weight}"><div class="slider-extremes"><span class="extreme-left">${EXTREMES[f.key].left}</span><span class="extreme-right">${EXTREMES[f.key].right}</span></div><div class="meta"><span class="weight-badge">peso: ${f.weight}/100</span><span class="effective-badge">efectivo: ${effective}</span></div></div><div class="drag-handle" aria-hidden>≡</div>`;
+    li.innerHTML=`<div class="priority-badge">#${priority}</div><div class="content"><label for="weight-${f.key}" class="label">${f.label}</label><input id="weight-${f.key}" class="weight-range" type="range" min="0" max="100" step="1" value="${f.weight}"><div class="slider-extremes scale"><span class="extreme-left">${EXTREMES[f.key].left}</span><span class="extreme-right">${EXTREMES[f.key].right}</span></div><span class="weight-badge">peso: ${f.weight}/100</span></div><div class="drag-handle" aria-hidden>≡</div>`;
     const range=li.querySelector('.weight-range');
     range.addEventListener('input',e=>{
-      const v=Math.round(parseFloat(e.target.value));
+      const v=parseInt(e.target.value,10);
       e.target.value=v;
       f.weight=v;
-      const priorityWeight2=n-idx;
-      const priorityFactor2=priorityWeight2/(sumRanks/n);
-      const eff=Math.round(f.weight*priorityFactor2);
       li.querySelector('.weight-badge').textContent=`peso: ${f.weight}/100`;
-      li.querySelector('.effective-badge').textContent=`efectivo: ${eff}`;
+      markDirty();
     });
     list.appendChild(li);
   });
@@ -565,27 +562,32 @@ function renderFactors(){
     const orderKeys=Array.from(list.children).map(li=>li.dataset.key);
     factors.sort((a,b)=>orderKeys.indexOf(a.key)-orderKeys.indexOf(b.key));
     renderFactors();
+    markDirty();
   }});
 }
 
 function resetWeights(){
   factors=defaultFactors();
   renderFactors();
+  markDirty();
 }
 
-async function saveWeights(){
+async function saveSettings(){
+  const payload = {
+    winner_weights: Object.fromEntries(factors.map(x=>[x.key, clampWeight(x.weight)])),
+    winner_order: factors.map(x=>x.key)
+  };
   try{
-    await fetch('/api/config/winner-weights',{
-      method:'PATCH',
-      headers:{'Content-Type':'application/json'},
-      body:JSON.stringify({ weights: toWeightMap(), order: toOrder() })
-    });
+    await api.updateSettings(payload);
     toast.success('Pesos y prioridades guardados');
+    clearDirty();
   }catch(err){
     console.error('Error saving weights',err);
     toast.error('No se pudo guardar');
   }
 }
+
+async function saveWeights(){ await saveSettings(); }
 
 function stratifiedSample(list, n){
   const byCat = {};
@@ -676,6 +678,7 @@ async function adjustWeightsAI(){
     }
     factors=factors.map(f=>({ ...f, weight:newWeights[f.key] ?? f.weight }));
     renderFactors();
+    markDirty();
     toast.success('Pesos ajustados por IA');
   }catch(err){
     console.error(err);
@@ -694,6 +697,7 @@ async function loadWeights(){
     WEIGHT_FIELDS.forEach(f=>{ base[f.key] = { ...f, weight:50 }; });
     factors = order.filter(k=>base[k]).map(k=>({ ...base[k], weight: weights[k] !== undefined ? Math.round(weights[k]) : 50 }));
     renderFactors();
+    clearDirty();
     const resetBtn=document.getElementById('resetWeights');
     if(resetBtn) resetBtn.onclick=resetWeights;
     const aiBtn=document.getElementById('aiWeights');
@@ -1122,7 +1126,7 @@ document.getElementById('configBtn').onclick = async () => {
   if(!cfg || !wcard || !window.modalManager) return;
   const btn = document.getElementById('configBtn');
   const modal = document.createElement('div');
-  modal.className = 'modal';
+  modal.className = 'modal config-modal';
   modal.setAttribute('role','dialog');
   modal.setAttribute('aria-modal','true');
   modal.innerHTML = '<header class="modal-header"><h3 id="configModalTitle">Configuración</h3><button type="button" class="modal-close" aria-label="Cerrar">✕</button></header><div class="modal-body"></div>';

--- a/product_research_app/static/js/net.js
+++ b/product_research_app/static/js/net.js
@@ -39,3 +39,10 @@ export async function updateProductField(id, data, timeoutMs = 25000) {
     body: JSON.stringify(data),
   }, timeoutMs);
 }
+
+export async function updateSettings(data, timeoutMs = 25000) {
+  return fetchJson('/api/config/winner-weights', {
+    method: 'PATCH',
+    body: JSON.stringify({ weights: data.winner_weights, order: data.winner_order }),
+  }, timeoutMs);
+}


### PR DESCRIPTION
## Summary
- Ajusta el modal de configuración para mostrar tarjetas de factores en rejilla de dos columnas sin scroll.
- Elimina referencias visuales a "efectivo" y compacta estilos de las tarjetas.
- Implementa autosave con debounce y persistencia de `winner_weights` y `winner_order`.
- Refuerza el backend guardando pesos y orden en `config.json` con coerción, normalización y cabecera `Cache-Control: no-store`.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c58c7a3d108328bce5cbed178f90aa