### PR TITLE
feat: expand winner weight selection to all variables

### DIFF
--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -114,8 +114,11 @@ def test_recommend_winner_weights_includes_awareness(monkeypatch):
     samples = [{"price": 10.0, "awareness": 0.75, "target": 5.0}]
     res = gpt.recommend_winner_weights("k", "m", samples, "target")
     weights = res["weights"]
-    assert set(weights) == {"price", "awareness"}
-    assert math.isclose(sum(weights.values()), 1.0)
+    assert set(weights) == set(ws.ALLOWED_FIELDS)
+    assert weights["price"] == 1
+    assert weights["awareness"] == 3
+    assert weights["revenue"] == 50
+    assert all(0 <= v <= 100 for v in weights.values())
 
 
 def test_awareness_priority_and_closeness():


### PR DESCRIPTION
## Summary
- update GPT weight recommender to always consider all Winner Score variables, including revenue, and return independent 0–100 weights
- normalize GPT output if it's 0–1 and remove final normalization step
- adjust winner weight tests for new behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d8b2c5688328ad4d45f4a2cc9a6d