### PR TITLE
Handle GPT auto weights as absolute 0-100 with uniform fallback

### DIFF
--- a/product_research_app/services/auto_weights.py
+++ b/product_research_app/services/auto_weights.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+KNOWN = ['price','rating','units_sold','revenue','desire','competition','oldness','awareness']
+ALIASES = {
+  'income':'revenue','turnover':'revenue','sales_revenue':'revenue',
+  'sold_units':'units_sold','qty_sold':'units_sold','units':'units_sold',
+  'score':'rating','stars':'rating'
+}
+
+def _map_name(k: str) -> str:
+    k = (k or '').strip().lower()
+    return ALIASES.get(k, k)
+
+def _to_abs_0_100(v):
+    if isinstance(v, (int, float)):
+        x = float(v)
+        if 0 <= x <= 100:
+            return int(round(x))
+        if 0 <= x <= 1:
+            return int(round(x * 100))
+        return int(round(max(0, min(100, x))))
+    if isinstance(v, str):
+        s = v.strip().replace('%', '')
+        try:
+            x = float(s)
+            if 0 <= x <= 100:
+                return int(round(x))
+            if 0 <= x <= 1:
+                return int(round(x * 100))
+            return int(round(max(0, min(100, x))))
+        except Exception:
+            return None
+    return None
+
+def ai_to_abs(prev_cfg: dict, ai_raw: dict) -> dict[str, int]:
+    prev = {k: int(v) for k, v in (prev_cfg.get('weights') or {}).items()}
+    out = {}
+    for k, v in (ai_raw or {}).items():
+        fk = _map_name(k)
+        if fk in KNOWN:
+            mv = _to_abs_0_100(v)
+            if mv is not None:
+                out[fk] = mv
+    for f in KNOWN:
+        if f not in out and f in prev:
+            out[f] = prev[f]
+    if not out:
+        out = {f: 50 for f in KNOWN}
+    return out
+
+def is_uniform(vals: list[int]) -> bool:
+    if not vals:
+        return True
+    mn, mx = min(vals), max(vals)
+    if mx - mn <= 5:
+        return True
+    mean = sum(vals) / len(vals)
+    var = sum((x - mean) ** 2 for x in vals) / len(vals)
+    if var ** 0.5 < 3:
+        return True
+    uniq = sorted(set(vals))
+    if len(uniq) <= 2 and (uniq[-1] - uniq[0] <= 5):
+        return True
+    return False
+
+def compute_final_weights(prev_cfg: dict, ai_raw: dict) -> tuple[dict[str, int], list[str], bool]:
+    enabled = (prev_cfg.get('weights_enabled') or {})
+    prev = {k: int(v) for k, v in (prev_cfg.get('weights') or {}).items()}
+    cand = ai_to_abs(prev_cfg, ai_raw)
+    enabled_vals = [cand[k] for k in KNOWN if enabled.get(k, True) and k in cand]
+    fallback = is_uniform(enabled_vals)
+    final_w = prev.copy()
+    if not fallback:
+        for k in KNOWN:
+            if enabled.get(k, True) and k in cand:
+                final_w[k] = cand[k]
+    for k in KNOWN:
+        final_w.setdefault(k, prev.get(k, 50))
+    order = sorted(final_w, key=lambda k: final_w[k], reverse=True)
+    return final_w, order, fallback

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -662,6 +662,25 @@ th.ec-col-competition,   td.ec-col-competition   { width: var(--ec-w-competition
 
 /* Fila con 3 columnas: ≡ | barra (1fr) | valor fijo */
 #weightsCard{ overflow-x:hidden; }
+#settingsPane{
+  display:flex; flex-direction:column;
+  height: calc(100vh - 220px);
+  min-height: 420px;
+}
+#weightsScroll{
+  flex:1 1 auto;
+  overflow:auto;
+  padding-right: 4px;
+}
+#weightsActions{
+  flex:0 0 auto;
+  display:flex; gap:10px;
+  justify-content:flex-start;
+  padding: 10px 0 4px;
+  border-top: 1px solid rgba(255,255,255,.06);
+  background: transparent;
+}
+#weightsActions .btn{ min-width: 160px; }
 .weight-row {
   display: grid;
   grid-template-columns: 24px minmax(0, 1fr) 40px; /* barra ocupa todo */

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -103,11 +103,15 @@ body.dark pre { background:#2e315f; }
 <div id="weightsCard" class="card" style="display:none;">
   <strong>Ponderaciones Winner Score</strong>
   <div class="legend">ℹ️ Arrastra para reordenar. Más arriba = mayor prioridad. El número (0–100) es el peso.</div>
-  <ul id="weightsList" class="weights-list"></ul>
-</div>
-<div id="weightsFooter" class="config-footer" style="display:none;">
-  <button id="btnReset" class="btn">Reset</button>
-  <button id="btnAiWeights" class="btn primary">Ajustar pesos con IA</button>
+  <div class="settings-pane" id="settingsPane">
+    <div class="weights-scroll" id="weightsScroll">
+      <ul id="weightsList" class="weights-list"></ul>
+    </div>
+    <div class="weights-actions" id="weightsActions">
+      <button id="btnResetWeights" class="btn btn-secondary">Reset</button>
+      <button id="btnAutoWeights" class="btn btn-primary">Ajustar pesos con IA</button>
+    </div>
+  </div>
 </div>
 <div id="custom" style="display:none;">
   <div id="history" style="margin-top:10px;"></div>
@@ -914,8 +918,7 @@ document.getElementById('configBtn').onclick = async () => {
   await openConfigModal();
   const cfg = document.getElementById('config');
   const wcard = document.getElementById('weightsCard');
-  const footer = document.getElementById('weightsFooter');
-  if(!cfg || !wcard || !footer || !window.modalManager) return;
+  if(!cfg || !wcard || !window.modalManager) return;
   const btn = document.getElementById('configBtn');
   const modal = document.createElement('div');
   modal.id = 'configModal';
@@ -927,23 +930,17 @@ document.getElementById('configBtn').onclick = async () => {
   const body = modal.querySelector('.modal-body');
   const cfgParent = cfg.parentElement;
   const wParent = wcard.parentElement;
-  const fParent = footer.parentElement;
   const cfgNext = cfg.nextSibling;
   const wNext = wcard.nextSibling;
-  const fNext = footer.nextSibling;
   body.appendChild(cfg);
   body.appendChild(wcard);
-  modal.appendChild(footer);
   cfg.style.display = 'block';
   wcard.style.display = 'block';
-  footer.style.display = 'flex';
   const handle = modalManager.open(modal, {returnFocus: btn, closeOnBackdrop:true, onClose: () => {
     cfg.style.display = 'none';
     wcard.style.display = 'none';
-    footer.style.display = 'none';
     cfgParent.insertBefore(cfg, cfgNext);
     wParent.insertBefore(wcard, wNext);
-    fParent.insertBefore(footer, fNext);
     saveIfDirty();
   }});
   modal.querySelector('.modal-close').addEventListener('click', () => handle.close());


### PR DESCRIPTION
## Summary
- add auto_weights helpers to map and convert AI weight suggestions to absolute 0-100 values and detect uniform outputs
- update `/scoring/v2/auto-weights-gpt` to compute final weights, persist them in one patch, and log uniform fallbacks
- keep weight action buttons fixed at the bottom of the settings modal with a scrollable slider list

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b03e07a48328b23a94d44258f1de