### PR TITLE
feat: add metric toggles in settings modal

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -76,6 +76,23 @@ def load_config() -> Dict[str, Any]:
         changed = True
     if _merge_defaults(data, DEFAULT_CONFIG):
         changed = True
+
+    # ensure weights_enabled defaulting to True for all weight keys
+    weights_map = data.get("winner_weights")
+    if isinstance(weights_map, dict):
+        enabled = data.get("weights_enabled")
+        if not isinstance(enabled, dict):
+            data["weights_enabled"] = {k: True for k in weights_map.keys()}
+            changed = True
+        else:
+            for k in weights_map.keys():
+                if k not in enabled:
+                    enabled[k] = True
+                    changed = True
+    if "winner_order" in data and "weights_order" not in data:
+        data["weights_order"] = list(data["winner_order"])
+        changed = True
+
     if changed:
         save_config(data)
     return data

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -759,6 +759,7 @@ body.dark .weight-card:nth-child(odd) { background: rgba(255,255,255,0.03); }
 .weight-card .label{ margin-bottom:2px; }
 .weight-card .scale{ margin-top:2px; }
 .weight-card .meta{ margin-top:4px; }
+.weight-card.disabled{ opacity:0.5; }
 
 /* Awareness segmented slider */
 .segmented-range{ position:relative; margin:10px 0 6px; }

--- a/product_research_app/static/js/config.js
+++ b/product_research_app/static/js/config.js
@@ -29,7 +29,7 @@ let factors = [];
 let userConfig = {};
 
 function defaultFactors(){
-  return WEIGHT_FIELDS.map(f => ({ ...f, weight:50 }));
+  return WEIGHT_FIELDS.map(f => ({ ...f, weight:50, enabled:true }));
 }
 let saveTimer=null;
 let isInitialRender = true;
@@ -38,7 +38,7 @@ function markDirty(){
   saveTimer=setTimeout(saveSettings,700);
 }
 
-function renderFactors(){
+function renderWeightsUI(){
   const list = document.getElementById('weightsList');
   if(!list) return;
   list.innerHTML = '';
@@ -84,6 +84,28 @@ function renderFactors(){
         updateAw(e.target.value);
         if(!isInitialRender) markDirty();
       });
+      const contentEl = li.querySelector('.content');
+      const toggle = document.createElement('div');
+      toggle.className = 'weight-toggle';
+      toggle.innerHTML = '<input type="checkbox" class="wt-enabled" aria-label="Activar métrica" />';
+      contentEl.appendChild(toggle);
+      const cb = toggle.querySelector('input');
+      cb.checked = f.enabled !== false;
+      cb.addEventListener('change', e => {
+        const on = !!e.target.checked;
+        f.enabled = on;
+        for (const el of li.querySelectorAll('input[type="range"], input[type="number"]')) {
+          el.disabled = !on;
+        }
+        li.classList.toggle('disabled', !on);
+        if(!isInitialRender) markDirty();
+      });
+      if(!cb.checked){
+        for (const el of li.querySelectorAll('input[type="range"], input[type="number"]')) {
+          el.disabled = true;
+        }
+        li.classList.add('disabled');
+      }
     } else {
       li.innerHTML = `<div class="priority-badge">#${priority}</div><div class="content"><label for="weight-${f.key}" class="label">${f.label}</label><input id="weight-${f.key}" class="weight-range" type="range" min="0" max="100" step="1" value="${f.weight}"><div class="slider-extremes scale"><span class="extreme-left">${EXTREMES[f.key].left}</span><span class="extreme-right">${EXTREMES[f.key].right}</span></div><span class="weight-badge">peso: ${f.weight}/100</span></div><div class="drag-handle" aria-hidden>≡</div>`;
       const range = li.querySelector('.weight-range');
@@ -94,13 +116,35 @@ function renderFactors(){
         li.querySelector('.weight-badge').textContent = `peso: ${f.weight}/100`;
         if(!isInitialRender) markDirty();
       });
+      const contentEl = li.querySelector('.content');
+      const toggle = document.createElement('div');
+      toggle.className = 'weight-toggle';
+      toggle.innerHTML = '<input type="checkbox" class="wt-enabled" aria-label="Activar métrica" />';
+      contentEl.appendChild(toggle);
+      const cb = toggle.querySelector('input');
+      cb.checked = f.enabled !== false;
+      cb.addEventListener('change', e => {
+        const on = !!e.target.checked;
+        f.enabled = on;
+        for (const el of li.querySelectorAll('input[type="range"], input[type="number"]')) {
+          el.disabled = !on;
+        }
+        li.classList.toggle('disabled', !on);
+        if(!isInitialRender) markDirty();
+      });
+      if(!cb.checked){
+        for (const el of li.querySelectorAll('input[type="range"], input[type="number"]')) {
+          el.disabled = true;
+        }
+        li.classList.add('disabled');
+      }
     }
     list.appendChild(li);
   });
   Sortable.create(list,{ handle:'.drag-handle', animation:150, onEnd:()=>{
     const orderKeys = Array.from(list.children).map(li=>li.dataset.key);
     factors.sort((a,b)=>orderKeys.indexOf(a.key)-orderKeys.indexOf(b.key));
-    renderFactors();
+    renderWeightsUI();
     if(!isInitialRender) markDirty();
   }});
   isInitialRender = false;
@@ -108,7 +152,7 @@ function renderFactors(){
 
 function resetWeights(){
   factors = defaultFactors();
-  renderFactors();
+  renderWeightsUI();
   markDirty();
 }
 
@@ -118,7 +162,11 @@ async function saveSettings(){
     weights: Object.fromEntries(
       factors.map(f => [f.key, Math.max(0, Math.min(100, Math.round(Number(f.weight))))])
     ),
-    order: factors.map(f => f.key)
+    order: factors.map(f => f.key),
+    weights_enabled: Object.fromEntries(
+      factors.map(f => [f.key, f.enabled !== false])
+    ),
+    weights_order: factors.map(f => f.key)
   };
   try{
     await fetch('/api/config/winner-weights', {
@@ -248,7 +296,7 @@ async function adjustWeightsAI(){
     if (Array.isArray(window.factors) && window.factors.length){
       const byKey = Object.fromEntries(window.factors.map(f => [f.key, f]));
       window.factors = newOrder.filter(k => byKey[k]).map(k => ({ ...byKey[k], weight: intWeights[k] ?? byKey[k].weight }));
-      if (typeof renderFactors === 'function') renderFactors();
+      if (typeof renderWeightsUI === 'function') renderWeightsUI();
     }
 
     // Guardar {weights, order} y recargar desde servidor para reflejar lo persistido
@@ -270,47 +318,46 @@ async function adjustWeightsAI(){
 }
 
 
-async function openConfigModal(){
+async function hydrateSettingsModal(){
   try{
     isInitialRender = true;
     const res = await fetch('/api/config/winner-weights');
-    const data = await res.json(); // backend: { weights, order, effective? }  (o legado: mapa plano)
+    const data = await res.json(); // backend: { weights, order, weights_enabled? }
 
-    // Soporta ambas formas (nueva y legacy)
     const weights = (data && data.weights) ? data.weights : (data || {});
     const order   = (data && Array.isArray(data.order) && data.order.length)
       ? data.order
       : (typeof WEIGHT_KEYS !== 'undefined' ? WEIGHT_KEYS : Object.keys(weights));
+    const enabled = (data && data.weights_enabled) ? data.weights_enabled : Object.fromEntries(Object.keys(weights).map(k => [k, true]));
 
-    // Construcción de factors respetando orden y pesos persistidos
     const fieldList = (typeof WEIGHT_FIELDS !== 'undefined' && Array.isArray(WEIGHT_FIELDS)) ? WEIGHT_FIELDS : [];
     const byKey = Object.fromEntries(fieldList.map(f => [f.key, f]));
 
     window.factors = order
-      .filter(k => byKey[k]) // ignora claves desconocidas
+      .filter(k => byKey[k])
       .map(k => ({
         ...byKey[k],
-        weight: (weights[k] !== undefined && !isNaN(weights[k]))
-          ? Math.round(Number(weights[k]))
-          : 50
+        weight: (weights[k] !== undefined && !isNaN(weights[k])) ? Math.round(Number(weights[k])) : 50,
+        enabled: enabled[k] !== undefined ? !!enabled[k] : true
       }));
 
-    renderFactors();
-
-    // Wire de botones (no dupliques si ya existe)
-    const resetBtn = document.getElementById('btnReset');
-    if (resetBtn) resetBtn.onclick = resetWeights;
-    const aiBtn = document.getElementById('btnAiWeights');
-    if (aiBtn) aiBtn.onclick = adjustWeightsAI;
-
-    console.debug('openConfigModal -> weights/order aplicados:', { weights, order });
+    renderWeightsUI();
+    console.debug('hydrateSettingsModal -> weights/order aplicados:', { weights, order, enabled });
   }catch(err){
     /* silencioso */
   }
 }
 
+async function openConfigModal(){
+  await hydrateSettingsModal();
+  const resetBtn = document.getElementById('btnReset');
+  if (resetBtn) resetBtn.onclick = resetWeights;
+  const aiBtn = document.getElementById('btnAiWeights');
+  if (aiBtn) aiBtn.onclick = adjustWeightsAI;
+}
+
 window.openConfigModal = openConfigModal;
-window.loadWeights = openConfigModal;
+window.loadWeights = hydrateSettingsModal;
 window.resetWeights = resetWeights;
 window.adjustWeightsAI = adjustWeightsAI;
 window.markDirty = markDirty;

--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -131,3 +131,13 @@ def test_awareness_priority_and_closeness():
 def test_compute_effective_weights_includes_awareness():
     eff = ws.compute_effective_weights({"awareness": 10}, [])
     assert "awareness" in eff and eff["awareness"] > 0
+
+
+def test_disabled_weight_excluded_from_score():
+    ws.prepare_oldness_bounds([])
+    prod = {"price": 10.0, "rating": 5.0}
+    weights = {"price": 50, "rating": 50}
+    enabled = {"price": False, "rating": True}
+    res = ws.compute_winner_score_v2(prod, weights, order=["price", "rating"], enabled=enabled)
+    assert "price" in res.get("disabled_fields", [])
+    assert res["effective_weights"]["price"] == 0.0


### PR DESCRIPTION
## Summary
- hydrate settings modal before display and persist metric order and enabled state
- add per-metric toggle to enable or disable weights and send `weights_enabled` / `weights_order`
- dim disabled metrics in settings UI
- persist `weights_enabled`/`weights_order` in config, include them in API responses and apply them in Winner Score

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c695fa1a5c8328bba342a1dd8885a9