### PR TITLE
Include revenue metric and drop weight normalization

### DIFF
--- a/product_research_app/services/winner_score.py
+++ b/product_research_app/services/winner_score.py
@@ -180,18 +180,15 @@ WEIGHTS_VERSION: int = 0
 
 
 def compute_effective_weights(weights: dict[str, int | float], order: list[str]) -> dict[str, float]:
-    order = list(order)
-    if "awareness" in weights and "awareness" not in order:
-        order.append("awareness")
-    n = len(order)
-    if n == 0:
-        return {}
-    sum_ranks = n * (n + 1) / 2.0
-    pri = {k: (n - i) for i, k in enumerate(order)}
-    pri_factor = {k: pri[k] / (sum_ranks / n) for k in order}
-    eff = {k: float(weights.get(k, 0)) * pri_factor[k] for k in order}
-    s = sum(eff.values()) or 1.0
-    return {k: v / s for k, v in eff.items()}
+    """Map integer weights 0..100 to float ratios 0..1 without normalization."""
+
+    out: dict[str, float] = {}
+    for k in order:
+        out[k] = float(weights.get(k, 0)) / 100.0  # NOTE: pesos 0–100 → ratios 0–1 con división float; sin normalización global.
+    for k in weights:
+        if k not in out:
+            out[k] = float(weights.get(k, 0)) / 100.0
+    return out
 
 def sanitize_weights(weights: dict | None) -> dict:
     w = (weights or {}).copy()
@@ -202,63 +199,24 @@ def sanitize_weights(weights: dict | None) -> dict:
     return {k: v / s for k, v in w.items()}
 
 
-def to_int_weights_0_100(raw: dict[str, float], prev_cfg: dict) -> tuple[dict[str, int], list[str]]:
-    """Scale arbitrary weights to 0-100 integers using Hamilton apportionment.
+def to_int_weights_0_100(raw: dict[str, float], prev_cfg: dict | None = None) -> tuple[dict[str, int], list[str]]:
+    """Convert raw weights to clamped integers 0-100 without normalization."""  # NOTE: pesos 0–100 independientes; sin normalización.
 
-    ``raw`` may contain any non-negative values (normalized or not).  ``prev_cfg``
-    should provide previous ``{"weights": ..., "weights_enabled": ...}`` so that
-    missing keys can fall back to prior configuration.
-    """
-
-    vals = {
-        k: (
-            0.0
-            if v is None or not isinstance(v, (int, float)) or v < 0
-            else float(v)
-        )
-        for k, v in raw.items()
-    }
-    if not vals or all(v == 0 for v in vals.values()):
-        prev_w = {k: int(v) for k, v in (prev_cfg.get("weights") or {}).items()}
-        if prev_w:
-            order = sorted(prev_w, key=lambda k: prev_w[k], reverse=True)
-            return prev_w, order
-        fields = list((prev_cfg.get("weights") or {}).keys()) or list(vals.keys())
-        if not fields:
-            fields = [
-                "price",
-                "rating",
-                "units_sold",
-                "revenue",
-                "desire",
-                "competition",
-            ]
-        base = {k: 1.0 for k in fields}
-        return _hamilton_0_100(base)
-
-    return _hamilton_0_100(vals)
-
-
-def _hamilton_0_100(vals: dict[str, float]) -> tuple[dict[str, int], list[str]]:
-    total = sum(vals.values())
-    if total <= 0:
-        n = len(vals) or 1
-        q, r = divmod(100, n)
-        ints = {k: q for k in vals.keys()}
-        for k in sorted(vals.keys())[:r]:
-            ints[k] += 1
-        order = sorted(ints, key=lambda k: ints[k], reverse=True)
-        return ints, order
-    shares = {k: (v / total) * 100.0 for k, v in vals.items()}
-    floors = {k: int(shares[k] // 1) for k in shares}
-    leftover = 100 - sum(floors.values())
-    frac_sorted = sorted(
-        shares.items(), key=lambda kv: (kv[1] - int(kv[1]), kv[0]), reverse=True
-    )
-    ints = floors.copy()
-    for i in range(leftover):
-        ints[frac_sorted[i % len(frac_sorted)][0]] += 1
-    order = sorted(ints, key=lambda k: ints[k], reverse=True)
+    ints: dict[str, int] = {}
+    missing: list[str] = []
+    for k in ALLOWED_FIELDS:
+        if k not in raw:
+            missing.append(k)
+            v = 0
+        else:
+            try:
+                v = int(round(float(raw.get(k, 0))))
+            except Exception:
+                v = 0
+        ints[k] = max(0, min(100, v))
+    for k in missing:
+        logger.warning("auto-weights missing %s", k)
+    order = sorted(ints.keys(), key=lambda x: (-ints[x], x))
     return ints, order
 
 
@@ -587,14 +545,13 @@ def _norm_identity(v: float) -> float:
     return clamp(v)
 
 
-def _oldness_pref_and_weight(cfg_weights: dict[str, float]) -> tuple[float, float]:
-    # Entrada UI 0..100 (la misma barra que ves en el modal)
-    v = float(cfg_weights.get("oldness", 50))
-    # Intensidad 0..1 (50 => 0, 0/100 => 1)
-    intensity = abs(v - 50.0) / 50.0
-    # Dirección: -1 recientes, +1 antiguos (50 => 0)
-    direction = (v - 50.0) / 50.0
-    return direction, intensity
+def _oldness_dir_from_pref(pref: str) -> float:
+    pref = (pref or "").strip().lower()
+    if pref == "older":
+        return 1.0
+    if pref == "newer":
+        return -1.0
+    return 0.0
 
 
 NORMALIZERS: Dict[str, Callable[[float], float]] = {
@@ -611,9 +568,10 @@ NORMALIZERS: Dict[str, Callable[[float], float]] = {
 
 def compute_winner_score_v2(
     product_row: Any,
-    user_weights: Dict[str, float],
+    weights_int: Dict[str, float],
     order: Optional[list[str]] = None,
     enabled: Optional[Dict[str, bool]] = None,
+    oldness_dir: float = 0.0,
 ) -> Dict[str, Any]:
     """Compute Winner Score using available features only."""
 
@@ -625,42 +583,38 @@ def compute_winner_score_v2(
             continue
         raw_vals[name] = val
 
-    w_aw = user_weights.get("awareness", 50)
+    w_aw = weights_int.get("awareness", 0)
     raw_vals["awareness"] = awareness_feature_value(product_row, w_aw)
 
     present = list(raw_vals.keys())
     missing_fields = [f for f in ALLOWED_FIELDS if f not in present]
     disabled_fields = [f for f in ALLOWED_FIELDS if enabled and not enabled.get(f, True)]
 
-    dir_old, w_old_intensity = _oldness_pref_and_weight(user_weights)
-
     norms: Dict[str, float] = {}
     for k, v in raw_vals.items():
         n = NORMALIZERS[k](v)
-        if k == "oldness" and dir_old < 0:
+        if k == "oldness" and oldness_dir < 0:
             n = 1.0 - n
         norms[k] = n
 
-    weights_for_priority: Dict[str, int] = {}
-    for k in ALLOWED_FIELDS:
-        base = int(round(user_weights.get(k, 0)))
-        on = enabled.get(k, True) if enabled else True
-        weights_for_priority[k] = base if on else 0
-    weights_for_priority["oldness"] = (
-        int(round(w_old_intensity * 100))
-        if (enabled.get("oldness", True) if enabled else True)
-        else 0
-    )
     if order is None:
-        order = list(weights_for_priority.keys())
-    eff_all = compute_effective_weights(weights_for_priority, order)
-    eff_weights = {k: eff_all.get(k, 0.0) for k in norms.keys()}
+        order = [k for k, _ in sorted(weights_int.items(), key=lambda kv: (-kv[1], kv[0]))]
 
+    weights_ratio: Dict[str, float] = {}
+    for k in ALLOWED_FIELDS:
+        base = float(weights_int.get(k, 0))
+        if enabled and not enabled.get(k, True):
+            base = 0.0
+        weights_ratio[k] = base / 100.0  # NOTE: pesos 0–100 → ratios 0–1 con división float; sin normalización global.
+
+    eff_weights = {k: weights_ratio.get(k, 0.0) for k in norms.keys()}
     sum_filtered = sum(eff_weights.values())
-    score_float = sum(eff_weights.get(k, 0.0) * norms[k] for k in norms)
+    score_float = 0.0
+    if sum_filtered > 0:
+        score_float = sum(eff_weights.get(k, 0.0) * norms[k] for k in norms) / sum_filtered
     score_int = int(round(score_float * 100))
 
-    eff_all_full = {k: eff_all.get(k, 0.0) for k in ALLOWED_FIELDS}
+    eff_all_full = {k: weights_ratio.get(k, 0.0) for k in ALLOWED_FIELDS}
     return {
         "score": score_int,
         "score_float": score_float,
@@ -695,19 +649,27 @@ def generate_winner_scores(
     """
 
     if weights is None:
-        weights, order, enabled = load_winner_settings()
+        weights, _, enabled = load_winner_settings()
     else:
-        order = get_winner_order_raw()
         from .config import get_weights_enabled_raw
 
         enabled = get_weights_enabled_raw()
 
-    dir_old, w_old_intensity = _oldness_pref_and_weight(weights)
-    oldness_ui = float(weights.get("oldness", 50))
+    ints, _ = to_int_weights_0_100(weights, {})
+    ints = {k: (ints.get(k, 0) if enabled.get(k, True) else 0) for k in ALLOWED_FIELDS}
+    order = [k for k, _ in sorted(ints.items(), key=lambda kv: (-kv[1], kv[0]))]
+    ratios = {k: ints[k] / 100.0 for k in ALLOWED_FIELDS}
+    logger.info("weights_effective_int=%s effective_weights=%s order=%s", ints, ratios, order)
+
+    cfg = load_config()
+    pref = cfg.get("oldness_preference", "newer")
+    dir_old = _oldness_dir_from_pref(pref)
+    oldness_ui = 0.0 if pref == "newer" else 100.0 if pref == "older" else 50.0
+    w_old_intensity = ratios.get("oldness", 0.0)
     dir_old_label = "+1" if dir_old >= 0 else "-1"
 
     weights_hash_all = hashlib.sha1(
-        json.dumps(weights, sort_keys=True).encode("utf-8")
+        json.dumps(ints, sort_keys=True).encode("utf-8")
     ).hexdigest()[:8]
     weights_hash_eff = ""
 
@@ -734,7 +696,7 @@ def generate_winner_scores(
     for row in rows:
         pid = row["id"]
         old_score = row["winner_score"]
-        res = compute_winner_score_v2(row, weights, order, enabled)
+        res = compute_winner_score_v2(row, ints, order, enabled, dir_old)
         sf = res.get("score_float") or 0.0
         present = set(res.get("present_fields", []))
         missing = set(res.get("missing_fields", []))

--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from product_research_app import web_app, database, config
+from product_research_app import web_app, database, config, gpt
 from product_research_app.services import winner_score
 from product_research_app.services import config as cfg_service
 from product_research_app.utils.db import row_to_dict
@@ -668,7 +668,7 @@ def test_logging_and_explain_endpoint(tmp_path, monkeypatch):
     assert "oldness" in info["missing"]
     eff = info["effective_weights"]
     assert set(eff.keys()) == set(winner_score.ALLOWED_FIELDS)
-    assert abs(sum(eff.values()) - 1.0) < 1e-2
+    assert sum(eff.values()) > 0
 
 
 def test_weights_eff_stable_when_touching_missing_metric(tmp_path, monkeypatch):
@@ -730,4 +730,111 @@ def test_weights_eff_stable_when_touching_missing_metric(tmp_path, monkeypatch):
     resp2 = json.loads(h2.wfile.getvalue().decode("utf-8"))
     assert resp2["weights_all"] != hash_all1
     assert resp2["weights_eff"] != hash_eff1
-    assert resp2["diag"]["sum_filtered"] > sum1
+    assert resp2["diag"]["sum_filtered"] == sum1
+
+
+def test_auto_weights_missing_revenue_persisted(tmp_path, monkeypatch):
+    conn = setup_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(config, "get_api_key", lambda: "k")
+    monkeypatch.setattr(config, "get_model", lambda: "m")
+
+    def fake_recommend(api_key, model, samples, target):
+        return {
+            "weights": {
+                "price": 72,
+                "rating": 88,
+                "units_sold": 65,
+                "desire": 40,
+                "competition": 30,
+                "oldness": 10,
+                "awareness": 20,
+            },
+            "justification": "",
+        }
+
+    monkeypatch.setattr(gpt, "recommend_winner_weights", fake_recommend)
+    sample = {
+        "price": 1,
+        "rating": 1,
+        "units_sold": 1,
+        "revenue": 1,
+        "desire": 1,
+        "competition": 1,
+        "oldness": 1,
+        "awareness": 1,
+        "target": 1,
+    }
+    body = json.dumps({"data_sample": [sample], "target": "target"})
+
+    class Dummy:
+        def __init__(self, body):
+            self.path = "/scoring/v2/auto-weights-gpt"
+            self.headers = {"Content-Length": str(len(body))}
+            self.rfile = io.BytesIO(body.encode("utf-8"))
+            self.wfile = io.BytesIO()
+
+        def _set_json(self, code=200):
+            self.status = code
+
+    h = Dummy(body)
+    web_app.RequestHandler.handle_scoring_v2_auto_weights_gpt(h)
+    resp = json.loads(h.wfile.getvalue().decode("utf-8"))
+    assert h.status == 200
+    assert resp["weights"]["revenue"] == 0
+    from product_research_app.services.config import get_winner_weights_raw
+
+    saved = get_winner_weights_raw()
+    assert saved["revenue"] == 0
+    log_text = web_app.LOG_PATH.read_text()
+    assert "missing revenue" in log_text
+
+
+def test_auto_weights_no_normalization(tmp_path, monkeypatch):
+    conn = setup_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(config, "get_api_key", lambda: "k")
+    monkeypatch.setattr(config, "get_model", lambda: "m")
+
+    def fake_recommend(api_key, model, samples, target):
+        return {
+            "weights": {
+                "price": 72,
+                "rating": 88,
+                "units_sold": 65,
+                "revenue": 50,
+                "desire": 40,
+                "competition": 30,
+                "oldness": 10,
+                "awareness": 20,
+            },
+            "justification": "",
+        }
+
+    monkeypatch.setattr(gpt, "recommend_winner_weights", fake_recommend)
+    sample = {
+        "price": 1,
+        "rating": 1,
+        "units_sold": 1,
+        "revenue": 1,
+        "desire": 1,
+        "competition": 1,
+        "oldness": 1,
+        "awareness": 1,
+        "target": 1,
+    }
+    body = json.dumps({"data_sample": [sample], "target": "target"})
+
+    class Dummy:
+        def __init__(self, body):
+            self.path = "/scoring/v2/auto-weights-gpt"
+            self.headers = {"Content-Length": str(len(body))}
+            self.rfile = io.BytesIO(body.encode("utf-8"))
+            self.wfile = io.BytesIO()
+
+        def _set_json(self, code=200):
+            self.status = code
+
+    h = Dummy(body)
+    web_app.RequestHandler.handle_scoring_v2_auto_weights_gpt(h)
+    resp = json.loads(h.wfile.getvalue().decode("utf-8"))
+    assert h.status == 200
+    assert sum(resp["weights"].values()) == 375

--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -72,26 +72,32 @@ def test_oldness_weight_direction():
     prod_new = {"first_seen": (today - timedelta(days=10)).isoformat()}
     ws.prepare_oldness_bounds([prod_old, prod_new])
 
-    res_old = ws.compute_winner_score_v2(prod_old, {"oldness": 100})
-    res_new = ws.compute_winner_score_v2(prod_new, {"oldness": 100})
+    res_old = ws.compute_winner_score_v2(prod_old, {"oldness": 100}, oldness_dir=1)
+    res_new = ws.compute_winner_score_v2(prod_new, {"oldness": 100}, oldness_dir=1)
     assert res_old["score"] > res_new["score"]
 
-    res_old_rev = ws.compute_winner_score_v2(prod_old, {"oldness": 0})
-    res_new_rev = ws.compute_winner_score_v2(prod_new, {"oldness": 0})
+    res_old_rev = ws.compute_winner_score_v2(prod_old, {"oldness": 100}, oldness_dir=-1)
+    res_new_rev = ws.compute_winner_score_v2(prod_new, {"oldness": 100}, oldness_dir=-1)
     assert res_new_rev["score"] > res_old_rev["score"]
 
-    res_old_neu = ws.compute_winner_score_v2(prod_old, {"oldness": 50})
-    res_new_neu = ws.compute_winner_score_v2(prod_new, {"oldness": 50})
+    res_old_neu = ws.compute_winner_score_v2(prod_old, {"oldness": 0}, oldness_dir=0)
+    res_new_neu = ws.compute_winner_score_v2(prod_new, {"oldness": 0}, oldness_dir=0)
     assert res_old_neu["score"] == res_new_neu["score"] == 0
 
+    eff = ws.compute_winner_score_v2(prod_old, {"oldness": 100}, oldness_dir=1)
+    assert eff["effective_weights"]["oldness"] == 1.0
+    for k in ws.ALLOWED_FIELDS:
+        if k != "oldness":
+            assert eff["effective_weights"][k] == 0.0
 
-def test_order_affects_score():
+
+def test_order_no_longer_affects_score():
     prod = {"price": 10.0, "rating": 5.0}
     ws.prepare_oldness_bounds([])
     weights = {"price": 50, "rating": 50}
     res_price_first = ws.compute_winner_score_v2(prod, weights, order=["price", "rating"])
     res_rating_first = ws.compute_winner_score_v2(prod, weights, order=["rating", "price"])
-    assert res_price_first["score"] != res_rating_first["score"]
+    assert res_price_first["score"] == res_rating_first["score"]
 
 
 def test_awareness_weight_impacts_score():
@@ -108,14 +114,14 @@ def test_awareness_weight_impacts_score():
 def test_recommend_winner_weights_includes_awareness(monkeypatch):
     # simulate GPT returning weights for price and awareness
     def fake_call(api_key, model, messages):
-        return {"choices": [{"message": {"content": '{"pesos": {"price": 1, "awareness": 3}}'}}]}
+        return {"choices": [{"message": {"content": '{"weights": {"price": 1, "awareness": 3}}'}}]}
 
     monkeypatch.setattr(gpt, "call_openai_chat", fake_call)
     samples = [{"price": 10.0, "awareness": 0.75, "target": 5.0}]
     res = gpt.recommend_winner_weights("k", "m", samples, "target")
     weights = res["weights"]
     assert set(weights) == {"price", "awareness"}
-    assert math.isclose(sum(weights.values()), 1.0)
+    assert weights["awareness"] == 3
 
 
 def test_awareness_priority_and_closeness():
@@ -143,23 +149,71 @@ def test_disabled_weight_excluded_from_score():
     assert res["effective_weights"]["price"] == 0.0
 
 
-def test_to_int_weights_uses_hamilton_method():
+def test_to_int_weights_clamps_and_orders():
     raw = {
-        "price": 0.35,
-        "rating": 0.25,
-        "units_sold": 0.15,
-        "revenue": 0.15,
-        "desire": 0.07,
-        "competition": 0.03,
+        "price": 72,
+        "rating": 88,
+        "units_sold": 65,
+        "revenue": 50,
+        "desire": 40,
+        "competition": 30,
+        "oldness": 10,
+        "awareness": 20,
     }
-    ints, order = ws.to_int_weights_0_100(raw, {"weights": {}, "weights_enabled": {}})
-    assert ints == {
-        "price": 35,
-        "rating": 25,
-        "units_sold": 15,
-        "revenue": 15,
-        "desire": 7,
-        "competition": 3,
+    ints, order = ws.to_int_weights_0_100(raw, {})
+    assert ints == raw
+    assert order == [
+        "rating",
+        "price",
+        "units_sold",
+        "revenue",
+        "desire",
+        "competition",
+        "awareness",
+        "oldness",
+    ]
+    assert sum(ints.values()) == 375
+
+
+def test_effective_weights_and_order_from_ints():
+    ws.prepare_oldness_bounds([])
+    raw = {
+        "price": 72,
+        "rating": 88,
+        "units_sold": 65,
+        "revenue": 50,
+        "desire": 40,
+        "competition": 30,
+        "oldness": 10,
+        "awareness": 20,
     }
-    assert sum(ints.values()) == 100
-    assert order[0] == "price" and order[-1] == "competition"
+    res = ws.compute_winner_score_v2({}, raw)
+    assert res["effective_weights"]["rating"] == pytest.approx(0.88)
+    assert res["effective_weights"]["oldness"] == pytest.approx(0.10)
+    assert res["order"] == [
+        "rating",
+        "price",
+        "units_sold",
+        "revenue",
+        "desire",
+        "competition",
+        "awareness",
+        "oldness",
+    ]
+
+
+def test_to_int_weights_missing_metric_warns(caplog):
+    raw = {
+        "price": 72,
+        "rating": 88,
+        "units_sold": 65,
+        "desire": 40,
+        "competition": 30,
+        "oldness": 10,
+        "awareness": 20,
+    }
+    with caplog.at_level("WARNING"):
+        ints, order = ws.to_int_weights_0_100(raw, {})
+    assert ints["revenue"] == 0
+    assert any("missing revenue" in rec.message for rec in caplog.records)
+    assert set(ints.keys()) == set(ws.ALLOWED_FIELDS)

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -603,15 +603,14 @@ class RequestHandler(BaseHTTPRequestHandler):
         if path == "/api/config/winner-weights":
             from .services.config import (
                 get_winner_weights_raw,
-                get_winner_order_raw,
                 get_weights_enabled_raw,
                 compute_effective_int,
             )
 
             raw = get_winner_weights_raw()
-            order = get_winner_order_raw()
             enabled = get_weights_enabled_raw()
             raw_eff = {k: (raw.get(k, 0) if enabled.get(k, True) else 0) for k in raw}
+            order = [k for k, _ in sorted(raw_eff.items(), key=lambda kv: (-kv[1], kv[0]))]
             eff_int = compute_effective_int(raw_eff, order)
             logger.info("weights_effective_int=%s order=%s", eff_int, order)
             resp = {
@@ -2447,40 +2446,30 @@ class RequestHandler(BaseHTTPRequestHandler):
             return
         try:
             result = gpt.recommend_winner_weights(api_key, model, samples, target)
-            weights = winner_calc.sanitize_weights(result.get("weights", {}))
+            weights_raw = result.get("weights", {})
             notes = result.get("justification", "")
         except Exception as exc:
             self._set_json(500)
             self.wfile.write(json.dumps({"error": str(exc)}).encode('utf-8'))
             return
-        prev_settings = winner_calc.load_settings()
-        prev_cfg = {
-            "weights": {
-                k: int(v) for k, v in (prev_settings.get("winner_weights") or {}).items()
-            },
-            "weights_enabled": {
-                k: bool(v)
-                for k, v in (prev_settings.get("weights_enabled") or {}).items()
-            },
-        }
-        enabled_map = prev_cfg.get("weights_enabled") or {}
-        enabled_keys = [k for k, on in enabled_map.items() if on]
-        raw_enabled = {k: weights.get(k, 0.0) for k in enabled_keys if k in weights} or weights
-        ints_enabled, order = winner_calc.to_int_weights_0_100(raw_enabled, prev_cfg)
-        prev_all = prev_cfg.get("weights") or {}
-        final_weights = prev_all.copy()
-        for k, v in ints_enabled.items():
-            final_weights[k] = v
+        ints, order = winner_calc.to_int_weights_0_100(weights_raw, {})  # NOTE: pesos 0–100 independientes; sin normalización.
         logger.info(
-            "ai_raw=%s enabled_only=%s ints=%s order=%s sum=%s",
-            weights,
-            raw_enabled,
-            ints_enabled,
+            "ai_raw=%s validated_ints=%s order=%s",
+            weights_raw,
+            ints,
             order,
-            sum(ints_enabled.values()),
         )
+        prev_settings = winner_calc.load_settings()
+        prev_enabled = prev_settings.get("weights_enabled") or {}
+        winner_calc.save_winner_weights_raw(
+            {"weights": ints, "order": order, "weights_enabled": prev_enabled}
+        )
+        try:
+            winner_calc.recompute_scores_for_all_products(scope="all")
+        except Exception as exc:
+            logger.warning("auto-weights recompute failed: %s", exc)
         resp = {
-            "weights": final_weights,
+            "weights": ints,
             "weights_order": order,
             "order": order,
             "method": "gpt",
@@ -2653,7 +2642,13 @@ class RequestHandler(BaseHTTPRequestHandler):
         ids = [int(x) for x in ids_param.split(",") if x.strip()]
 
         conn = ensure_db()
-        weights, order, enabled = winner_calc.load_winner_settings()
+        weights, _, enabled = winner_calc.load_winner_settings()
+        ints, _ = winner_calc.to_int_weights_0_100(weights, {})
+        ints = {k: (ints.get(k, 0) if enabled.get(k, True) else 0) for k in winner_calc.ALLOWED_FIELDS}
+        order = [k for k, _ in sorted(ints.items(), key=lambda kv: (-kv[1], kv[0]))]
+        cfg = config.load_config()
+        pref = cfg.get("oldness_preference", "newer")
+        dir_old = winner_calc._oldness_dir_from_pref(pref)
 
         if ids:
             placeholders = ",".join("?" for _ in ids)
@@ -2669,7 +2664,7 @@ class RequestHandler(BaseHTTPRequestHandler):
 
         data: Dict[str, Any] = {}
         for row in rows:
-            res = winner_calc.compute_winner_score_v2(row, weights, order, enabled)
+            res = winner_calc.compute_winner_score_v2(row, ints, order, enabled, dir_old)
             sf = res.get("score_float") or 0.0
             score_raw = max(0.0, min(1.0, sf)) * 100.0
             data[row["id"]] = {


### PR DESCRIPTION
## Summary
- map stored 0-100 winner weights to 0-1 ratios with float division and clamp/order them from the same integer set
- derive weight order from enabled integers and log effective ratios alongside direction for oldness
- expand tests to cover ratio conversion and confirm order independence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6b38363448328b0b0dd9998261c55