### PR TITLE
Fix configuration modal weights hydration and toggles

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -736,6 +736,9 @@ input[type="range"].weight-range { width: 100% !important; }
 body.dark .weight-card:nth-child(odd) { background: rgba(255,255,255,0.03); }
 .weights-list .weight-card:nth-child(odd){ margin-bottom:0; }
 
+.weight-item.disabled{ opacity:0.5; }
+.weight-item.disabled .weight-input{ pointer-events:none; cursor:not-allowed; }
+
 .priority-badge {
   width: 40px;
   height: 40px;

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -238,7 +238,7 @@ import * as api from "/static/js/net.js";
 import * as groupsService from "/static/js/groups-service.js";
 const { fetchJson } = api;
 const metricKeys = window.metricKeys;
-const openConfigModal = window.openConfigModal;
+const hydrateSettingsModal = window.hydrateSettingsModal;
 const saveIfDirty = window.saveIfDirty;
 window.fetchJson = fetchJson;
 window.groupsService = groupsService;
@@ -911,7 +911,7 @@ window.onload = async () => {
 };
 // Toggle config panel
 document.getElementById('configBtn').onclick = async () => {
-  await openConfigModal();
+  await hydrateSettingsModal();
   const cfg = document.getElementById('config');
   const wcard = document.getElementById('weightsCard');
   const footer = document.getElementById('weightsFooter');


### PR DESCRIPTION
## Summary
- Hydrate config modal on open to render weights with enabled toggles
- Persist weight order and enabled flags, including AI adjustments
- Style disabled weight items and numeric inputs

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68c69169092c832886ff6eb34afc7991