### PR TITLE
feat: support legacy auto-weight endpoint

### DIFF
--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -1189,6 +1189,9 @@ class RequestHandler(BaseHTTPRequestHandler):
         if path == "/auto_weights":
             self.handle_auto_weights()
             return
+        if path == "/api/config/winner-weights/ai":
+            self.handle_scoring_v2_auto_weights_gpt()
+            return
         if path == "/scoring/v2/auto-weights-gpt":
             self.handle_scoring_v2_auto_weights_gpt()
             return


### PR DESCRIPTION
## Summary
- accept legacy `/api/config/winner-weights/ai` calls and handle them with the GPT auto-weights endpoint

## Testing
- `node --check product_research_app/static/js/config.js`
- `curl -i -X POST http://localhost:8000/api/config/winner-weights/ai -H 'Content-Type: application/json' -d '{"features":["price","rating"],"target":"revenue","data_sample":[{"price":10,"rating":4.5,"target":1000},{"price":12,"rating":4.7,"target":1200}]}'`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6d6070df8832884b58252da4ea19e