### PR TITLE
Remove manual save button and enforce single-column weight layout

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -709,11 +709,11 @@ input[type="range"].weight-range { width: 100% !important; }
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 10px;
 }
-@media (max-width: 991px), (max-height: 699px){
-  .weights-list { grid-template-columns:1fr; }
+@media (min-width: 0){
+  .weights-list{ grid-template-columns: 1fr; }
 }
 
 .weight-card {
@@ -726,7 +726,6 @@ input[type="range"].weight-range { width: 100% !important; }
 }
 .weight-card:nth-child(odd) { background: rgba(0,0,0,0.03); }
 body.dark .weight-card:nth-child(odd) { background: rgba(255,255,255,0.03); }
-.weights-list .weight-card:nth-child(odd){ margin-bottom:0; }
 
 .priority-badge {
   width: 40px;
@@ -770,13 +769,14 @@ body.dark .weight-badge {
 .config-footer {
   position: sticky;
   bottom: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 8px 0;
-  margin-top: 8px;
-  background: inherit;
-  box-shadow: 0 -2px 4px rgba(0,0,0,0.2);
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  justify-content:flex-start;
+  padding:8px 0;
+  margin-top:8px;
+  background:inherit;
+  box-shadow:0 -2px 4px rgba(0,0,0,0.2);
 }
 
 /* Cabecera y celdas de la columna Desire */

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -107,7 +107,6 @@ body.dark pre { background:#2e315f; }
   <ul id="weightsList" class="weights-list"></ul>
   <div class="config-footer">
     <button id="resetWeights">Reset</button>
-    <button id="saveWeights">Guardar</button>
     <button id="aiWeights">Ajustar pesos con IA</button>
   </div>
 </div>
@@ -532,11 +531,16 @@ function defaultFactors(){
 
 function clampWeight(v){ return Math.max(0, Math.min(100, Math.round(v))); }
 let saveTimer=null, dirty=false;
-function enableSaveButton(){ const b=document.getElementById('saveWeights'); if(b) b.disabled=false; }
-function disableSaveButton(){ const b=document.getElementById('saveWeights'); if(b) b.disabled=true; }
-function markDirty(){ dirty=true; enableSaveButton(); clearTimeout(saveTimer); saveTimer=setTimeout(saveIfDirty,700); }
-function clearDirty(){ dirty=false; disableSaveButton(); clearTimeout(saveTimer); }
-async function saveIfDirty(){ if(!dirty) return; await saveSettings(); }
+function markDirty(){
+  dirty=true;
+  clearTimeout(saveTimer);
+  saveTimer=setTimeout(saveIfDirty,700);
+}
+async function saveIfDirty(){
+  if(!dirty) return;
+  await saveSettings();
+  dirty=false;
+}
 
 function renderFactors(){
   const list=document.getElementById('weightsList');
@@ -579,15 +583,12 @@ async function saveSettings(){
   };
   try{
     await api.updateSettings(payload);
-    toast.success('Pesos y prioridades guardados');
-    clearDirty();
+    toast.success('Guardado automáticamente');
   }catch(err){
     console.error('Error saving weights',err);
     toast.error('No se pudo guardar');
   }
 }
-
-async function saveWeights(){ await saveSettings(); }
 
 function stratifiedSample(list, n){
   const byCat = {};
@@ -697,13 +698,12 @@ async function loadWeights(){
     WEIGHT_FIELDS.forEach(f=>{ base[f.key] = { ...f, weight:50 }; });
     factors = order.filter(k=>base[k]).map(k=>({ ...base[k], weight: weights[k] !== undefined ? Math.round(weights[k]) : 50 }));
     renderFactors();
-    clearDirty();
+    dirty=false;
+    clearTimeout(saveTimer);
     const resetBtn=document.getElementById('resetWeights');
     if(resetBtn) resetBtn.onclick=resetWeights;
     const aiBtn=document.getElementById('aiWeights');
     if(aiBtn) aiBtn.onclick=adjustWeightsAI;
-    const saveBtn=document.getElementById('saveWeights');
-    if(saveBtn) saveBtn.onclick=saveWeights;
   }catch(err){
     console.error('Error loading weights', err);
   }
@@ -1141,6 +1141,7 @@ document.getElementById('configBtn').onclick = async () => {
   cfg.style.display = 'block';
   wcard.style.display = 'block';
   const handle = modalManager.open(modal, {returnFocus: btn, closeOnBackdrop:true, onClose: () => {
+    saveIfDirty();
     cfg.style.display = 'none';
     wcard.style.display = 'none';
     cfgParent.insertBefore(cfg, cfgNext);


### PR DESCRIPTION
## Summary
- Force weights list into a single-column grid on all screen sizes
- Remove the manual "Guardar" button and tidy modal footer layout
- Simplify settings JS to autosave weights with debounce and flush on modal close

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c591306df083289c781a975e2f4ece