### PR TITLE
Fix modal weight persistence and backend compatibility

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -35,7 +35,10 @@ export default function SettingsModal() {
       .then((r) => r.json())
       .then((d) => {
         if (!alive) return;
-        const raw = d && typeof d === "object" ? d : {};
+        const raw =
+          d && typeof d === "object"
+            ? (d.weights || d.winner_weights || d)
+            : {};
         setWeights({ ...DEFAULTS_50, ...raw });
         loadedRef.current = true;
       })
@@ -54,7 +57,7 @@ export default function SettingsModal() {
       fetch("/api/config/winner-weights", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ winner_weights: next }),
+        body: JSON.stringify({ weights: next }),
         keepalive: true,
       }).catch(() => {});
     };


### PR DESCRIPTION
## Summary
- Ensure `/api/config/winner-weights` returns and accepts both `weights`/`order` and legacy `winner_*` keys
- Load persisted weights/order in config modal while preventing initial autosave
- Update React SettingsModal to parse new payload shape

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5ca5cabe88328bfca729f3efa793f