### PR TITLE
feat: add AI weights endpoint

### DIFF
--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -114,8 +114,10 @@ def test_recommend_winner_weights_includes_awareness(monkeypatch):
     samples = [{"price": 10.0, "awareness": 0.75, "target": 5.0}]
     res = gpt.recommend_winner_weights("k", "m", samples, "target")
     weights = res["weights"]
-    assert set(weights) == {"price", "awareness"}
-    assert math.isclose(sum(weights.values()), 1.0)
+    assert set(weights.keys()) == set(ws.ALLOWED_FIELDS)
+    assert weights["price"] == 1
+    assert weights["awareness"] == 3
+    assert weights["revenue"] == 50
 
 
 def test_awareness_priority_and_closeness():


### PR DESCRIPTION
## Summary
- replace winner weight recommendation with raw 0-100 weights and explicit priority order
- add POST /api/config/winner-weights/ai endpoint to persist AI-suggested weights and recompute scores
- adjust tests for new weight behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c629f0988328876a996ba1aa60b0