### PR TITLE
Refine Awareness slider layout

### DIFF
--- a/product_research_app/api/__init__.py
+++ b/product_research_app/api/__init__.py
@@ -2,7 +2,13 @@ from flask import Flask
 
 app = Flask(__name__)
 
+# Import API modules which attach routes to ``app`` or expose blueprints.
 from . import config  # noqa: E402,F401
-from .winner_score import bp as winner_score_bp  # noqa: E402
+from .winner_score import winner_score_api  # noqa: E402
 
-app.register_blueprint(winner_score_bp)
+# Mount winner score blueprint under the /api namespace.
+app.register_blueprint(winner_score_api, url_prefix="/api")
+
+# Log registered routes for easier debugging in start-up logs.
+for r in app.url_map.iter_rules():
+    app.logger.info("ROUTE %s %s", ",".join(sorted(r.methods)), r.rule)

--- a/product_research_app/api/winner_score.py
+++ b/product_research_app/api/winner_score.py
@@ -1,10 +1,12 @@
 from flask import Blueprint, request, jsonify
 from product_research_app.services.winner_score import recompute_scores_for_all_products
 
-bp = Blueprint('winner_score_api', __name__)
+# Dedicated blueprint for winner score operations.  It will be mounted under
+# the ``/api`` prefix by the application factory.
+winner_score_api = Blueprint("winner_score_api", __name__)
 
-@bp.route('/api/winner-score/recompute', methods=['POST'])
+@winner_score_api.route("/winner-score/recompute", methods=["POST"])
 def recompute_api():
-    scope = (request.get_json(silent=True) or {}).get('scope', 'all')
+    scope = (request.get_json(silent=True) or {}).get("scope", "all")
     n = recompute_scores_for_all_products(scope=scope)
     return jsonify({"updated": n}), 200

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -761,24 +761,27 @@ body.dark .weight-card:nth-child(odd) { background: rgba(255,255,255,0.03); }
 .weight-card .meta{ margin-top:4px; }
 
 /* Awareness segmented slider */
-.segmented-range{ position:relative; }
-.segmented-range .segments{
-  position:absolute; inset:0 0 -18px 0;
-  display:grid; grid-template-columns:repeat(5,1fr);
+.segmented-range{ position:relative; margin:10px 0 6px; }
+input[type="range"].seg-awareness{ width:100%; display:block; margin:0; }
+.segmented-range .ticks{
   pointer-events:none;
+  position:absolute; top:50%; left:0; right:0; height:0;
+  transform: translateY(-50%);
 }
-.segmented-range .segments .seg{
-  position:relative; text-align:center; font-size:12px; opacity:.9; padding-top:4px;
+.segmented-range .ticks i{
+  position:absolute; top:-8px; width:1px; height:16px;
+  background: rgba(255,255,255,.28);
 }
-.segmented-range .segments .seg + .seg::before{
-  content:''; position:absolute; left:0; top:6px; bottom:22px; width:1px;
-  background: rgba(255,255,255,.25);
+.awareness-labels{
+  display:grid; grid-template-columns:repeat(5,1fr);
+  gap:0; margin-top:6px; font-size:12px; opacity:.95;
+  text-align:center;
 }
-.segmented-range .segments .seg::after{
-  content:''; position:absolute; left:0; right:0; top:6px; height:2px;
-  background: rgba(255,255,255,.12);
+.awareness-labels span{ padding-top:2px; }
+.awareness-labels span.active{
+  background: rgba(124,93,255,.12);
+  border-radius:6px;
 }
-input[type="range"].seg-awareness{ width:100%; margin:14px 0 22px 0; }
 
 
 .weight-badge {

--- a/product_research_app/static/js/config.js
+++ b/product_research_app/static/js/config.js
@@ -28,8 +28,6 @@ const metricKeys = WEIGHT_KEYS;
 let factors = [];
 let userConfig = {};
 
-const STAGE_LABELS = ['Unaware','Problem aware','Solution aware','Product aware','Most aware'];
-
 function defaultFactors(){
   return WEIGHT_FIELDS.map(f => ({ ...f, weight:50 }));
 }
@@ -53,9 +51,17 @@ function renderFactors(){
 
     <div class="segmented-range">
       <input id="awarenessSlider" class="weight-slider seg-awareness" type="range" min="0" max="100" step="1" />
-      <div class="segments" aria-hidden="true">
-        ${STAGE_LABELS.map(l=>`<div class="seg"><span>${l}</span></div>`).join('')}
+      <div class="ticks" aria-hidden="true">
+        <i style="left:20%"></i><i style="left:40%"></i><i style="left:60%"></i><i style="left:80%"></i>
       </div>
+    </div>
+
+    <div class="awareness-labels">
+      <span>Unaware</span>
+      <span>Problem aware</span>
+      <span>Solution aware</span>
+      <span>Product aware</span>
+      <span>Most aware</span>
     </div>
 
     <div class="meta"><span class="weight-badge">peso: <span id="awarenessWeight"></span>/100</span></div>
@@ -63,15 +69,17 @@ function renderFactors(){
   <div class="drag-handle" title="Arrastra para reordenar">≡</div>`;
       const slider = li.querySelector('#awarenessSlider');
       const weightEl = li.querySelector('#awarenessWeight');
-      slider.value = f.weight;
-      weightEl.textContent = f.weight;
-      slider.addEventListener('input', e => {
-        const v = Math.max(0, Math.min(100, parseInt(e.target.value,10)));
-        slider.value = v;
-        f.weight = v;
-        weightEl.textContent = v;
-        markDirty();
-      });
+      const segs = Array.from(li.querySelectorAll('.awareness-labels span'));
+      function setAw(v){
+        const val = Math.max(0, Math.min(100, parseInt(v,10) || 0));
+        f.weight = val;
+        slider.value = val;
+        weightEl.textContent = val;
+        const idx = Math.min(4, Math.floor(val/20));
+        segs.forEach((el,i)=>el.classList.toggle('active', i===idx));
+      }
+      setAw(f.weight);
+      slider.addEventListener('input', e => { setAw(e.target.value); markDirty(); });
     } else {
       li.innerHTML = `<div class="priority-badge">#${priority}</div><div class="content"><label for="weight-${f.key}" class="label">${f.label}</label><input id="weight-${f.key}" class="weight-range" type="range" min="0" max="100" step="1" value="${f.weight}"><div class="slider-extremes scale"><span class="extreme-left">${EXTREMES[f.key].left}</span><span class="extreme-right">${EXTREMES[f.key].right}</span></div><span class="weight-badge">peso: ${f.weight}/100</span></div><div class="drag-handle" aria-hidden>≡</div>`;
       const range = li.querySelector('.weight-range');


### PR DESCRIPTION
## Summary
- Rebuilt Awareness weight card with tick marks and labels beneath the slider.
- Added CSS grid layout and active-state highlighting for awareness stages.
- Debounced autosave now schedules `/api/winner-score/recompute` after updates.
- Registered winner score blueprint under `/api` and log routes at startup.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5a76564848328bd6b4d8fd3df7f3b