### PR TITLE
feat: robust winner weight recommendations

### DIFF
--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -117,7 +117,7 @@ def test_recommend_winner_weights_includes_awareness(monkeypatch):
     assert set(weights) == set(ws.ALLOWED_FIELDS)
     assert weights["price"] == 1
     assert weights["awareness"] == 3
-    assert weights["revenue"] == 50
+    assert weights["revenue"] == 0
     assert all(0 <= v <= 100 for v in weights.values())
 
 


### PR DESCRIPTION
## Summary
- overhaul `recommend_winner_weights` to parse messy JSON and fall back to correlation-based stats
- adjust winner weight test for new default revenue weight

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6dbf0426083288321cef2e69be20b