### PR TITLE
feat: tolerant trends summary date range

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -134,9 +134,9 @@ body.dark .skeleton{background:#333;}
 </div>
 <div id="trendsSummary" class="card">
   <div id="trendHeader">
-    <label>Desde: <input type="text" id="trendStart" placeholder="dd/mm/aaaa"></label>
-    <label>Hasta: <input type="text" id="trendEnd" placeholder="dd/mm/aaaa"></label>
-    <button id="applyTrendFilters" aria-label="Aplicar filtros">Aplicar</button>
+    <label>Desde: <input type="text" id="fecha-desde" placeholder="dd/mm/aaaa"></label>
+    <label>Hasta: <input type="text" id="fecha-hasta" placeholder="dd/mm/aaaa"></label>
+    <button id="btn-aplicar-tendencias" aria-label="Aplicar filtros">Aplicar</button>
   </div>
   <div id="kpiGrid" class="kpi-grid"></div>
   <div class="sparklines-row">

--- a/product_research_app/static/js/trends-summary.js
+++ b/product_research_app/static/js/trends-summary.js
@@ -3,9 +3,9 @@ import { toISOFromDDMMYYYY, formatDDMMYYYY } from './dates.js';
 
 const container = document.getElementById('trendsSummary');
 const btn = document.getElementById('trendsBtn');
-const startInput = document.getElementById('trendStart');
-const endInput = document.getElementById('trendEnd');
-const applyBtn = document.getElementById('applyTrendFilters');
+const startInput = document.getElementById('fecha-desde');
+const endInput = document.getElementById('fecha-hasta');
+const applyBtn = document.getElementById('btn-aplicar-tendencias');
 const metricButtons = document.querySelectorAll('#topCatCard .metric-btn');
 const toggleLogBtn = document.getElementById('toggleLog');
 
@@ -53,10 +53,18 @@ async function fetchTrends() {
     }
     render();
   } catch (e) {
-    toast.error('No se pudieron cargar las tendencias.');
+    showToastError('No se pudieron cargar las tendencias.');
     if (currentData) render();
   } finally {
     setLoading(false);
+  }
+}
+
+function showToastError(msg) {
+  if (window.toast && typeof window.toast.error === 'function') {
+    window.toast.error(msg);
+  } else {
+    alert(msg);
   }
 }
 


### PR DESCRIPTION
## Summary
- handle optional from/to dates in `/api/trends/summary` with 30-day defaults
- wire trends page date inputs with safe fetch and toast fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6e5f9c0ac8328bc043e270fb31b7f