### PR TITLE
Add trends summary API endpoint

### DIFF
--- a/product_research_app/services/trends_service.py
+++ b/product_research_app/services/trends_service.py
@@ -1,0 +1,205 @@
+import json
+import logging
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .. import database
+
+logger = logging.getLogger(__name__)
+
+DB_PATH = Path(__file__).resolve().parents[1] / "data.sqlite3"
+
+
+def _parse_extra(extra: str | bytes | None) -> Dict[str, Any]:
+    if not extra:
+        return {}
+    try:
+        return json.loads(extra)
+    except Exception:
+        try:
+            return json.loads(extra.decode("utf-8"))
+        except Exception:
+            return {}
+
+
+def get_trends_summary(start: datetime, end: datetime, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return aggregated metrics and timeseries for the given period.
+
+    Args:
+        start: Start of range (inclusive).
+        end: End of range (exclusive).
+        filters: Optional dict of filters (e.g., {"category": "Electronics"}).
+
+    Returns:
+        Dict with categories aggregation and timeseries.
+    """
+    filters = filters or {}
+    t0 = time.perf_counter()
+    conn = database.get_connection(DB_PATH)
+    cur = conn.cursor()
+
+    params = [start.isoformat(), end.isoformat()]
+    where = "WHERE import_date >= ? AND import_date < ?"
+    cat_filter = filters.get("category")
+    if cat_filter:
+        where += " AND category LIKE ?"
+        params.append(f"{cat_filter}%")
+
+    rows = cur.execute(
+        f"SELECT id, category, price, import_date, extra FROM products {where}",
+        params,
+    ).fetchall()
+    logger.info("trends_summary_rows=%s", len(rows))
+
+    duration = end - start
+    prev_start = start - duration
+    prev_end = start
+    prev_rows = cur.execute(
+        "SELECT category, extra, price FROM products WHERE import_date >= ? AND import_date < ?",
+        [prev_start.isoformat(), prev_end.isoformat()],
+    ).fetchall()
+
+    prev_rev: Dict[str, float] = {}
+    prev_units: Dict[str, float] = {}
+    prev_total_rev = 0.0
+    prev_total_units = 0.0
+    for prow in prev_rows:
+        extra = _parse_extra(prow[1])
+        units = float(extra.get("units_sold") or 0)
+        revenue = extra.get("revenue")
+        if revenue is None:
+            price = prow[2] or 0
+            revenue = price * units
+        cat = prow[0] or ""
+        prev_rev[cat] = prev_rev.get(cat, 0.0) + float(revenue or 0)
+        prev_units[cat] = prev_units.get(cat, 0.0) + units
+        prev_total_rev += float(revenue or 0)
+        prev_total_units += units
+
+    categories: list[Dict[str, Any]] = []
+    cat_data: Dict[str, Dict[str, Any]] = {}
+    timeseries: Dict[str, Dict[str, float]] = {}
+    granularity = "day" if duration <= timedelta(days=31) else "week"
+
+    for row in rows:
+        cat = row[1] or ""
+        extra = _parse_extra(row[4])
+        units = float(extra.get("units_sold") or 0)
+        revenue = extra.get("revenue")
+        price = row[2] or 0
+        if revenue is None:
+            revenue = price * units
+        rating = extra.get("rating")
+        import_dt = datetime.fromisoformat(row[3])
+
+        c = cat_data.setdefault(
+            cat,
+            {
+                "products": set(),
+                "units": 0.0,
+                "revenue": 0.0,
+                "price_sum": 0.0,
+                "price_count": 0,
+                "rating_sum": 0.0,
+                "rating_count": 0,
+            },
+        )
+        c["products"].add(row[0])
+        c["units"] += units
+        c["revenue"] += float(revenue or 0)
+        if row[2] is not None:
+            c["price_sum"] += row[2]
+            c["price_count"] += 1
+        if rating is not None:
+            try:
+                c["rating_sum"] += float(rating)
+                c["rating_count"] += 1
+            except Exception:
+                pass
+
+        if granularity == "week":
+            key = (import_dt - timedelta(days=import_dt.weekday())).date().isoformat()
+        else:
+            key = import_dt.date().isoformat()
+        ts = timeseries.setdefault(key, {"units": 0.0, "revenue": 0.0})
+        ts["units"] += units
+        ts["revenue"] += float(revenue or 0)
+
+    total_products = 0
+    total_units = 0.0
+    total_revenue = 0.0
+    price_sum = 0.0
+    price_count = 0
+    rating_sum = 0.0
+    rating_count = 0
+
+    for cat, data in cat_data.items():
+        units = data["units"]
+        revenue = data["revenue"]
+        prev = prev_rev.get(cat, 0.0)
+        delta_pct = ((revenue - prev) / prev * 100.0) if prev else 0.0
+        avg_price = data["price_sum"] / data["price_count"] if data["price_count"] else 0.0
+        avg_rating = data["rating_sum"] / data["rating_count"] if data["rating_count"] else 0.0
+        rev_per_unit = revenue / units if units else 0.0
+        categories.append(
+            {
+                "category": cat,
+                "unique_products": len(data["products"]),
+                "units": units,
+                "revenue": revenue,
+                "avg_price": avg_price,
+                "avg_rating": avg_rating,
+                "rev_per_unit": rev_per_unit,
+                "delta_revenue_pct": delta_pct,
+            }
+        )
+        total_products += len(data["products"])
+        total_units += units
+        total_revenue += revenue
+        price_sum += data["price_sum"]
+        price_count += data["price_count"]
+        rating_sum += data["rating_sum"]
+        rating_count += data["rating_count"]
+
+    categories.sort(key=lambda x: x["revenue"], reverse=True)
+    ts_list = [
+        {"date": k, "units": v["units"], "revenue": v["revenue"]}
+        for k, v in sorted(timeseries.items())
+    ]
+
+    avg_price = price_sum / price_count if price_count else 0.0
+    avg_rating = rating_sum / rating_count if rating_count else 0.0
+    rev_per_unit = total_revenue / total_units if total_units else 0.0
+    totals = {
+        "unique_products": total_products,
+        "units": total_units,
+        "revenue": total_revenue,
+        "avg_price": avg_price,
+        "avg_rating": avg_rating,
+        "rev_per_unit": rev_per_unit,
+    }
+    totals["delta_revenue_pct"] = (
+        (total_revenue - prev_total_rev) / prev_total_rev * 100.0
+        if prev_total_rev
+        else 0.0
+    )
+    totals["delta_units_pct"] = (
+        (total_units - prev_total_units) / prev_total_units * 100.0
+        if prev_total_units
+        else 0.0
+    )
+
+    logger.info(
+        "trends_summary_done categories=%s points=%s duration_ms=%.2f",
+        len(categories),
+        len(ts_list),
+        (time.perf_counter() - t0) * 1000,
+    )
+    return {
+        "categories": categories,
+        "timeseries": ts_list,
+        "granularity": granularity,
+        "totals": totals,
+    }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -45,6 +45,26 @@ pre { white-space:pre-wrap; background:#f5f7ff; padding:8px; border-radius:4px; 
 body.dark pre { background:#2e315f; }
 /* Weight slider styling */
 .field-label { display:block; margin-top:10px; font-weight:600; }
+
+#trendsSummary{display:none;}
+#trendHeader{display:flex;flex-wrap:wrap;gap:8px;align-items:flex-end;margin-bottom:16px;}
+.kpi-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:20px;}
+@media (max-width:600px){.kpi-grid{grid-template-columns:repeat(2,1fr);}}
+.kpi{text-align:center;padding:8px;}
+.kpi-value{font-size:1.2rem;font-weight:600;}
+.kpi-label{font-size:0.8rem;opacity:0.8;}
+.kpi-delta{font-size:0.8rem;}
+.sparklines-row{display:flex;gap:10px;margin-bottom:20px;}
+.sparklines-row canvas{flex:1;height:140px;}
+.trend-main{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:20px;}
+.trend-main .card{flex:1;min-width:280px;max-height:320px;overflow:auto;}
+.chart-wrapper{position:relative;height:240px;}
+.metric-selector{display:flex;gap:4px;margin-left:auto;}
+.metric-btn{padding:4px 8px;font-size:12px;}
+.metric-btn.active{opacity:0.7;}
+.skeleton{background:#ddd;border-radius:4px;height:40px;animation:skeleton-pulse 1.2s infinite ease-in-out;}
+body.dark .skeleton{background:#333;}
+@keyframes skeleton-pulse{0%{opacity:0.7;}50%{opacity:0.4;}100%{opacity:0.7;}}
 </style>
 </head>
 <body class="dark">
@@ -112,57 +132,40 @@ body.dark pre { background:#2e315f; }
 <div id="custom" style="display:none;">
   <div id="history" style="margin-top:10px;"></div>
 </div>
-<div id="trends" class="card" style="display:none;"></div>
-<!-- Chart container for trends -->
-<div id="chartContainer" class="card" style="display:none;">
-  <div id="trendControls" style="display:flex; flex-wrap:wrap; gap:10px; align-items:flex-end; margin-bottom:20px;">
-    <div><label>Desde: <input type="date" id="trendStart"></label></div>
-    <div><label>Hasta: <input type="date" id="trendEnd"></label></div>
-    <div><label>Métrica:
-      <select id="metricSelect">
-        <option value="revenue">Ingresos</option>
-        <option value="units">Unidades</option>
-        <option value="avg_price">Avg. Unit Price</option>
-      </select>
-    </label></div>
-    <button id="applyTrendFilters">Aplicar</button>
+<div id="trendsSummary" class="card">
+  <div id="trendHeader">
+    <label>Desde: <input type="date" id="trendStart"></label>
+    <label>Hasta: <input type="date" id="trendEnd"></label>
+    <button id="applyTrendFilters" aria-label="Aplicar filtros">Aplicar</button>
   </div>
-  <div id="kpiPanel" style="display:flex; flex-wrap:wrap; gap:20px; justify-content:space-around; margin-bottom:20px;"></div>
-  <div style="width:100%; margin-bottom:20px;">
-    <h3 style="margin-bottom:8px; font-size:18px; text-align:center;">Comparativo por categoría</h3>
-    <canvas id="catCompareCanvas" style="width:100%; height:400px;"></canvas>
+  <div id="kpiGrid" class="kpi-grid"></div>
+  <div class="sparklines-row">
+    <canvas id="sparkRevenue"></canvas>
+    <canvas id="sparkUnits"></canvas>
   </div>
-  <div style="width:100%; margin-bottom:20px;">
-    <h3 style="margin-bottom:8px; font-size:18px; text-align:center;">Resumen por categoría</h3>
-    <table id="categorySummaryTable"></table>
+  <div class="trend-main">
+    <div class="card" id="topCatCard">
+      <div class="card-header" style="display:flex;align-items:center;gap:8px;">
+        <span>Top categorías</span>
+        <div class="metric-selector">
+          <button class="metric-btn active" data-metric="revenue" aria-label="Ordenar por ingresos">Ingresos</button>
+          <button class="metric-btn" data-metric="units" aria-label="Ordenar por unidades">Unidades</button>
+          <button class="metric-btn" data-metric="avg_price" aria-label="Ordenar por precio medio">Precio</button>
+          <button class="metric-btn" data-metric="avg_rating" aria-label="Ordenar por rating medio">Rating</button>
+        </div>
+      </div>
+      <div class="chart-wrapper"><canvas id="topCatChart"></canvas></div>
+    </div>
+    <div class="card" id="priceRevCard">
+      <div class="card-header" style="display:flex;align-items:center;justify-content:space-between;">
+        <span>Precio vs Ingresos</span>
+        <button id="toggleLog" class="metric-btn" aria-label="Alternar escala log">Log</button>
+      </div>
+      <div class="chart-wrapper"><canvas id="priceRevChart"></canvas></div>
+    </div>
   </div>
-  <div style="width:100%; margin-bottom:20px;">
-    <h3 style="margin-bottom:8px; font-size:18px; text-align:center;">Top categorías por crecimiento en ingresos</h3>
-    <canvas id="catRevenueGrowthCanvas" style="width:100%;"></canvas>
-  </div>
-  <div style="width:100%; margin-bottom:20px;">
-    <h3 style="margin-bottom:8px; font-size:18px; text-align:center;">Top categorías por crecimiento en unidades</h3>
-    <canvas id="catUnitGrowthCanvas" style="width:100%;"></canvas>
-  </div>
-  <div style="width:100%; margin-bottom:20px;">
-    <h3 style="margin-bottom:8px; font-size:18px; text-align:center;">Ingresos/unidades por categoría</h3>
-    <canvas id="catRevPerUnitCanvas" style="width:100%;"></canvas>
-  </div>
-  <div style="width:100%; margin-bottom:20px;">
-    <h3 style="margin-bottom:8px; font-size:18px; text-align:center;">Palabras clave destacadas</h3>
-    <canvas id="keywordTrendCanvas" style="width:100%;"></canvas>
-  </div>
-  <div style="width:100%; margin-bottom:20px;">
-    <h3 style="margin-bottom:8px; font-size:18px; text-align:center;">Marcas más repetidas</h3>
-    <canvas id="brandTrendCanvas" style="width:100%;"></canvas>
-  </div>
-  <div style="width:100%; margin-bottom:20px;">
-    <h3 style="margin-bottom:8px; font-size:18px; text-align:center;">Rating vs Ingresos</h3>
-    <canvas id="ratingRevenueCanvas" style="width:100%; height:400px;"></canvas>
-  </div>
-  <div style="width:100%;">
-    <h3 style="margin-bottom:8px; font-size:18px; text-align:center;">Precio promedio vs Ingresos</h3>
-    <canvas id="priceRevenueCanvas" style="width:100%; height:400px;"></canvas>
+  <div class="card" id="topCatTableCard">
+    <table id="topCatTable"></table>
   </div>
 </div>
 
@@ -233,6 +236,8 @@ body.dark pre { background:#2e315f; }
 <script type="module" src="/static/js/manage-groups.js"></script>
 <script src="/static/js/winner_score.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<script type="module" src="/static/js/trends-summary.js"></script>
 <script type="module">
 import * as api from "/static/js/net.js";
 import * as groupsService from "/static/js/groups-service.js";
@@ -1362,138 +1367,11 @@ document.getElementById('createListBtn').onclick = async () => {
 window.addEventListener('DOMContentLoaded', () => {
   loadLists();
 });
-
-// trends button & analytics rendering
-let trendsData = null;
-let currentMetric = 'revenue';
-document.getElementById('trendsBtn').onclick = async () => {
-  const cont = document.getElementById('trends');
-  if (cont.style.display === 'block') {
-    cont.style.display = 'none';
-    cont.innerHTML = '';
-    document.getElementById('chartContainer').style.display = 'none';
-    return;
-  }
-  cont.style.display = 'block';
-  cont.innerHTML = '<h3>Tendencias</h3>';
-  await loadTrends();
-};
-document.getElementById('applyTrendFilters').onclick = () => loadTrends();
-document.getElementById('metricSelect').onchange = e => {
-  currentMetric = e.target.value;
-  renderTrends();
-};
-
-async function loadTrends(){
-  const cont = document.getElementById('trends');
-  const start = document.getElementById('trendStart').value;
-  const end = document.getElementById('trendEnd').value;
-  let url = '/trends';
-  const params=[];
-  if(start) params.push('start='+encodeURIComponent(start));
-  if(end) params.push('end='+encodeURIComponent(end));
-  if(params.length) url += '?' + params.join('&');
-  const data = await fetchJson(url);
-  if(data.error){ cont.textContent = 'Error al cargar tendencias: '+data.error; return; }
-  trendsData = data;
-  trendingWords = (data.keywords || []).map(([w])=>w.toLowerCase());
-  let html = '<h3>Tendencias</h3>';
-  if(data.top_products && data.top_products.length){
-    html += '<strong>Top productos por Winner Score:</strong><ol>';
-        data.top_products.forEach(item=>{ const sc = Math.round(item.winner_score || 0); html += `<li>${item.name} (Winner Score: ${sc.toLocaleString(undefined,{maximumFractionDigits:0})})</li>`; });
-    html += '</ol>';
-  }
-  cont.innerHTML = html;
-  renderTrends();
-}
-
-function renderTrends(){
-  if(!trendsData) return;
-  const chartDiv = document.getElementById('chartContainer');
-  chartDiv.style.display='block';
-  const k = trendsData.kpis || {};
-  document.getElementById('kpiPanel').innerHTML = `
-    <div><strong>Ingresos totales:</strong> ${k.total_revenue ? k.total_revenue.toFixed(2) : 0}</div>
-    <div><strong>Unidades totales:</strong> ${k.total_units || 0}</div>
-    <div><strong>Precio medio:</strong> ${k.avg_price ? k.avg_price.toFixed(2) : 0}</div>
-    <div><strong>Categoría top:</strong> ${k.top_category || '-'}</div>
-    <div><strong>Producto top:</strong> ${k.top_product || '-'}</div>`;
-  const tooltip = document.getElementById('chartTooltip');
-  const drawHorizontal = (canvasId, entries, color, axisLabel) => {
-    const canvas = document.getElementById(canvasId);
-    const ctx = canvas.getContext('2d');
-    const padL=120,padT=20,padB=40,barH=28,gap=12;
-    const width = chartDiv.clientWidth - 40;
-    canvas.width = width;
-    canvas.height = padT + padB + entries.length*(barH+gap);
-    ctx.fillStyle='#fafafa'; ctx.fillRect(0,0,canvas.width,canvas.height);
-    const maxVal = Math.max(...entries.map(e=>e.value),0);
-    ctx.font='14px sans-serif'; ctx.textBaseline='middle';
-    const rects=[];
-    entries.forEach((e,i)=>{
-      const y=padT+i*(barH+gap);
-      const len=maxVal?(e.value/maxVal)*(canvas.width-padL-40):0;
-      ctx.fillStyle=color; ctx.fillRect(padL,y,len,barH);
-      ctx.fillStyle='#000'; ctx.fillText(e.value,padL+len+5,y+barH/2);
-      ctx.fillText(e.label,10,y+barH/2);
-      rects.push({x:padL,y:y,w:len,h:barH,data:e});
-    });
-    ctx.strokeStyle='#666'; ctx.beginPath();
-    ctx.moveTo(padL,padT-10); ctx.lineTo(padL,canvas.height-padB); ctx.lineTo(canvas.width-20,canvas.height-padB); ctx.stroke();
-    ctx.font='16px sans-serif'; ctx.fillStyle='#000'; if(axisLabel) ctx.fillText(axisLabel,canvas.width/2,canvas.height-10);
-    canvas.onmousemove=ev=>{
-      const r=canvas.getBoundingClientRect(); const mx=ev.clientX-r.left,my=ev.clientY-r.top;
-      const hit=rects.find(b=>mx>=b.x && mx<=b.x+b.w && my>=b.y && my<=b.y+b.h);
-      if(hit){ tooltip.style.display='block'; tooltip.textContent=hit.data.tooltip||`${hit.data.label}: ${hit.data.value}`; tooltip.style.left=ev.pageX+10+'px'; tooltip.style.top=ev.pageY+10+'px'; }
-      else tooltip.style.display='none'; };
-    canvas.onmouseleave=()=>tooltip.style.display='none';
-  };
-  const drawScatter = (canvasId, points, color, xLabel, yLabel) => {
-    const canvas=document.getElementById(canvasId); const ctx=canvas.getContext('2d');
-    const padL=60,padB=40,padT=20,width=chartDiv.clientWidth-40,height=400;
-    canvas.width=width; canvas.height=height;
-    ctx.fillStyle='#fafafa'; ctx.fillRect(0,0,width,height);
-    const maxX=Math.max(...points.map(p=>p.x),0), maxY=Math.max(...points.map(p=>p.y),0), maxR=Math.max(...points.map(p=>p.r||0),0);
-    const pts=[];
-    points.forEach(p=>{ const x=padL+(maxX?(p.x/maxX)*(width-padL-20):0); const y=height-padB-(maxY?(p.y/maxY)*(height-padT-padB):0); const r=p.r?Math.max(4,(p.r/maxR)*20):6; ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.fillStyle=color; ctx.fill(); pts.push({x,y,r,data:p});});
-    ctx.strokeStyle='#666'; ctx.beginPath(); ctx.moveTo(padL,padT); ctx.lineTo(padL,height-padB); ctx.lineTo(width-20,height-padB); ctx.stroke();
-    ctx.font='16px sans-serif'; ctx.fillStyle='#000'; ctx.fillText(xLabel,width/2,height-10); ctx.save(); ctx.translate(20,height/2); ctx.rotate(-Math.PI/2); ctx.fillText(yLabel,0,0); ctx.restore();
-    canvas.onmousemove=ev=>{ const r=canvas.getBoundingClientRect(); const mx=ev.clientX-r.left,my=ev.clientY-r.top; const hit=pts.find(p=>Math.hypot(mx-p.x,my-p.y)<=p.r); if(hit){ const d=hit.data; tooltip.style.display='block'; tooltip.innerHTML=`${d.label||''}<br/>Ingresos: ${d.revenue?.toFixed?d.revenue.toFixed(2):d.y.toFixed(2)}<br/>Unidades: ${d.units||''}<br/>Rating: ${d.rating||''}`; tooltip.style.left=ev.pageX+10+'px'; tooltip.style.top=ev.pageY+10+'px'; } else tooltip.style.display='none'; };
-    canvas.onmouseleave=()=>tooltip.style.display='none';
-  };
-  const metricLabel = currentMetric==='units'?'Unidades medias':currentMetric==='avg_price'?'Precio medio':'Ingresos medios';
-  const catPts=(trendsData.category_compare||[]).map(c=>({x:c.products,y:currentMetric==='units'?c.avg_units:currentMetric==='avg_price'?c.avg_price:c.avg_revenue,label:c.category,revenue:c.total_revenue,units:c.total_units,rating:c.avg_rating}));
-  drawScatter('catCompareCanvas',catPts,'#26a69a','Productos listados',metricLabel);
-  renderCategorySummary();
-  drawHorizontal('catRevenueGrowthCanvas',(trendsData.cat_revenue_growth||[]).map(e=>({label:e[0],value:e[1]})),'#42a5f5','Crecimiento ingresos');
-  drawHorizontal('catUnitGrowthCanvas',(trendsData.cat_units_growth||[]).map(e=>({label:e[0],value:e[1]})),'#66bb6a','Crecimiento unidades');
-  drawHorizontal('catRevPerUnitCanvas',(trendsData.cat_rev_per_unit||[]).map(e=>({label:e[0],value:e[1]})),'#ffca28','Ingresos/unidad');
-  drawHorizontal('keywordTrendCanvas',(trendsData.keywords||[]).map(e=>({label:e[0],value:e[1]})),'#29b6f6','Frecuencia');
-  drawHorizontal('brandTrendCanvas',(trendsData.brands||[]).map(e=>({label:e[0],value:e[1]})),'#ab47bc','Frecuencia');
-  drawScatter('ratingRevenueCanvas',trendsData.scatter_rating_revenue||[],'#ef5350','Rating','Ingresos');
-  drawScatter('priceRevenueCanvas',trendsData.scatter_price_revenue||[],'#7e57c2','Precio promedio','Ingresos');
-  renderTable();
-}
-
-let catSort={key:'category',asc:true};
-function renderCategorySummary(){
-  const table=document.getElementById('categorySummaryTable');
-  if(!table) return;
-  let rows=[...(trendsData.category_summary||[])];
-  rows.sort((a,b)=>{const k=catSort.key;const va=a[k],vb=b[k];if(typeof va==='string') return catSort.asc?va.localeCompare(vb):vb.localeCompare(va);return catSort.asc?va-vb:vb-va;});
-  let head=`<thead><tr><th data-key="category">Categoría</th><th data-key="products">#Productos</th><th data-key="total_units">Unidades totales</th><th data-key="total_revenue">Ingresos totales</th><th data-key="avg_price">Precio promedio</th><th data-key="avg_rating">Rating promedio</th></tr></thead>`;
-  let body='<tbody>';
-  rows.forEach(r=>{body+=`<tr><td>${r.category}</td><td>${r.products}</td><td>${r.total_units.toFixed(0)}</td><td>${r.total_revenue.toFixed(2)}</td><td>${r.avg_price.toFixed(2)}</td><td>${r.avg_rating.toFixed(2)}</td></tr>`;});
-  body+='</tbody>'; table.innerHTML=head+body;
-  table.querySelectorAll('th').forEach(th=>{th.style.cursor='pointer';th.onclick=()=>{const key=th.dataset.key;if(catSort.key===key) catSort.asc=!catSort.asc; else {catSort.key=key;catSort.asc=true;} renderCategorySummary();};});
-}
-
 window.renderTable = renderTable;
 window.startProgress = startProgress;
 window.parseDate = parseDate;
 </script>
 <script type="module" src="/static/js/completar-ia.js"></script>
-<div id="chartTooltip" style="position:absolute; background:#fff; border:1px solid #333; padding:4px; font-size:12px; border-radius:4px; pointer-events:none; display:none; z-index:2000;"></div>
 <script src="/static/js/filters.js"></script>
 </body>
 </html>

--- a/product_research_app/static/js/format.js
+++ b/product_research_app/static/js/format.js
@@ -10,3 +10,26 @@ export function winnerScoreClass(s){
   return 'badge score-red';
 }
 
+export function fmtNumber(n, dec = 0) {
+  return Number(n || 0).toLocaleString('es-ES', {
+    minimumFractionDigits: dec,
+    maximumFractionDigits: dec,
+  });
+}
+
+export function fmtInt(n) {
+  return fmtNumber(n, 0);
+}
+
+export function fmtPrice(n) {
+  return fmtNumber(n, 2);
+}
+
+export function fmtFloat2(n) {
+  return fmtNumber(n, 2);
+}
+
+export function fmtPct(n) {
+  return fmtNumber(n, 1) + '%';
+}
+

--- a/product_research_app/static/js/trends-summary.js
+++ b/product_research_app/static/js/trends-summary.js
@@ -1,0 +1,127 @@
+import { fetchJson } from './net.js';
+import { fmtInt, fmtPrice, fmtPct, fmtFloat2 } from './format.js';
+
+const container = document.getElementById('trendsSummary');
+const btn = document.getElementById('trendsBtn');
+const startInput = document.getElementById('trendStart');
+const endInput = document.getElementById('trendEnd');
+const applyBtn = document.getElementById('applyTrendFilters');
+const metricButtons = document.querySelectorAll('#topCatCard .metric-btn');
+const toggleLogBtn = document.getElementById('toggleLog');
+
+let currentMetric = 'revenue';
+let scatterLog = false;
+let currentData = null;
+let prevData = null;
+let revenueSpark, unitsSpark, topCatChart, scatterChart;
+
+function showSkeleton() {
+  document.getElementById('kpiGrid').innerHTML = '<div class="skeleton"></div>'.repeat(6);
+}
+
+async function loadData() {
+  showSkeleton();
+  const from = startInput.value;
+  const to = endInput.value;
+  const url = `/api/trends/summary?from=${from}&to=${to}`;
+  try {
+    currentData = await fetchJson(url);
+    const start = new Date(from);
+    const end = new Date(to);
+    const diff = end.getTime() - start.getTime();
+    const prevFrom = new Date(start.getTime() - diff).toISOString().slice(0,10);
+    prevData = await fetchJson(`/api/trends/summary?from=${prevFrom}&to=${from}`);
+    render();
+  } catch (e) {
+    // fetchJson already toasts
+  }
+}
+
+function computeTotals(data) {
+  return data.totals || {
+    unique_products: data.categories.reduce((a,c)=>a+c.unique_products,0),
+    units: data.categories.reduce((a,c)=>a+c.units,0),
+    revenue: data.categories.reduce((a,c)=>a+c.revenue,0),
+    avg_price: 0,
+    avg_rating: 0,
+    rev_per_unit: 0,
+  };
+}
+
+function render() {
+  const totals = computeTotals(currentData);
+  const prevTotals = computeTotals(prevData);
+  const deltaRev = prevTotals.revenue ? ((totals.revenue - prevTotals.revenue)/prevTotals.revenue)*100 : 0;
+  const deltaUnits = prevTotals.units ? ((totals.units - prevTotals.units)/prevTotals.units)*100 : 0;
+  const kpiGrid = document.getElementById('kpiGrid');
+  kpiGrid.innerHTML = `
+    <div class="kpi"><div class="kpi-value">${fmtInt(totals.unique_products)}</div><div class="kpi-label">Productos únicos</div></div>
+    <div class="kpi"><div class="kpi-value">${fmtInt(totals.units)}</div><div class="kpi-label">Unidades</div><div class="kpi-delta" style="color:${deltaUnits>=0?'#4caf50':'#e53935'};">${fmtPct(deltaUnits)}</div></div>
+    <div class="kpi"><div class="kpi-value">${fmtPrice(totals.revenue)}</div><div class="kpi-label">Ingresos</div><div class="kpi-delta" style="color:${deltaRev>=0?'#4caf50':'#e53935'};">${fmtPct(deltaRev)}</div></div>
+    <div class="kpi"><div class="kpi-value">${fmtPrice(totals.rev_per_unit)}</div><div class="kpi-label">Rev/Unidad</div></div>
+    <div class="kpi"><div class="kpi-value">${fmtPrice(totals.avg_price)}</div><div class="kpi-label">Precio medio</div></div>
+    <div class="kpi"><div class="kpi-value">${fmtFloat2(totals.avg_rating)}</div><div class="kpi-label">Rating medio</div></div>`;
+  renderCharts();
+  renderTable();
+}
+
+function renderCharts() {
+  const labels = currentData.timeseries.map(p=>p.date);
+  const revData = currentData.timeseries.map(p=>p.revenue);
+  const unitsData = currentData.timeseries.map(p=>p.units);
+  const sparkOpts = {responsive:true, maintainAspectRatio:false, scales:{x:{display:false}, y:{display:false}}, elements:{line:{tension:0.3}, point:{radius:0}}, plugins:{legend:{display:false}}};
+  if(revenueSpark) revenueSpark.destroy();
+  revenueSpark = new Chart(document.getElementById('sparkRevenue'), {type:'line', data:{labels, datasets:[{data:revData,borderColor:'#42a5f5',fill:false}]}, options:sparkOpts});
+  if(unitsSpark) unitsSpark.destroy();
+  unitsSpark = new Chart(document.getElementById('sparkUnits'), {type:'line', data:{labels, datasets:[{data:unitsData,borderColor:'#66bb6a',fill:false}]}, options:sparkOpts});
+
+  const top = currentData.categories.slice(0,10);
+  const labelsCat = top.map(c=>c.category);
+  const values = top.map(c=>c[currentMetric]);
+  if(topCatChart) topCatChart.destroy();
+  topCatChart = new Chart(document.getElementById('topCatChart'), {
+    type:'bar',
+    data:{labels:labelsCat, datasets:[{data:values, backgroundColor:'#42a5f5'}]},
+    options:{indexAxis:'y', responsive:true, maintainAspectRatio:false, scales:{x:{grid:{display:false}, ticks:{callback:v=>fmtInt(v)}}, y:{grid:{display:false}}}, plugins:{legend:{display:false}, tooltip:{callbacks:{label:ctx=>fmtInt(ctx.parsed.x)}}}, maxBarThickness:24}
+  });
+
+  const scatterData = currentData.categories.map(c=>({x:c.avg_price, y:c.revenue, label:c.category, units:c.units, avg_price:c.avg_price, revenue:c.revenue, avg_rating:c.avg_rating}));
+  if(scatterChart) scatterChart.destroy();
+  scatterChart = new Chart(document.getElementById('priceRevChart'), {
+    type:'scatter',
+    data:{datasets:[{data:scatterData, backgroundColor:'#7e57c2'}]},
+    options:{responsive:true, maintainAspectRatio:false, scales:{x:{type:scatterLog?'logarithmic':'linear'}, y:{}}, plugins:{legend:{display:false}, tooltip:{callbacks:{label:ctx=>{const d=ctx.raw; return `${d.label}\nIngresos: ${fmtPrice(d.revenue)}\nUnidades: ${fmtInt(d.units)}\nPrecio: ${fmtPrice(d.avg_price)}\nRating: ${fmtFloat2(d.avg_rating)}`;}}}}}
+  });
+}
+
+function renderTable(){
+  const tbl = document.getElementById('topCatTable');
+  const rows = currentData.categories.slice(0,10);
+  let html='<thead><tr><th>Cat.</th><th>Productos</th><th>Unidades</th><th>Ingresos</th><th>Precio</th><th>Rating</th></tr></thead><tbody>';
+  rows.forEach(c=>{
+    html+=`<tr><td>${c.category}</td><td>${fmtInt(c.unique_products)}</td><td>${fmtInt(c.units)}</td><td>${fmtPrice(c.revenue)}</td><td>${fmtPrice(c.avg_price)}</td><td>${fmtFloat2(c.avg_rating)}</td></tr>`;
+  });
+  html+='</tbody>';
+  tbl.innerHTML = html;
+}
+
+btn?.addEventListener('click', () => {
+  container.style.display = container.style.display === 'block' ? 'none' : 'block';
+  if(container.style.display === 'block') loadData();
+});
+
+applyBtn?.addEventListener('click', () => loadData());
+
+metricButtons.forEach(btn => btn.addEventListener('click', e => {
+  metricButtons.forEach(b=>b.classList.remove('active'));
+  e.currentTarget.classList.add('active');
+  currentMetric = e.currentTarget.dataset.metric;
+  renderCharts();
+}));
+
+toggleLogBtn?.addEventListener('click', () => {
+  scatterLog = !scatterLog;
+  renderCharts();
+});
+
+export {};

--- a/product_research_app/tests/test_trends_service.py
+++ b/product_research_app/tests/test_trends_service.py
@@ -1,0 +1,60 @@
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from product_research_app import web_app, database, config
+from product_research_app.services import trends_service
+from product_research_app.services import config as cfg_service
+
+
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(web_app, "DB_PATH", tmp_path / "data.sqlite3")
+    monkeypatch.setattr(web_app, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(web_app, "LOG_PATH", tmp_path / "logs" / "app.log")
+    web_app.LOG_DIR.mkdir(exist_ok=True)
+    for h in list(logging.getLogger().handlers):
+        logging.getLogger().removeHandler(h)
+    logging.basicConfig(level=logging.INFO, handlers=[logging.FileHandler(web_app.LOG_PATH, encoding="utf-8")], force=True)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(cfg_service, "DB_PATH", tmp_path / "data.sqlite3")
+    cfg_service.init_app_config()
+    return web_app.ensure_db()
+
+
+def test_trends_no_data(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(trends_service, "DB_PATH", tmp_path / "data.sqlite3")
+    start = datetime.utcnow() - timedelta(days=1)
+    end = datetime.utcnow()
+    res = trends_service.get_trends_summary(start, end)
+    assert res["categories"] == []
+    assert res["timeseries"] == []
+    assert res["totals"]["units"] == 0
+    assert res["totals"]["revenue"] == 0
+
+
+def test_trends_with_data_delta(tmp_path, monkeypatch):
+    conn = setup_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(trends_service, "DB_PATH", tmp_path / "data.sqlite3")
+    database.insert_product(
+        conn,
+        name="P1",
+        description="",
+        category="Cat/Sub",
+        price=10.0,
+        currency=None,
+        image_url="",
+        source="",
+        extra={"units_sold": 2, "revenue": 20.0, "rating": 4.0},
+    )
+    start = datetime.utcnow() - timedelta(days=1)
+    end = datetime.utcnow() + timedelta(days=1)
+    res = trends_service.get_trends_summary(start, end)
+    assert res["categories"]
+    cat = res["categories"][0]
+    assert "delta_revenue_pct" in cat
+    assert cat["delta_revenue_pct"] == 0
+    assert res["timeseries"]
+    totals = res["totals"]
+    assert "delta_revenue_pct" in totals
+    assert "delta_units_pct" in totals


### PR DESCRIPTION
## Summary
- expand `trends_service.get_trends_summary` to return overall totals and deltas
- add formatting helpers and new `trends-summary` frontend module
- rebuild trends view with KPI grid, sparklines and charts using the new summary API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6df1f6360832881ffa577ae716b23