### PR TITLE
feat: compact settings weights with cached config

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -826,3 +826,50 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
   resize: vertical;
 }
 
+/* Contenedor compacto */
+.weights-section.compact .weight-item {
+  margin: 10px 0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--panel-700, #23283a);
+}
+.weights-section.compact .weight-item.disabled { opacity: .55; }
+
+/* Filas finas */
+.weights-section.compact .wi-row { display: grid; align-items: center; }
+.weights-section.compact .wi-head {
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.weights-section.compact .wi-title { font-weight: 600; }
+.weights-section.compact .wi-handle { opacity: .7; cursor: grab; }
+
+/* Slider ocupa todo el ancho, con menos altura vertical */
+.weights-section.compact .wi-slider { margin: 2px 0 6px 0; }
+.weights-section.compact .wi-slider input[type="range"] { width: 100%; }
+
+/* Meta en una fila */
+.weights-section.compact .wi-meta {
+  grid-template-columns: auto 1fr auto auto;
+  gap: 10px;
+  font-size: 12px;
+  opacity: .85;
+}
+.weights-section.compact .wi-min { justify-self: start; }
+.weights-section.compact .wi-max { justify-self: end; }
+
+/* Pastilla de peso */
+.weights-section.compact .wi-pill {
+  justify-self: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(99,102,241,.15);
+  border: 1px solid rgba(99,102,241,.35);
+}
+
+/* Toggle pequeño */
+.weights-section.compact .wi-toggle input[type="checkbox"] {
+  transform: scale(.9);
+}
+

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -238,8 +238,7 @@ import * as api from "/static/js/net.js";
 import * as groupsService from "/static/js/groups-service.js";
 const { fetchJson } = api;
 const metricKeys = window.metricKeys;
-const openConfigModal = window.openConfigModal;
-const saveIfDirty = window.saveIfDirty;
+const openSettingsModal = window.openSettingsModal;
 window.fetchJson = fetchJson;
 window.groupsService = groupsService;
 const IMPORT_TASK_LS_KEY = 'last_import_task';
@@ -910,47 +909,7 @@ window.onload = async () => {
   }
 };
 // Toggle config panel
-document.getElementById('configBtn').onclick = async () => {
-  await openConfigModal();
-  const cfg = document.getElementById('config');
-  const wcard = document.getElementById('weightsCard');
-  const footer = document.getElementById('weightsFooter');
-  if(!cfg || !wcard || !footer || !window.modalManager) return;
-  const btn = document.getElementById('configBtn');
-  const modal = document.createElement('div');
-  modal.id = 'configModal';
-  modal.className = 'modal config-modal';
-  modal.setAttribute('role','dialog');
-  modal.setAttribute('aria-modal','true');
-  modal.setAttribute('aria-labelledby','configModalTitle');
-  modal.innerHTML = '<header class="modal-header"><h3 id="configModalTitle">Configuración</h3><button type="button" class="modal-close" aria-label="Cerrar">✕</button></header><div class="modal-body"></div>';
-  const body = modal.querySelector('.modal-body');
-  const cfgParent = cfg.parentElement;
-  const wParent = wcard.parentElement;
-  const fParent = footer.parentElement;
-  const cfgNext = cfg.nextSibling;
-  const wNext = wcard.nextSibling;
-  const fNext = footer.nextSibling;
-  body.appendChild(cfg);
-  body.appendChild(wcard);
-  modal.appendChild(footer);
-  cfg.style.display = 'block';
-  wcard.style.display = 'block';
-  footer.style.display = 'flex';
-  const handle = modalManager.open(modal, {returnFocus: btn, closeOnBackdrop:true, onClose: () => {
-    cfg.style.display = 'none';
-    wcard.style.display = 'none';
-    footer.style.display = 'none';
-    cfgParent.insertBefore(cfg, cfgNext);
-    wParent.insertBefore(wcard, wNext);
-    fParent.insertBefore(footer, fNext);
-    saveIfDirty();
-  }});
-  modal.querySelector('.modal-close').addEventListener('click', () => handle.close());
-  modal.addEventListener('close', saveIfDirty);
-  const first = modal.querySelector('input,select,textarea,button');
-  if(first) first.focus();
-};
+document.getElementById('configBtn').onclick = openSettingsModal;
 
 
 // Handle file upload: clicking the upload button opens file chooser


### PR DESCRIPTION
## Summary
- cache `/config` with ConfigStore and prefetch on load
- redesign weights list with compact draggable items and toggles
- open configuration modal after ensuring data is ready and keep cache in sync

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c69aa01720832885d71cf960f9b3f8