### PR TITLE
Add winner score recompute endpoint and awareness closeness

### DIFF
--- a/product_research_app/api/__init__.py
+++ b/product_research_app/api/__init__.py
@@ -3,3 +3,6 @@ from flask import Flask
 app = Flask(__name__)
 
 from . import config  # noqa: E402,F401
+from .winner_score import bp as winner_score_bp  # noqa: E402
+
+app.register_blueprint(winner_score_bp)

--- a/product_research_app/api/config.py
+++ b/product_research_app/api/config.py
@@ -32,9 +32,9 @@ def api_patch_winner_weights():
     order_in = data.get("winner_order") or data.get("order")
     saved_weights, saved_order = update_winner_settings(raw_in, order_in)
     try:
-        recompute_scores_for_all_products(async_ok=True)
+        recompute_scores_for_all_products(scope="all")
     except Exception as e:
-        current_app.logger.warning(f"winner-score recompute deferred: {e}")
+        current_app.logger.warning(f"recompute on settings change failed: {e}")
     app.logger.info(
         "settings_saved winner_weights=%s winner_order_len=%s",
         len(saved_weights),

--- a/product_research_app/api/winner_score.py
+++ b/product_research_app/api/winner_score.py
@@ -1,0 +1,10 @@
+from flask import Blueprint, request, jsonify
+from product_research_app.services.winner_score import recompute_scores_for_all_products
+
+bp = Blueprint('winner_score_api', __name__)
+
+@bp.route('/api/winner-score/recompute', methods=['POST'])
+def recompute_api():
+    scope = (request.get_json(silent=True) or {}).get('scope', 'all')
+    n = recompute_scores_for_all_products(scope=scope)
+    return jsonify({"updated": n}), 200


### PR DESCRIPTION
## Summary
- add /api/winner-score/recompute endpoint
- compute awareness score by closeness to stage centers (10,30,50,70,90)
- trigger winner score recomputation after updating weights

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5a32a15b08328ba504f13cd52670f