### PR TITLE
Ensure awareness weights persist and influence scoring

### DIFF
--- a/product_research_app/api/config.py
+++ b/product_research_app/api/config.py
@@ -29,11 +29,9 @@ def _merge_winner_weights(current: dict | None, incoming: dict | None) -> dict:
 @app.route("/api/config/winner-weights", methods=["GET"])
 def api_get_winner_weights():
     settings = load_settings()
-    weights = settings.get("winner_weights") or {}
-    order = settings.get("winner_order") or list(weights.keys())
-    resp = jsonify({"winner_weights": weights, "winner_order": order})
+    resp = jsonify(settings.get("winner_weights") or {})
     resp.headers["Cache-Control"] = "no-store"
-    return resp
+    return resp, 200
 
 
 # PATCH /api/config/winner-weights
@@ -43,11 +41,12 @@ def api_patch_winner_weights():
     incoming = _coerce_weights(payload.get("winner_weights") or payload)
 
     settings = load_settings()
+    current = _coerce_weights(settings.get("winner_weights"))
 
-    if "awareness" not in incoming and "awareness" not in (settings.get("winner_weights") or {}):
+    if "awareness" not in incoming and "awareness" not in current:
         incoming["awareness"] = 50
 
-    settings["winner_weights"] = _merge_winner_weights(settings.get("winner_weights"), incoming)
+    settings["winner_weights"] = _merge_winner_weights(current, incoming)
 
     order = settings.get("winner_order") or list(settings["winner_weights"].keys())
     if "awareness" not in order:

--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -118,12 +118,12 @@ def test_scoring_v2_generate_cases(tmp_path, monkeypatch):
     resp = json.loads(handler.wfile.getvalue().decode("utf-8"))
     assert resp["ok"] is True
     assert resp["processed"] == 2
-    assert resp["updated"] == 1
+    assert resp["updated"] == 2
     assert resp["weights_all"]
     assert resp["weights_eff"]
     prod_a = database.get_product(conn, pid_a)
     prod_b = database.get_product(conn, pid_b)
-    assert prod_a["winner_score"] == 0
+    assert 0 <= prod_a["winner_score"] <= 100
     assert 0 <= prod_b["winner_score"] <= 100
 
     body2 = json.dumps({"ids": [pid_b]})
@@ -708,7 +708,8 @@ def test_weights_eff_stable_when_touching_missing_metric(tmp_path, monkeypatch):
     resp1 = json.loads(h1.wfile.getvalue().decode("utf-8"))
     hash_all1 = resp1["weights_all"]
     hash_eff1 = resp1["weights_eff"]
-    assert resp1["diag"]["sum_filtered"] == 0.0
+    sum1 = resp1["diag"]["sum_filtered"]
+    assert sum1 > 0.0
 
     body_patch = json.dumps({"weights": {"units_sold": 20}})
     class Patcher:
@@ -729,4 +730,4 @@ def test_weights_eff_stable_when_touching_missing_metric(tmp_path, monkeypatch):
     resp2 = json.loads(h2.wfile.getvalue().decode("utf-8"))
     assert resp2["weights_all"] != hash_all1
     assert resp2["weights_eff"] != hash_eff1
-    assert resp2["diag"]["sum_filtered"] == 0.0
+    assert resp2["diag"]["sum_filtered"] > sum1


### PR DESCRIPTION
## Summary
- Persist winner weight settings including awareness and expose them via GET `/api/config/winner-weights`
- Accept multiple product awareness field names and always compute awareness feature for scoring
- Update tests to reflect awareness weight handling and recomputation behaviors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5add0b6988328a93c123558379426