### PR TITLE
Recompute winner scores on weight update

### DIFF
--- a/product_research_app/api/__init__.py
+++ b/product_research_app/api/__init__.py
@@ -2,12 +2,8 @@ from flask import Flask
 
 app = Flask(__name__)
 
-# Import API modules which attach routes to ``app`` or expose blueprints.
+# Import API modules which attach routes to ``app``.
 from . import config  # noqa: E402,F401
-from .winner_score import winner_score_api  # noqa: E402
-
-# Mount winner score blueprint under the /api namespace.
-app.register_blueprint(winner_score_api, url_prefix="/api")
 
 # Log registered routes for easier debugging in start-up logs.
 for r in app.url_map.iter_rules():

--- a/product_research_app/api/config.py
+++ b/product_research_app/api/config.py
@@ -1,25 +1,37 @@
 from flask import request, jsonify, current_app
 from . import app
 
-from product_research_app.services.config import (
-    get_winner_weights_raw,
-    get_winner_order_raw,
-    update_winner_settings,
-    compute_effective_int,
+from product_research_app.services.winner_score import (
+    recompute_scores_for_all_products,
+    load_settings,
+    save_settings,
 )
-from product_research_app.services.winner_score import recompute_scores_for_all_products
+
+
+def _coerce_weights(raw: dict | None) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for k, v in (raw or {}).items():
+        try:
+            iv = int(round(float(v)))
+        except Exception:
+            iv = 0
+        out[k] = max(0, min(100, iv))
+    return out
+
+
+def _merge_winner_weights(current: dict | None, incoming: dict | None) -> dict:
+    cur = dict(current or {})
+    cur.update(incoming or {})
+    return cur
 
 
 # GET /api/config/winner-weights
 @app.route("/api/config/winner-weights", methods=["GET"])
 def api_get_winner_weights():
-    raw = get_winner_weights_raw()
-    order = get_winner_order_raw()
-    resp = jsonify({
-        "weights": raw,
-        "order": order,
-        "effective": {"int": compute_effective_int(raw, order)},
-    })
+    settings = load_settings()
+    weights = settings.get("winner_weights") or {}
+    order = settings.get("winner_order") or list(weights.keys())
+    resp = jsonify({"winner_weights": weights, "winner_order": order})
     resp.headers["Cache-Control"] = "no-store"
     return resp
 
@@ -27,23 +39,36 @@ def api_get_winner_weights():
 # PATCH /api/config/winner-weights
 @app.route("/api/config/winner-weights", methods=["PATCH"])
 def api_patch_winner_weights():
-    data = request.get_json(force=True) or {}
-    raw_in = data.get("winner_weights") or data.get("weights") or {}
-    order_in = data.get("winner_order") or data.get("order")
-    saved_weights, saved_order = update_winner_settings(raw_in, order_in)
+    payload = request.get_json(force=True) or {}
+    incoming = _coerce_weights(payload.get("winner_weights") or payload)
+
+    settings = load_settings()
+
+    if "awareness" not in incoming and "awareness" not in (settings.get("winner_weights") or {}):
+        incoming["awareness"] = 50
+
+    settings["winner_weights"] = _merge_winner_weights(settings.get("winner_weights"), incoming)
+
+    order = settings.get("winner_order") or list(settings["winner_weights"].keys())
+    if "awareness" not in order:
+        order.append("awareness")
+    settings["winner_order"] = order
+
+    save_settings(settings)
+
+    updated = 0
     try:
-        recompute_scores_for_all_products(scope="all")
+        updated = recompute_scores_for_all_products(scope="all")
     except Exception as e:
-        current_app.logger.warning(f"recompute on settings change failed: {e}")
-    app.logger.info(
-        "settings_saved winner_weights=%s winner_order_len=%s",
-        len(saved_weights),
-        len(saved_order),
+        current_app.logger.warning("recompute on save failed: %s", e)
+
+    resp = jsonify(
+        {
+            "ok": True,
+            "updated": updated,
+            "winner_weights": settings["winner_weights"],
+            "winner_order": order,
+        }
     )
-    resp = jsonify({
-        "weights": saved_weights,
-        "order": saved_order,
-        "effective": {"int": compute_effective_int(saved_weights, saved_order)},
-    })
     resp.headers["Cache-Control"] = "no-store"
-    return resp
+    return resp, 200

--- a/product_research_app/static/js/net.js
+++ b/product_research_app/static/js/net.js
@@ -40,10 +40,10 @@ export async function updateProductField(id, data, timeoutMs = 25000) {
   }, timeoutMs);
 }
 
-export async function updateSettings(data, timeoutMs = 25000) {
-  return fetchJson('/api/config/winner-weights', {
+export async function patch(url, data, timeoutMs = 25000) {
+  return fetchJson(url, {
     method: 'PATCH',
-    body: JSON.stringify({ weights: data.winner_weights, order: data.winner_order }),
+    body: JSON.stringify(data),
   }, timeoutMs);
 }
 


### PR DESCRIPTION
## Summary
- ensure PATCH `/api/config/winner-weights` always coerces and merges integer weights, adds default awareness weight, and recomputes scores inline
- expose simple `load_settings`/`save_settings` helpers and streamlined awareness feature extraction
- drop registration of the obsolete `/api/winner-score/recompute` endpoint
- autosave config weights from frontend without extra recompute call and refresh product table

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5a9fdc83483288d45be2014b95336