### PR TITLE
Add awareness factor to Winner Score

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ const FIELDS = [
   { key: "desire", label: "Desire" },
   { key: "competition", label: "Competition" },
   { key: "oldness", label: "Oldness" },
+  { key: "awareness", label: "Awareness" },
 ];
 
 const DEFAULTS_50 = {
@@ -19,6 +20,7 @@ const DEFAULTS_50 = {
   desire: 50,
   competition: 50,
   oldness: 50,
+  awareness: 50,
 };
 
 export default function SettingsModal() {

--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -186,6 +186,7 @@ SCORING_DEFAULT_WEIGHTS: Dict[str, float] = {
     "desire": 1.0,
     "competition": 1.0,
     "oldness": 1.0,
+    "awareness": 1.0,
 }
 
 

--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -91,3 +91,15 @@ def test_order_affects_score():
     res_price_first = ws.compute_winner_score_v2(prod, weights, order=["price", "rating"])
     res_rating_first = ws.compute_winner_score_v2(prod, weights, order=["rating", "price"])
     assert res_price_first["score"] != res_rating_first["score"]
+
+
+def test_awareness_weight_impacts_score():
+    ws.prepare_oldness_bounds([])
+    prod_low = {"awareness_level": "unaware"}
+    prod_high = {"awareness_level": "most aware"}
+    hi = ws.compute_winner_score_v2(prod_high, {"awareness": 100})
+    lo = ws.compute_winner_score_v2(prod_low, {"awareness": 100})
+    assert hi["score"] > lo["score"]
+    hi0 = ws.compute_winner_score_v2(prod_high, {"awareness": 0})
+    lo0 = ws.compute_winner_score_v2(prod_low, {"awareness": 0})
+    assert hi0["score"] == lo0["score"]


### PR DESCRIPTION
## Summary
- include `awareness` as a new Winner Score feature and weight
- map product awareness levels to numeric values in scoring pipeline
- expose awareness weight in settings and ensure old configs upgrade gracefully

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c598797bf883289552f23c72bc326d