### PR TITLE
feat: normalize auto-weights to 0-100 integers

### DIFF
--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -141,3 +141,25 @@ def test_disabled_weight_excluded_from_score():
     res = ws.compute_winner_score_v2(prod, weights, order=["price", "rating"], enabled=enabled)
     assert "price" in res.get("disabled_fields", [])
     assert res["effective_weights"]["price"] == 0.0
+
+
+def test_to_int_weights_uses_hamilton_method():
+    raw = {
+        "price": 0.35,
+        "rating": 0.25,
+        "units_sold": 0.15,
+        "revenue": 0.15,
+        "desire": 0.07,
+        "competition": 0.03,
+    }
+    ints, order = ws.to_int_weights_0_100(raw, {"weights": {}, "weights_enabled": {}})
+    assert ints == {
+        "price": 35,
+        "rating": 25,
+        "units_sold": 15,
+        "revenue": 15,
+        "desire": 7,
+        "competition": 3,
+    }
+    assert sum(ints.values()) == 100
+    assert order[0] == "price" and order[-1] == "competition"


### PR DESCRIPTION
## Summary
- add Hamilton apportionment helpers for converting raw weights to 0-100 ints
- use new helpers in `/scoring/v2/auto-weights-gpt` respecting enabled metrics and logging results
- persist new weights from UI without re-normalizing client-side

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6a3e96e5c8328b9d10972835c4c1d