### PR TITLE
feat: support flexible winner weight config

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -35,8 +35,8 @@ export default function SettingsModal() {
       .then((r) => r.json())
       .then((d) => {
         if (!alive) return;
-        const raw = d && typeof d === "object" ? d : {};
-        setWeights({ ...DEFAULTS_50, ...raw });
+        const raw = d && d.weights ? d.weights : d;
+        setWeights({ ...DEFAULTS_50, ...(raw || {}) });
         loadedRef.current = true;
       })
       .catch(() => {
@@ -54,7 +54,7 @@ export default function SettingsModal() {
       fetch("/api/config/winner-weights", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ winner_weights: next }),
+        body: JSON.stringify({ winner_weights: next, order: FIELDS.map((f) => f.key) }),
         keepalive: true,
       }).catch(() => {});
     };


### PR DESCRIPTION
## Summary
- make `/api/config/winner-weights` tolerant: GET exposes legacy flat map plus `{weights,order,effective}` and PATCH accepts flat, `weights`, or `winner_weights` payloads
- ensure Node server mirrors API behaviour for GET/PATCH
- update config modal to load and persist ordered weights without autosaving defaults
- support new weight shape in React SettingsModal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5cd3163dc8328a58c093eba864445