### PR TITLE
feat: load and save weights from backend

### DIFF
--- a/product_research_app/static/js/config.js
+++ b/product_research_app/static/js/config.js
@@ -112,11 +112,11 @@ function resetWeights(){
 
 async function saveSettings(){
   const payload = {
-    // usar "weights" (no "winner_weights") y persistir el orden visible
+    // Backend espera "weights" (0–100 enteros) y también "order"
     weights: Object.fromEntries(
-      factors.map(f => [f.key, Math.max(0, Math.min(100, Math.round(Number(f.weight))))])
+      (window.factors || []).map(f => [f.key, Math.max(0, Math.min(100, Math.round(Number(f.weight))))])
     ),
-    order: factors.map(f => f.key)
+    order: (window.factors || []).map(f => f.key)
   };
   try{
     await fetch('/api/config/winner-weights', {
@@ -273,29 +273,36 @@ async function adjustWeightsAI(){
 async function openConfigModal(){
   try{
     const res = await fetch('/api/config/winner-weights');
-    const data = await res.json(); // { weights, order, effective:{int:...} }
+    const data = await res.json(); // backend: { weights, order, effective? }  (o legado: mapa plano)
 
-    const weights = (data && data.weights) ? data.weights : {};
+    // Soporta ambas formas (nueva y legacy)
+    const weights = (data && data.weights) ? data.weights : (data || {});
     const order   = (data && Array.isArray(data.order) && data.order.length)
       ? data.order
       : (typeof WEIGHT_KEYS !== 'undefined' ? WEIGHT_KEYS : Object.keys(weights));
 
-    // Construye factors en el ORDEN guardado, con fallback de peso=50
-    const byKey = Object.fromEntries(WEIGHT_FIELDS.map(f => [f.key, f]));
+    // Construcción de factors respetando orden y pesos persistidos
+    const fieldList = (typeof WEIGHT_FIELDS !== 'undefined' && Array.isArray(WEIGHT_FIELDS)) ? WEIGHT_FIELDS : [];
+    const byKey = Object.fromEntries(fieldList.map(f => [f.key, f]));
+
     window.factors = order
-      .filter(k => byKey[k])
+      .filter(k => byKey[k]) // ignora claves desconocidas
       .map(k => ({
         ...byKey[k],
-        weight: (weights[k] !== undefined && !isNaN(weights[k])) ? Math.round(Number(weights[k])) : 50
+        weight: (weights[k] !== undefined && !isNaN(weights[k]))
+          ? Math.round(Number(weights[k]))
+          : 50
       }));
 
     renderFactors();
 
-    const resetBtn=document.getElementById('btnReset');
+    // Wire de botones (no dupliques si ya existe)
+    const resetBtn = document.getElementById('btnReset');
     if (resetBtn) resetBtn.onclick = resetWeights;
-    const aiBtn=document.getElementById('btnAiWeights');
+    const aiBtn = document.getElementById('btnAiWeights');
     if (aiBtn) aiBtn.onclick = adjustWeightsAI;
 
+    console.debug('openConfigModal -> weights/order aplicados:', { weights, order });
   }catch(err){
     console.error('Error loading weights', err);
   }


### PR DESCRIPTION
## Summary
- fetch winner weight config from backend for modal
- send weights and order when saving config

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5c5a483608328b5e9b99857900cff