### PR TITLE
Fix configuration modal weights hydration and toggles

### DIFF
--- a/product_research_app/services/config.py
+++ b/product_research_app/services/config.py
@@ -16,6 +16,7 @@ ALLOWED_FIELDS = (
 )
 DEFAULT_WEIGHTS_RAW: Dict[str, int] = {k: 50 for k in ALLOWED_FIELDS}
 DEFAULT_ORDER: List[str] = list(ALLOWED_FIELDS)
+DEFAULT_ENABLED: Dict[str, bool] = {k: True for k in ALLOWED_FIELDS}
 
 # Compatibility placeholder; not used but kept for tests that monkeypatch it
 DB_PATH = Path(__file__).resolve().parents[1] / "data.sqlite3"
@@ -59,6 +60,18 @@ def init_app_config() -> None:
         if "awareness" not in order:
             order.append("awareness")
             changed = True
+    enabled = cfg.get("weights_enabled")
+    if not isinstance(enabled, dict):
+        cfg["weights_enabled"] = DEFAULT_ENABLED.copy()
+        changed = True
+    else:
+        for k in ALLOWED_FIELDS:
+            if k not in enabled:
+                enabled[k] = True
+                changed = True
+    if "weights_order" not in cfg and "winner_order" in cfg:
+        cfg["weights_order"] = list(cfg["winner_order"])
+        changed = True
     if "weightsUpdatedAt" not in cfg:
         cfg["weightsUpdatedAt"] = int(time.time())
         changed = True
@@ -66,7 +79,7 @@ def init_app_config() -> None:
         save_config(cfg)
 
 
-def _load() -> Tuple[Dict[str, int], List[str]]:
+def _load() -> Tuple[Dict[str, int], List[str], Dict[str, bool]]:
     cfg = load_config()
     weights = cfg.get("winner_weights")
     if not isinstance(weights, dict) or not weights:
@@ -74,19 +87,31 @@ def _load() -> Tuple[Dict[str, int], List[str]]:
     weights = _coerce_weights(weights)
     for k, v in DEFAULT_WEIGHTS_RAW.items():
         weights.setdefault(k, v)
-    order = _normalize_order(cfg.get("winner_order"), weights)
-    return weights, order
+    raw_order = cfg.get("weights_order") or cfg.get("winner_order")
+    order = _normalize_order(raw_order, weights)
+    enabled = cfg.get("weights_enabled")
+    if not isinstance(enabled, dict):
+        enabled = {k: True for k in weights.keys()}
+    else:
+        enabled = {k: bool(enabled.get(k, True)) for k in weights.keys()}
+    if cfg.get("weights_enabled") != enabled or cfg.get("weights_order") != order:
+        cfg["weights_enabled"] = enabled
+        cfg["weights_order"] = order
+        save_config(cfg)
+    return weights, order, enabled
 
 
-def update_winner_settings(weights_in=None, order_in=None) -> Tuple[Dict[str, int], List[str]]:
+def update_winner_settings(weights_in=None, order_in=None, enabled_in=None) -> Tuple[Dict[str, int], List[str], Dict[str, bool]]:
     init_app_config()
     cfg = load_config()
     weights = cfg.get("winner_weights", DEFAULT_WEIGHTS_RAW.copy())
-    order = cfg.get("winner_order", DEFAULT_ORDER.copy())
+    order = cfg.get("weights_order") or cfg.get("winner_order", DEFAULT_ORDER.copy())
+    enabled = cfg.get("weights_enabled", DEFAULT_ENABLED.copy())
     weights = _coerce_weights(weights)
     for k, v in DEFAULT_WEIGHTS_RAW.items():
         weights.setdefault(k, v)
     order = _normalize_order(order, weights)
+    enabled = {k: bool(enabled.get(k, True)) for k in weights.keys()}
     if weights_in is not None:
         wi = _coerce_weights(weights_in)
         weights.update(wi)
@@ -94,31 +119,48 @@ def update_winner_settings(weights_in=None, order_in=None) -> Tuple[Dict[str, in
             weights.setdefault(k, v)
     if order_in is not None:
         order = _normalize_order(order_in, weights)
+    if enabled_in is not None:
+        ei = {k: bool(v) for k, v in (enabled_in or {}).items() if k in weights}
+        enabled.update(ei)
+        for k in weights.keys():
+            enabled.setdefault(k, True)
     cfg["winner_weights"] = weights
     cfg["winner_order"] = order
+    cfg["weights_order"] = order
+    cfg["weights_enabled"] = enabled
     cfg["weightsUpdatedAt"] = int(time.time())
     save_config(cfg)
-    return weights, order
+    return weights, order, enabled
 
 
 def get_winner_weights_raw() -> Dict[str, int]:
-    weights, _ = _load()
+    weights, _, _ = _load()
     return weights
 
 
 def get_winner_order_raw() -> List[str]:
-    _, order = _load()
+    _, order, _ = _load()
     return order
 
 
+def get_winner_enabled_raw() -> Dict[str, bool]:
+    _, _, enabled = _load()
+    return enabled
+
+
 def set_winner_weights_raw(weights: Dict[str, object]) -> Dict[str, int]:
-    weights, _ = update_winner_settings(weights_in=weights, order_in=None)
+    weights, _, _ = update_winner_settings(weights_in=weights, order_in=None, enabled_in=None)
     return weights
 
 
 def set_winner_order_raw(order: List[str]) -> List[str]:
-    _, order = update_winner_settings(weights_in=None, order_in=order)
+    _, order, _ = update_winner_settings(weights_in=None, order_in=order, enabled_in=None)
     return order
+
+
+def set_winner_enabled_raw(enabled: Dict[str, object]) -> Dict[str, bool]:
+    _, _, enabled_out = update_winner_settings(weights_in=None, order_in=None, enabled_in=enabled)
+    return enabled_out
 
 
 # Útil para logs/cálculo: pesos efectivos enteros 0..100 considerando prioridad

--- a/product_research_app/services/winner_score.py
+++ b/product_research_app/services/winner_score.py
@@ -15,6 +15,8 @@ from .config import (
     get_winner_weights_raw,
     set_winner_weights_raw,
     get_winner_order_raw,
+    get_winner_enabled_raw,
+    set_winner_enabled_raw,
     DB_PATH as CONFIG_DB_PATH,
 )
 from ..config import load_config, save_config
@@ -175,6 +177,7 @@ def prepare_oldness_bounds(rows: Iterable[Any]) -> None:
 
 WEIGHTS_CACHE: Dict[str, float] | None = None
 ORDER_CACHE: list[str] | None = None
+ENABLED_CACHE: Dict[str, bool] | None = None
 WEIGHTS_VERSION: int = 0
 
 
@@ -202,9 +205,10 @@ def sanitize_weights(weights: dict | None) -> dict:
 
 
 def invalidate_weights_cache() -> None:
-    global WEIGHTS_CACHE, ORDER_CACHE, WEIGHTS_VERSION
+    global WEIGHTS_CACHE, ORDER_CACHE, ENABLED_CACHE, WEIGHTS_VERSION
     WEIGHTS_CACHE = None
     ORDER_CACHE = None
+    ENABLED_CACHE = None
     WEIGHTS_VERSION += 1
 
 
@@ -228,8 +232,8 @@ def normalize_weight_key(key: str) -> str:
 def load_winner_weights_raw() -> Dict[str, Any]:
     """Return persisted weights with minimal metadata."""
 
-    w, o = load_winner_settings()
-    return {"weights": w, "order": o}
+    w, o, e = load_winner_settings()
+    return {"weights": w, "order": o, "enabled": e}
 
 
 def save_winner_weights_raw(data: Dict[str, Any]) -> None:
@@ -238,24 +242,32 @@ def save_winner_weights_raw(data: Dict[str, Any]) -> None:
         from .config import set_winner_order_raw
 
         set_winner_order_raw(data.get("order", []))
+    if "enabled" in data:
+        set_winner_enabled_raw(data.get("enabled", {}))
     invalidate_weights_cache()
 
 
-def load_winner_settings() -> tuple[Dict[str, float], list[str]]:
-    global WEIGHTS_CACHE, ORDER_CACHE
-    if WEIGHTS_CACHE is not None and ORDER_CACHE is not None:
-        return WEIGHTS_CACHE, ORDER_CACHE
+def load_winner_settings() -> tuple[Dict[str, float], list[str], Dict[str, bool]]:
+    global WEIGHTS_CACHE, ORDER_CACHE, ENABLED_CACHE
+    if (
+        WEIGHTS_CACHE is not None
+        and ORDER_CACHE is not None
+        and ENABLED_CACHE is not None
+    ):
+        return WEIGHTS_CACHE, ORDER_CACHE, ENABLED_CACHE
     weights = get_winner_weights_raw()
     order = get_winner_order_raw()
+    enabled = get_winner_enabled_raw()
     WEIGHTS_CACHE = weights
     ORDER_CACHE = order
-    return weights, order
+    ENABLED_CACHE = enabled
+    return weights, order, enabled
 
 
 def load_winner_weights() -> Dict[str, float]:
     """Load Winner Score weights (RAW integers)."""
 
-    weights, _ = load_winner_settings()
+    weights, _, _ = load_winner_settings()
     return weights
 
 
@@ -536,7 +548,10 @@ NORMALIZERS: Dict[str, Callable[[float], float]] = {
 
 
 def compute_winner_score_v2(
-    product_row: Any, user_weights: Dict[str, float], order: Optional[list[str]] = None
+    product_row: Any,
+    user_weights: Dict[str, float],
+    order: Optional[list[str]] = None,
+    enabled: Optional[Dict[str, bool]] = None,
 ) -> Dict[str, Any]:
     """Compute Winner Score using available features only."""
 
@@ -552,7 +567,9 @@ def compute_winner_score_v2(
     raw_vals["awareness"] = awareness_feature_value(product_row, w_aw)
 
     present = list(raw_vals.keys())
-    missing_fields = [f for f in ALLOWED_FIELDS if f not in present]
+    enabled = enabled or {}
+    disabled_fields = [f for f in ALLOWED_FIELDS if not enabled.get(f, True)]
+    missing_fields = [f for f in ALLOWED_FIELDS if f not in present and f not in disabled_fields]
 
     dir_old, w_old_intensity = _oldness_pref_and_weight(user_weights)
 
@@ -565,6 +582,9 @@ def compute_winner_score_v2(
 
     weights_for_priority = {k: int(round(user_weights.get(k, 0))) for k in ALLOWED_FIELDS}
     weights_for_priority["oldness"] = int(round(w_old_intensity * 100))
+    for k in ALLOWED_FIELDS:
+        if not enabled.get(k, True):
+            weights_for_priority[k] = 0
     if order is None:
         order = list(weights_for_priority.keys())
     eff_all = compute_effective_weights(weights_for_priority, order)
@@ -579,8 +599,9 @@ def compute_winner_score_v2(
         "score": score_int,
         "score_float": score_float,
         "used": len(present),
-        "missing": len(ALLOWED_FIELDS) - len(present),
+        "missing": len(missing_fields),
         "missing_fields": missing_fields,
+        "disabled_fields": disabled_fields,
         "present_fields": present,
         "effective_weights": eff_all_full,
         "sum_filtered": sum_filtered,
@@ -608,9 +629,10 @@ def generate_winner_scores(
     """
 
     if weights is None:
-        weights, order = load_winner_settings()
+        weights, order, enabled = load_winner_settings()
     else:
         order = get_winner_order_raw()
+        enabled = get_winner_enabled_raw()
 
     dir_old, w_old_intensity = _oldness_pref_and_weight(weights)
     oldness_ui = float(weights.get("oldness", 50))
@@ -644,10 +666,11 @@ def generate_winner_scores(
     for row in rows:
         pid = row["id"]
         old_score = row["winner_score"]
-        res = compute_winner_score_v2(row, weights, order)
+        res = compute_winner_score_v2(row, weights, order, enabled)
         sf = res.get("score_float") or 0.0
         present = set(res.get("present_fields", []))
         missing = set(res.get("missing_fields", []))
+        disabled = set(res.get("disabled_fields", []))
         eff_w = {k: round(v, 3) for k, v in res.get("effective_weights", {}).items()}
         eff_hash = hashlib.sha1(
             json.dumps(res.get("effective_weights", {}), sort_keys=True).encode("utf-8")
@@ -675,7 +698,7 @@ def generate_winner_scores(
 
         if not present:
             logger.warning(
-                "Winner Score: product=%s score_int=%s score_raw=%.3f weights_all=%s weights_eff=%s present=%s missing=%s "
+                "Winner Score: product=%s score_int=%s score_raw=%.3f weights_all=%s weights_eff=%s present=%s disabled=%s missing=%s "
                 "effective_weights=%s order=%s weights_effective_int=%s oldness_dir=%s oldness_intensity=%.3f oldness_ui=%.1f no_features_present",
                 pid,
                 new_score,
@@ -683,6 +706,7 @@ def generate_winner_scores(
                 weights_hash_all,
                 eff_hash,
                 present,
+                disabled,
                 missing,
                 eff_w,
                 ord_list,
@@ -693,7 +717,7 @@ def generate_winner_scores(
             )
         else:
             logger.info(
-                "Winner Score: product=%s score_int=%s score_raw=%.3f weights_all=%s weights_eff=%s present=%s missing=%s "
+                "Winner Score: product=%s score_int=%s score_raw=%.3f weights_all=%s weights_eff=%s present=%s disabled=%s missing=%s "
                 "effective_weights=%s order=%s weights_effective_int=%s oldness_dir=%s oldness_intensity=%.3f oldness_ui=%.1f",
                 pid,
                 new_score,
@@ -701,6 +725,7 @@ def generate_winner_scores(
                 weights_hash_all,
                 eff_hash,
                 present,
+                disabled,
                 missing,
                 eff_w,
                 ord_list,

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -736,6 +736,9 @@ input[type="range"].weight-range { width: 100% !important; }
 body.dark .weight-card:nth-child(odd) { background: rgba(255,255,255,0.03); }
 .weights-list .weight-card:nth-child(odd){ margin-bottom:0; }
 
+.weight-item.disabled{ opacity:0.5; }
+.weight-item.disabled .weight-input{ pointer-events:none; cursor:not-allowed; }
+
 .priority-badge {
   width: 40px;
   height: 40px;

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -238,7 +238,7 @@ import * as api from "/static/js/net.js";
 import * as groupsService from "/static/js/groups-service.js";
 const { fetchJson } = api;
 const metricKeys = window.metricKeys;
-const openConfigModal = window.openConfigModal;
+const hydrateSettingsModal = window.hydrateSettingsModal;
 const saveIfDirty = window.saveIfDirty;
 window.fetchJson = fetchJson;
 window.groupsService = groupsService;
@@ -911,7 +911,7 @@ window.onload = async () => {
 };
 // Toggle config panel
 document.getElementById('configBtn').onclick = async () => {
-  await openConfigModal();
+  await hydrateSettingsModal();
   const cfg = document.getElementById('config');
   const wcard = document.getElementById('weightsCard');
   const footer = document.getElementById('weightsFooter');

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -2595,7 +2595,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         ids = [int(x) for x in ids_param.split(",") if x.strip()]
 
         conn = ensure_db()
-        weights = winner_calc.load_winner_weights()
+        weights, order, enabled = winner_calc.load_winner_settings()
 
         if ids:
             placeholders = ",".join("?" for _ in ids)
@@ -2611,7 +2611,7 @@ class RequestHandler(BaseHTTPRequestHandler):
 
         data: Dict[str, Any] = {}
         for row in rows:
-            res = winner_calc.compute_winner_score_v2(row, weights)
+            res = winner_calc.compute_winner_score_v2(row, weights, order, enabled)
             sf = res.get("score_float") or 0.0
             score_raw = max(0.0, min(1.0, sf)) * 100.0
             data[row["id"]] = {


### PR DESCRIPTION
## Summary
- Hydrate config modal on open to render weights with enabled toggles
- Persist weight order and enabled flags, including AI adjustments
- Style disabled weight items and numeric inputs
- Add backend support for weights_enabled/order in config and Winner Score

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69169092c832886ff6eb34afc7991