### PR TITLE
Add AI winner weights endpoint and GPT weighting logic

### DIFF
--- a/product_research_app/static/js/config.js
+++ b/product_research_app/static/js/config.js
@@ -323,75 +323,118 @@ function stratifiedSample(list, n){
   return sample.slice(0,n);
 }
 
-async function adjustWeightsAI(){
-  const num = v => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
-  try{
-    const base = Array.isArray(window.products) && window.products.length
-      ? window.products.slice()
-      : (Array.isArray(window.allProducts) ? window.allProducts.slice() : []);
-    if (!base.length){ if (typeof toast !== 'undefined') toast.info('No hay productos cargados'); return; }
-    let rows = base;
-    const MAX = 100;
-    if (rows.length > MAX){
-      rows = typeof stratifiedSample === 'function' ? stratifiedSample(rows, MAX) : rows.slice(0, MAX);
-    }
-    const samples = rows.map(p => {
-      const ratingRaw = p.rating ?? (p.extras && p.extras.rating);
-      const unitsRaw  = p.units_sold ?? (p.extras && (p.extras['Item Sold'] || p.extras['Orders']));
-      let revRaw    = p.revenue ?? (p.extras && (p.extras['Revenue($)'] || p.extras['Revenue']));
-      const price    = num(p.price);
-      const units    = num(unitsRaw);
-      let revenue    = num(revRaw);
-      if (!revenue && price && units) revenue = price * units;
+function setSliderValue(key, val){
+  const slider = document.getElementById(`weight-${key}`);
+  if (!slider) return;
+  const v = Math.max(0, Math.min(100, parseInt(val,10) || 0));
+  slider.value = v;
+  const item = slider.closest('li.weight-item');
+  const pill = item ? item.querySelector('.wi-pill') : null;
+  if (pill) pill.textContent = `peso: ${v}/100`;
+  const factor = factors.find(f => f.key === key);
+  if (factor) factor.weight = v;
+  cacheState.weights[key] = v;
+}
+
+function setToggleEnabled(key, enabled){
+  const item = document.querySelector(`li.weight-item[data-key="${key}"]`);
+  const toggle = item ? item.querySelector('.wt-enabled') : null;
+  if (toggle){
+    toggle.checked = enabled;
+  }
+  const factor = factors.find(f => f.key === key);
+  if (factor) factor.enabled = enabled;
+  cacheState.enabled[key] = enabled;
+}
+
+function reorderWeightsUI(order){
+  const list = document.getElementById('weightsList');
+  if (!list) return;
+  const items = Array.from(list.children);
+  const byKey = Object.fromEntries(items.map(el => [el.dataset.key, el]));
+  const ordered = [];
+  order.forEach(k => {
+    const el = byKey[k];
+    if (el) ordered.push(el);
+  });
+  list.innerHTML = '';
+  ordered.forEach(el => list.appendChild(el));
+  factors.sort((a,b) => order.indexOf(a.key) - order.indexOf(b.key));
+  cacheState.order = factors.map(f => f.key);
+  factors.forEach((f, idx) => {
+    const el = byKey[f.key];
+    const rank = el ? el.querySelector('.wi-rank') : null;
+    if (rank) rank.textContent = `#${idx+1}`;
+  });
+}
+
+function renderEffectiveBadges(eff){
+  window.winnerWeightsEffective = eff;
+  const effEl = document.getElementById('effectiveWeights');
+  if (effEl) effEl.textContent = JSON.stringify(eff);
+}
+
+async function onClickAjustarPesosIA() {
+  try {
+    showToast?.('Ajustando pesos con IA…');
+
+    // Construir muestras desde la tabla (usa tu fuente real de productos)
+    const all = typeof window.getAllFilteredRows === 'function'
+      ? window.getAllFilteredRows()
+      : (Array.isArray(window.products) ? window.products.slice() : []);
+    const samples = all.slice(0, 100).map(p => {
+      const price = +p.price || 0;
+      const units = +p.units_sold || 0;
+      const revenue = Number.isFinite(+p.revenue) ? +p.revenue : (price * units);
       return {
-        price:       price,
-        rating:      num(ratingRaw),
-        units_sold:  units,
-        revenue:     revenue,
-        desire:      num(p.desire_magnitude),
-        competition: num(p.competition_level),
-        oldness:     num(typeof computeOldnessDays === 'function' ? computeOldnessDays(p) : 0),
-        awareness:   num(typeof awarenessValue === 'function' ? awarenessValue(p) : 0),
+        price,
+        rating: +p.rating || 0,
+        units_sold: units,
+        revenue,
+        desire: +p.desire || 0,
+        competition: +p.competition || 0,
+        oldness: +p.oldness || 0,
+        awareness: +p.awareness || 0,
       };
     });
 
-    if (typeof toast !== 'undefined' && toast.info){ toast.info('Ajustando pesos con IA...'); }
     const res = await fetch('/api/config/winner-weights/ai', {
-      method:'POST', headers:{'Content-Type':'application/json'},
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ samples, success_key: 'revenue' })
     });
-    const data = await res.json().catch(()=>({}));
-    if (!res.ok){
-      if (data && data.error === 'missing_api_key' && typeof showApiKeyModal === 'function') {
-        await showApiKeyModal();
-      } else if (typeof toast !== 'undefined' && toast.error) {
-        toast.error('No se pudo ajustar por IA');
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      if (err.error === 'missing_api_key' && typeof openApiKeyModal === 'function') {
+        openApiKeyModal();
       }
-      return;
+      throw new Error('AI weights request failed');
     }
 
-    const state = await SettingsCache.get().catch(()=>({enabled:{}}));
+    const data = await res.json();
     const weights = data.winner_weights || {};
     const order = data.winner_order || Object.keys(weights);
-    const nextState = { order, weights, enabled: state.enabled };
-    SettingsCache.set(nextState);
-    isInitialRender = true;
-    renderWeightsUI(nextState);
 
-    if (data.effective && data.effective.int){
-      window.winnerWeightsEffective = data.effective.int;
-      const effEl = document.getElementById('effectiveWeights');
-      if (effEl) effEl.textContent = JSON.stringify(data.effective.int);
+    // 1) Aplicar sliders con 0..100 CRUDO (no normalizar aquí)
+    for (const [k, v] of Object.entries(weights)) {
+      if (typeof setSliderValue === 'function') setSliderValue(k, v);
+      if (typeof setToggleEnabled === 'function') setToggleEnabled(k, true);
     }
 
-    if (data.justification){
-      const btn = document.getElementById('btnAiWeights');
-      if (btn) btn.title = data.justification;
+    // 2) Reordenar la UI según prioridad (arriba = más importante)
+    if (typeof reorderWeightsUI === 'function') reorderWeightsUI(order);
+
+    // 3) Refrescar vista de pesos efectivos si existe
+    if (data.effective && data.effective.int && typeof renderEffectiveBadges === 'function') {
+      renderEffectiveBadges(data.effective.int);
     }
 
-    if (typeof toast !== 'undefined' && toast.success){ toast.success('Pesos ajustados por IA'); }
-  }catch(err){
-    if (typeof toast !== 'undefined' && toast.error){ toast.error('No se pudo ajustar por IA'); }
+    SettingsCache.set({ order, weights, enabled: cacheState.enabled });
+    showToast?.('Pesos ajustados con IA');
+  } catch (e) {
+    console.error(e);
+    showToast?.('Error al ajustar pesos con IA', 'error');
   }
 }
 
@@ -422,13 +465,12 @@ async function openConfigModal(){
   revealSettingsModalContent();
   const resetBtn = document.getElementById('btnReset');
   if (resetBtn) resetBtn.onclick = resetWeights;
-  const aiBtn = document.getElementById('btnAiWeights');
-  if (aiBtn) aiBtn.onclick = adjustWeightsAI;
 }
 
 window.openConfigModal = openConfigModal;
 window.loadWeights = hydrateSettingsModal;
 window.resetWeights = resetWeights;
-window.adjustWeightsAI = adjustWeightsAI;
 window.markDirty = markDirty;
 window.metricKeys = metricKeys;
+document.querySelector('#btnAiWeights')?.addEventListener('click', onClickAjustarPesosIA);
+window.adjustWeightsAI = onClickAjustarPesosIA;


### PR DESCRIPTION
## Summary
- add POST `/api/config/winner-weights/ai` endpoint to compute weights via AI and persist them
- update `recommend_winner_weights` to return independent 0-100 weights with explicit order
- connect "Ajustar pesos con IA" button to call AI endpoint and apply raw 0-100 slider values without normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6cc9a82a483289c9cf3d8f26c24b9