### PR TITLE
Improve awareness scoring and recomputation

### DIFF
--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -116,3 +116,18 @@ def test_recommend_winner_weights_includes_awareness(monkeypatch):
     weights = res["weights"]
     assert set(weights) == {"price", "awareness"}
     assert math.isclose(sum(weights.values()), 1.0)
+
+
+def test_awareness_priority_and_closeness():
+    order = ws.awareness_priority_order_from_weight(44)
+    assert order == [2, 1, 3, 0, 4]
+    prod = {"awareness_level": "solution aware"}
+    val = ws.awareness_feature_value(prod, 44)
+    idx = ws.awareness_stage_index_from_product(prod)
+    expected = ws.awareness_closeness_from_weight(44, idx)
+    assert math.isclose(val, expected)
+
+
+def test_compute_effective_weights_includes_awareness():
+    eff = ws.compute_effective_weights({"awareness": 10}, [])
+    assert "awareness" in eff and eff["awareness"] > 0


### PR DESCRIPTION
## Summary
- score awareness by slider proximity using five stages and center distances
- ensure awareness weight is always considered and debounce score recomputation
- trigger winner score refresh after updating winner weights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c59e74a8dc8328afd52287f5060a62