### PR TITLE
feat: expand winner weight selection to all variables

### DIFF
--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -114,8 +114,11 @@ def test_recommend_winner_weights_includes_awareness(monkeypatch):
     samples = [{"price": 10.0, "awareness": 0.75, "target": 5.0}]
     res = gpt.recommend_winner_weights("k", "m", samples, "target")
     weights = res["weights"]
-    assert set(weights) == {"price", "awareness"}
-    assert math.isclose(sum(weights.values()), 1.0)
+    assert set(weights) == set(ws.ALLOWED_FIELDS)
+    assert weights["price"] == 1
+    assert weights["awareness"] == 3
+    assert weights["revenue"] == 50
+    assert all(0 <= v <= 100 for v in weights.values())
 
 
 def test_awareness_priority_and_closeness():


### PR DESCRIPTION
## Summary
- update GPT auto-weight endpoint to accept independent 0-100 weights for all Winner Score variables, including revenue, and return ordered priorities
- adjust statistical auto-weight endpoint to rescale correlations to 0-100 weights and output explicit order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d8b2c5688328ad4d45f4a2cc9a6d