### PR TITLE
Keep config modal actions visible

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -443,9 +443,17 @@ body.dark .bottombar {
   overscroll-behavior: contain;
   flex: 1 1 auto;
 }
-.config-modal .modal-body {
-  max-height: none;
-  overflow: visible;
+.config-modal {
+  display:flex;
+  flex-direction:column;
+  max-height:90vh;
+}
+.config-modal .modal-header{ flex:0 0 auto; }
+.config-modal .modal-body{
+  flex:1 1 auto;
+  min-height:0;
+  overflow-y:auto;
+  padding:8px 0 12px;
 }
 .modal-body input {
   width: 100%;
@@ -704,16 +712,13 @@ input[type="range"].weight-range { width: 100% !important; }
   opacity: .85;
 }
 
-.weights-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-}
-@media (max-width: 991px), (max-height: 699px){
-  .weights-list { grid-template-columns:1fr; }
+.weights-list{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  grid-template-columns:1fr;
+  gap:10px;
 }
 
 .weight-card {
@@ -767,16 +772,14 @@ body.dark .weight-badge {
   color: #E5EAF5;
 }
 
-.config-footer {
-  position: sticky;
-  bottom: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 8px 0;
-  margin-top: 8px;
-  background: inherit;
-  box-shadow: 0 -2px 4px rgba(0,0,0,0.2);
+.config-footer{
+  flex:0 0 auto;
+  display:flex;
+  gap:10px;
+  padding:10px 0 0;
+  background:inherit;
+  border-top:1px solid rgba(255,255,255,.08);
+  z-index:2;
 }
 
 /* Cabecera y celdas de la columna Desire */

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -5,6 +5,7 @@
 <title>Product Research Copilot</title>
 <link rel="stylesheet" href="/static/css/app.css">
 <link rel="stylesheet" href="/static/css/toast.css">
+<script type="module" src="/static/js/config.js"></script>
 <style>
 /* Basic layout */
 body { margin:0; padding:0; font-family: 'Segoe UI', Tahoma, sans-serif; color:#222; background: linear-gradient(to bottom, #f8fbff, #e9f0ff); }
@@ -105,11 +106,10 @@ body.dark pre { background:#2e315f; }
   <strong>Ponderaciones Winner Score</strong>
   <div class="legend">ℹ️ Arrastra para reordenar. Más arriba = mayor prioridad. El número (0–100) es el peso.</div>
   <ul id="weightsList" class="weights-list"></ul>
-  <div class="config-footer">
-    <button id="resetWeights">Reset</button>
-    <button id="saveWeights">Guardar</button>
-    <button id="aiWeights">Ajustar pesos con IA</button>
-  </div>
+</div>
+<div id="weightsFooter" class="config-footer" style="display:none;">
+  <button id="btnReset" class="btn">Reset</button>
+  <button id="btnAiWeights" class="btn primary">Ajustar pesos con IA</button>
 </div>
 <div id="custom" style="display:none;">
   <div id="history" style="margin-top:10px;"></div>
@@ -239,6 +239,9 @@ body.dark pre { background:#2e315f; }
 import * as api from "/static/js/net.js";
 import * as groupsService from "/static/js/groups-service.js";
 const { fetchJson } = api;
+const metricKeys = window.metricKeys;
+const loadWeights = window.loadWeights;
+const saveIfDirty = window.saveIfDirty;
 window.fetchJson = fetchJson;
 window.groupsService = groupsService;
 const IMPORT_TASK_LS_KEY = 'last_import_task';
@@ -498,215 +501,6 @@ function computeOldnessDays(p){
   const today=new Date();
   const diff=Math.floor((today-start)/(1000*60*60*24));
   return diff>0?diff:0;
-}
-
-const WEIGHT_FIELDS = [
-  { key: 'price',        label: 'Price' },
-  { key: 'rating',       label: 'Rating' },
-  { key: 'units_sold',   label: 'Units Sold' },
-  { key: 'revenue',      label: 'Revenue' },
-  { key: 'desire',       label: 'Desire' },
-  { key: 'competition',  label: 'Competition' },
-  { key: 'oldness',      label: 'Oldness (antigüedad)' }
-];
-const WEIGHT_KEYS = WEIGHT_FIELDS.map(f=>f.key);
-const EXTREMES = {
-  price:        { left: "Más barato",        right: "Más caro" },
-  rating:       { left: "Peor rating",       right: "Mejor rating" },
-  units_sold:   { left: "Menos ventas",      right: "Más ventas" },
-  revenue:      { left: "Menores ingresos",  right: "Mayores ingresos" },
-  desire:       { left: "Menor deseo",       right: "Mayor deseo" },
-  competition:  { left: "Menos competencia", right: "Más competencia" },
-  oldness:      { left: "Más reciente",      right: "Más antiguo" }
-};
-const ALIASES = { unitsSold:'units_sold', orders:'units_sold' };
-function normalizeKey(k){ return ALIASES[k] || k; }
-const metricDefs = WEIGHT_FIELDS;
-const metricKeys = WEIGHT_KEYS;
-let factors = [];
-let userConfig = {};
-
-function defaultFactors(){
-  return WEIGHT_FIELDS.map(f=>({ ...f, weight:50 }));
-}
-
-function clampWeight(v){ return Math.max(0, Math.min(100, Math.round(v))); }
-let saveTimer=null, dirty=false;
-function enableSaveButton(){ const b=document.getElementById('saveWeights'); if(b) b.disabled=false; }
-function disableSaveButton(){ const b=document.getElementById('saveWeights'); if(b) b.disabled=true; }
-function markDirty(){ dirty=true; enableSaveButton(); clearTimeout(saveTimer); saveTimer=setTimeout(saveIfDirty,700); }
-function clearDirty(){ dirty=false; disableSaveButton(); clearTimeout(saveTimer); }
-async function saveIfDirty(){ if(!dirty) return; await saveSettings(); }
-
-function renderFactors(){
-  const list=document.getElementById('weightsList');
-  if(!list) return;
-  list.innerHTML='';
-  factors.forEach((f,idx)=>{
-    const priority=idx+1;
-    const li=document.createElement('li');
-    li.className='weight-card';
-    li.dataset.key=f.key;
-    li.innerHTML=`<div class="priority-badge">#${priority}</div><div class="content"><label for="weight-${f.key}" class="label">${f.label}</label><input id="weight-${f.key}" class="weight-range" type="range" min="0" max="100" step="1" value="${f.weight}"><div class="slider-extremes scale"><span class="extreme-left">${EXTREMES[f.key].left}</span><span class="extreme-right">${EXTREMES[f.key].right}</span></div><span class="weight-badge">peso: ${f.weight}/100</span></div><div class="drag-handle" aria-hidden>≡</div>`;
-    const range=li.querySelector('.weight-range');
-    range.addEventListener('input',e=>{
-      const v=parseInt(e.target.value,10);
-      e.target.value=v;
-      f.weight=v;
-      li.querySelector('.weight-badge').textContent=`peso: ${f.weight}/100`;
-      markDirty();
-    });
-    list.appendChild(li);
-  });
-  Sortable.create(list,{ handle:'.drag-handle', animation:150, onEnd:()=>{
-    const orderKeys=Array.from(list.children).map(li=>li.dataset.key);
-    factors.sort((a,b)=>orderKeys.indexOf(a.key)-orderKeys.indexOf(b.key));
-    renderFactors();
-    markDirty();
-  }});
-}
-
-function resetWeights(){
-  factors=defaultFactors();
-  renderFactors();
-  markDirty();
-}
-
-async function saveSettings(){
-  const payload = {
-    winner_weights: Object.fromEntries(factors.map(x=>[x.key, clampWeight(x.weight)])),
-    winner_order: factors.map(x=>x.key)
-  };
-  try{
-    await api.updateSettings(payload);
-    toast.success('Pesos y prioridades guardados');
-    clearDirty();
-  }catch(err){
-    console.error('Error saving weights',err);
-    toast.error('No se pudo guardar');
-  }
-}
-
-async function saveWeights(){ await saveSettings(); }
-
-function stratifiedSample(list, n){
-  const byCat = {};
-  list.forEach(p=>{ const c = p.category || 'N/A'; (byCat[c] = byCat[c] || []).push(p); });
-  const total = list.length;
-  const sample = [];
-  for(const c in byCat){
-    const arr = byCat[c].slice().sort((a,b)=>{
-      const ra = Number(a.revenue || (a.extras && a.extras['Revenue($)']) || 0);
-      const rb = Number(b.revenue || (b.extras && b.extras['Revenue($)']) || 0);
-      const ua = Number(a.units_sold || (a.extras && a.extras['Item Sold']) || 0);
-      const ub = Number(b.units_sold || (b.extras && b.extras['Item Sold']) || 0);
-      const sa = ra || ua;
-      const sb = rb || ub;
-      return sb - sa;
-    });
-    const k = Math.max(1, Math.round(n * arr.length / total));
-    sample.push(...arr.slice(0,k));
-  }
-  return sample.slice(0,n);
-}
-
-async function adjustWeightsAI(){
-  try{
-    let sample=stratifiedSample(allProducts||[],30);
-    let payload=sample.map(p=>({
-      price:p.price,
-      rating:p.rating || (p.extras&&p.extras.rating),
-      units_sold:p.units_sold||(p.extras&&p.extras['Item Sold'])||0,
-      revenue:p.revenue||(p.extras&&p.extras['Revenue($)'])||0,
-      desire:p.desire_magnitude,
-      competition:p.competition_level,
-      oldness:computeOldnessDays(p)
-    }));
-    let tokenEstimate=JSON.stringify(payload).length/4;
-    const maxTokens=0.30/0.002*1000;
-    while(tokenEstimate>maxTokens && sample.length>1){
-      const ratio=maxTokens/tokenEstimate;
-      const newN=Math.max(1,Math.floor(sample.length*ratio));
-      sample=stratifiedSample(allProducts||[],newN);
-      payload=sample.map(p=>({
-        price:p.price,
-        rating:p.rating || (p.extras&&p.extras.rating),
-        units_sold:p.units_sold||(p.extras&&p.extras['Item Sold'])||0,
-        revenue:p.revenue||(p.extras&&p.extras['Revenue($)'])||0,
-        desire:p.desire_magnitude,
-        competition:p.competition_level,
-        oldness:computeOldnessDays(p)
-      }));
-      tokenEstimate=JSON.stringify(payload).length/4;
-    }
-    const cost=tokenEstimate/1000*0.002;
-    toast.info(`Analizando ${sample.length} productos (~$${cost.toFixed(2)})`);
-    const instruction='Devuelve SOLO un JSON plano con pesos 0-100 para estas 7 claves exactas, sin texto adicional:\n["price","rating","units_sold","revenue","desire","competition","oldness"]';
-    const prompt=`Basado en estos productos ${JSON.stringify(payload)}\n${instruction}`;
-    let res=await fetch('/custom_gpt',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt,response_format:{type:'json_object'}})});
-    if(!res.ok){
-      toast.error('No se pudo ajustar por IA. Revisa tu API Key o inténtalo más tarde.');
-      return;
-    }
-    const data=await res.json();
-    let raw=data.response||'';
-    console.debug('IA raw:', raw);
-    let obj;
-    if(typeof raw==='string'){
-      try{ obj=JSON.parse(raw); }
-      catch(e){
-        const m=raw.match(/\{[\s\S]*\}/);
-        if(m){ try{ obj=JSON.parse(m[0]); } catch(e2){} }
-      }
-    }else if(typeof raw==='object'){
-      obj=raw;
-    }
-    console.debug('IA parsed:', obj);
-    if(!obj || typeof obj!=='object'){
-      toast.error('No se pudo ajustar por IA. Revisa tu API Key o inténtalo más tarde.');
-      return;
-    }
-    const newWeights={};
-    for(const k of metricKeys){
-      let v=Number(obj[k]);
-      if(isNaN(v)){
-        const current=factors.find(f=>f.key===k);
-        v=current?current.weight:0;
-      }
-      if(v<0) v=0; if(v>100) v=100;
-      newWeights[k]=Math.round(v);
-    }
-    factors=factors.map(f=>({ ...f, weight:newWeights[f.key] ?? f.weight }));
-    renderFactors();
-    markDirty();
-    toast.success('Pesos ajustados por IA');
-  }catch(err){
-    console.error(err);
-    toast.error('No se pudo ajustar por IA. Revisa tu API Key o inténtalo más tarde.');
-  }
-}
-
-
-async function loadWeights(){
-  try{
-    const res = await fetch('/api/config/winner-weights');
-    const data = await res.json();
-    const weights = data.weights || {};
-    const order = Array.isArray(data.order) && data.order.length ? data.order : WEIGHT_KEYS;
-    const base = {};
-    WEIGHT_FIELDS.forEach(f=>{ base[f.key] = { ...f, weight:50 }; });
-    factors = order.filter(k=>base[k]).map(k=>({ ...base[k], weight: weights[k] !== undefined ? Math.round(weights[k]) : 50 }));
-    renderFactors();
-    clearDirty();
-    const resetBtn=document.getElementById('resetWeights');
-    if(resetBtn) resetBtn.onclick=resetWeights;
-    const aiBtn=document.getElementById('aiWeights');
-    if(aiBtn) aiBtn.onclick=adjustWeightsAI;
-    const saveBtn=document.getElementById('saveWeights');
-    if(saveBtn) saveBtn.onclick=saveWeights;
-  }catch(err){
-    console.error('Error loading weights', err);
-  }
 }
 
 async function loadConfig() {
@@ -1123,30 +917,40 @@ document.getElementById('configBtn').onclick = async () => {
   await loadWeights();
   const cfg = document.getElementById('config');
   const wcard = document.getElementById('weightsCard');
-  if(!cfg || !wcard || !window.modalManager) return;
+  const footer = document.getElementById('weightsFooter');
+  if(!cfg || !wcard || !footer || !window.modalManager) return;
   const btn = document.getElementById('configBtn');
   const modal = document.createElement('div');
+  modal.id = 'configModal';
   modal.className = 'modal config-modal';
   modal.setAttribute('role','dialog');
   modal.setAttribute('aria-modal','true');
-  modal.innerHTML = '<header class="modal-header"><h3 id="configModalTitle">Configuración</h3><button type="button" class="modal-close" aria-label="Cerrar">✕</button></header><div class="modal-body"></div>';
   modal.setAttribute('aria-labelledby','configModalTitle');
+  modal.innerHTML = '<header class="modal-header"><h3 id="configModalTitle">Configuración</h3><button type="button" class="modal-close" aria-label="Cerrar">✕</button></header><div class="modal-body"></div>';
   const body = modal.querySelector('.modal-body');
   const cfgParent = cfg.parentElement;
   const wParent = wcard.parentElement;
+  const fParent = footer.parentElement;
   const cfgNext = cfg.nextSibling;
   const wNext = wcard.nextSibling;
+  const fNext = footer.nextSibling;
   body.appendChild(cfg);
   body.appendChild(wcard);
+  modal.appendChild(footer);
   cfg.style.display = 'block';
   wcard.style.display = 'block';
+  footer.style.display = 'flex';
   const handle = modalManager.open(modal, {returnFocus: btn, closeOnBackdrop:true, onClose: () => {
     cfg.style.display = 'none';
     wcard.style.display = 'none';
+    footer.style.display = 'none';
     cfgParent.insertBefore(cfg, cfgNext);
     wParent.insertBefore(wcard, wNext);
+    fParent.insertBefore(footer, fNext);
+    saveIfDirty();
   }});
   modal.querySelector('.modal-close').addEventListener('click', () => handle.close());
+  modal.addEventListener('close', saveIfDirty);
   const first = modal.querySelector('input,select,textarea,button');
   if(first) first.focus();
 };

--- a/product_research_app/static/js/config.js
+++ b/product_research_app/static/js/config.js
@@ -1,0 +1,208 @@
+import * as api from './net.js';
+
+const WEIGHT_FIELDS = [
+  { key: 'price',        label: 'Price' },
+  { key: 'rating',       label: 'Rating' },
+  { key: 'units_sold',   label: 'Units Sold' },
+  { key: 'revenue',      label: 'Revenue' },
+  { key: 'desire',       label: 'Desire' },
+  { key: 'competition',  label: 'Competition' },
+  { key: 'oldness',      label: 'Oldness (antigüedad)' }
+];
+const WEIGHT_KEYS = WEIGHT_FIELDS.map(f => f.key);
+const EXTREMES = {
+  price:       { left: 'Más barato',       right: 'Más caro' },
+  rating:      { left: 'Peor rating',      right: 'Mejor rating' },
+  units_sold:  { left: 'Menos ventas',     right: 'Más ventas' },
+  revenue:     { left: 'Menores ingresos', right: 'Mayores ingresos' },
+  desire:      { left: 'Menor deseo',      right: 'Mayor deseo' },
+  competition: { left: 'Menos competencia', right: 'Más competencia' },
+  oldness:     { left: 'Más reciente',     right: 'Más antiguo' }
+};
+const ALIASES = { unitsSold: 'units_sold', orders: 'units_sold' };
+function normalizeKey(k){ return ALIASES[k] || k; }
+const metricDefs = WEIGHT_FIELDS;
+const metricKeys = WEIGHT_KEYS;
+let factors = [];
+let userConfig = {};
+
+function defaultFactors(){
+  return WEIGHT_FIELDS.map(f => ({ ...f, weight:50 }));
+}
+
+function clampWeight(v){ return Math.max(0, Math.min(100, Math.round(v))); }
+let saveTimer=null, dirty=false;
+function markDirty(){ dirty=true; clearTimeout(saveTimer); saveTimer=setTimeout(saveIfDirty,700); }
+function clearDirty(){ dirty=false; clearTimeout(saveTimer); }
+async function saveIfDirty(){ if(!dirty) return; await saveSettings(); dirty=false; }
+
+function renderFactors(){
+  const list = document.getElementById('weightsList');
+  if(!list) return;
+  list.innerHTML = '';
+  factors.forEach((f,idx) => {
+    const priority = idx+1;
+    const li = document.createElement('li');
+    li.className = 'weight-card';
+    li.dataset.key = f.key;
+    li.innerHTML = `<div class="priority-badge">#${priority}</div><div class="content"><label for="weight-${f.key}" class="label">${f.label}</label><input id="weight-${f.key}" class="weight-range" type="range" min="0" max="100" step="1" value="${f.weight}"><div class="slider-extremes scale"><span class="extreme-left">${EXTREMES[f.key].left}</span><span class="extreme-right">${EXTREMES[f.key].right}</span></div><span class="weight-badge">peso: ${f.weight}/100</span></div><div class="drag-handle" aria-hidden>≡</div>`;
+    const range = li.querySelector('.weight-range');
+    range.addEventListener('input', e => {
+      const v = parseInt(e.target.value,10);
+      e.target.value = v;
+      f.weight = v;
+      li.querySelector('.weight-badge').textContent = `peso: ${f.weight}/100`;
+      markDirty();
+    });
+    list.appendChild(li);
+  });
+  Sortable.create(list,{ handle:'.drag-handle', animation:150, onEnd:()=>{
+    const orderKeys = Array.from(list.children).map(li=>li.dataset.key);
+    factors.sort((a,b)=>orderKeys.indexOf(a.key)-orderKeys.indexOf(b.key));
+    renderFactors();
+    markDirty();
+  }});
+}
+
+function resetWeights(){
+  factors = defaultFactors();
+  renderFactors();
+  markDirty();
+}
+
+async function saveSettings(){
+  const payload = {
+    winner_weights: Object.fromEntries(factors.map(x=>[x.key, clampWeight(x.weight)])),
+    winner_order: factors.map(x=>x.key)
+  };
+  try{
+    await api.updateSettings(payload);
+    clearDirty();
+  }catch(err){
+    console.error('Error saving weights',err);
+  }
+}
+
+function stratifiedSample(list, n){
+  const byCat = {};
+  list.forEach(p=>{ const c = p.category || 'N/A'; (byCat[c] = byCat[c] || []).push(p); });
+  const total = list.length;
+  const sample = [];
+  for(const c in byCat){
+    const arr = byCat[c].slice().sort((a,b)=>{
+      const ra = Number(a.revenue || (a.extras && a.extras['Revenue($)']) || 0);
+      const rb = Number(b.revenue || (b.extras && b.extras['Revenue($)']) || 0);
+      const ua = Number(a.units_sold || (a.extras && a.extras['Item Sold']) || 0);
+      const ub = Number(b.units_sold || (b.extras && b.extras['Item Sold']) || 0);
+      const sa = ra || ua;
+      const sb = rb || ub;
+      return sb - sa;
+    });
+    const k = Math.max(1, Math.round(n * arr.length / total));
+    sample.push(...arr.slice(0,k));
+  }
+  return sample.slice(0,n);
+}
+
+async function adjustWeightsAI(){
+  try{
+    let sample=stratifiedSample(allProducts||[],30);
+    let payload=sample.map(p=>({
+      price:p.price,
+      rating:p.rating || (p.extras&&p.extras.rating),
+      units_sold:p.units_sold||(p.extras&&p.extras['Item Sold'])||0,
+      revenue:p.revenue||(p.extras&&p.extras['Revenue($)'])||0,
+      desire:p.desire_magnitude,
+      competition:p.competition_level,
+      oldness:computeOldnessDays(p)
+    }));
+    let tokenEstimate=JSON.stringify(payload).length/4;
+    const maxTokens=0.30/0.002*1000;
+    while(tokenEstimate>maxTokens && sample.length>1){
+      const ratio=maxTokens/tokenEstimate;
+      const newN=Math.max(1,Math.floor(sample.length*ratio));
+      sample=stratifiedSample(allProducts||[],newN);
+      payload=sample.map(p=>({
+        price:p.price,
+        rating:p.rating || (p.extras&&p.extras.rating),
+        units_sold:p.units_sold||(p.extras&&p.extras['Item Sold'])||0,
+        revenue:p.revenue||(p.extras&&p.extras['Revenue($)'])||0,
+        desire:p.desire_magnitude,
+        competition:p.competition_level,
+        oldness:computeOldnessDays(p)
+      }));
+      tokenEstimate=JSON.stringify(payload).length/4;
+    }
+    const cost=tokenEstimate/1000*0.002;
+    toast.info(`Analizando ${sample.length} productos (~$${cost.toFixed(2)})`);
+    const instruction='Devuelve SOLO un JSON plano con pesos 0-100 para estas 7 claves exactas, sin texto adicional:\n["price","rating","units_sold","revenue","desire","competition","oldness"]';
+    const prompt=`Basado en estos productos ${JSON.stringify(payload)}\n${instruction}`;
+    let res=await fetch('/custom_gpt',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt,response_format:{type:'json_object'}})});
+    if(!res.ok){
+      toast.error('No se pudo ajustar por IA. Revisa tu API Key o inténtalo más tarde.');
+      return;
+    }
+    const data=await res.json();
+    let raw=data.response||'';
+    console.debug('IA raw:', raw);
+    let obj;
+    if(typeof raw==='string'){
+      try{ obj=JSON.parse(raw); }
+      catch(e){
+        const m=raw.match(/\{[\s\S]*\}/);
+        if(m){ try{ obj=JSON.parse(m[0]); } catch(e2){} }
+      }
+    }else if(typeof raw==='object'){
+      obj=raw;
+    }
+    console.debug('IA parsed:', obj);
+    if(!obj || typeof obj!=='object'){
+      toast.error('No se pudo ajustar por IA. Revisa tu API Key o inténtalo más tarde.');
+      return;
+    }
+    const newWeights={};
+    for(const k of metricKeys){
+      let v=Number(obj[k]);
+      if(isNaN(v)){
+        const current=factors.find(f=>f.key===k);
+        v=current?current.weight:0;
+      }
+      if(v<0) v=0; if(v>100) v=100;
+      newWeights[k]=Math.round(v);
+    }
+    factors=factors.map(f=>({ ...f, weight:newWeights[f.key] ?? f.weight }));
+    renderFactors();
+    markDirty();
+    toast.success('Pesos ajustados por IA');
+  }catch(err){
+    console.error(err);
+    toast.error('No se pudo ajustar por IA. Revisa tu API Key o inténtalo más tarde.');
+  }
+}
+
+async function loadWeights(){
+  try{
+    const res = await fetch('/api/config/winner-weights');
+    const data = await res.json();
+    const weights = data.weights || {};
+    const order = Array.isArray(data.order) && data.order.length ? data.order : WEIGHT_KEYS;
+    const base = {};
+    WEIGHT_FIELDS.forEach(f=>{ base[f.key] = { ...f, weight:50 }; });
+    factors = order.filter(k=>base[k]).map(k=>({ ...base[k], weight: weights[k] !== undefined ? Math.round(weights[k]) : 50 }));
+    renderFactors();
+    clearDirty();
+    const resetBtn=document.getElementById('btnReset');
+    if(resetBtn) resetBtn.onclick=resetWeights;
+    const aiBtn=document.getElementById('btnAiWeights');
+    if(aiBtn) aiBtn.onclick=adjustWeightsAI;
+  }catch(err){
+    console.error('Error loading weights', err);
+  }
+}
+
+window.loadWeights = loadWeights;
+window.resetWeights = resetWeights;
+window.adjustWeightsAI = adjustWeightsAI;
+window.markDirty = markDirty;
+window.saveIfDirty = saveIfDirty;
+window.metricKeys = metricKeys;


### PR DESCRIPTION
## Summary
- Keep Reset and AI weights buttons always visible in config modal
- Make modal body scrollable with single-column weight cards
- Extract config modal logic into dedicated script with debounced autosave

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5949b8d1483289fc0734c71255f58