### PR TITLE
Improve trends dashboard layout and interactivity

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -1022,3 +1022,66 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
   resize: vertical;
 }
 
+
+/* BEGIN: TRENDS COMPACT */
+.trends-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.25fr;
+  gap: 12px;
+}
+
+.chart {
+  height: 360px;
+  min-height: 320px;
+}
+
+.chart--right {
+  height: 440px;
+}
+
+.trends-table-wrap {
+  max-height: calc(100vh - 420px);
+  overflow: auto;
+  border-radius: 10px;
+}
+
+.table-compact {
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.table-compact thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--panel, #0d1021);
+  padding: 6px 8px;
+  white-space: nowrap;
+}
+
+.table-compact tbody td {
+  padding: 6px 8px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  line-height: 1.2;
+}
+
+.table-compact tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+th.sortable .sort-caret {
+  margin-left: 6px;
+  opacity: 0.6;
+  font-size: 10px;
+}
+/* END: TRENDS COMPACT */
+

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -71,9 +71,7 @@ body.dark .skeleton{background:#333;}
 
 /* Fila de gráficos */
 .trends-row {
-  display: grid;
-  grid-template-columns: 2fr 1.2fr;
-  gap: 16px;
+  display: block;
   margin-top: 8px;
 }
 
@@ -82,7 +80,6 @@ body.dark .skeleton{background:#333;}
 #section-trends .card.lg { min-height: 380px; }
 #section-trends .card.md { min-height: 380px; }
 #section-trends .card-header { display:flex; align-items:center; justify-content:space-between; margin-bottom:8px; }
-#chart-top-categories, #chart-pareto { width:100%; height:320px !important; }
 
 /* Tabla compacta */
 .table.compact th, .table.compact td { padding: 8px 10px; }
@@ -165,30 +162,34 @@ body.dark .skeleton{background:#333;}
   </div>
   <div id="trends-status"></div>
   <div class="trends-row">
-    <div id="card-top-categories" class="card lg">
-      <canvas id="chart-top-categories"></canvas>
-    </div>
-    <div id="card-pareto" class="card md">
-      <div class="card-header">
-        <span>Pareto de ingresos (Top 10)</span>
-        <button id="btn-log-trends" class="mini">Log</button>
+    <div class="trends-grid">
+      <div id="card-top-categories" class="card lg">
+        <div id="chart-left" class="chart"></div>
       </div>
-      <canvas id="chart-pareto"></canvas>
+      <div id="card-pareto" class="card md">
+        <div class="card-header">
+          <span>Pareto de ingresos (Top 10)</span>
+          <button id="btn-log-trends" class="mini">Log</button>
+        </div>
+        <div id="chart-right" class="chart chart--right"></div>
+      </div>
     </div>
   </div>
-  <table id="tbl-categorias" class="table compact">
-    <thead>
-      <tr>
-        <th data-sort-key="categoria" role="button">Categorías</th>
-        <th data-sort-key="productos" role="button">Productos</th>
-        <th data-sort-key="unidades" role="button">Unidades</th>
-        <th data-sort-key="ingresos" role="button">Ingresos</th>
-        <th data-sort-key="precio" role="button">Precio</th>
-        <th data-sort-key="rating" role="button">Rating</th>
-      </tr>
-    </thead>
-    <tbody></tbody>
-  </table>
+  <div class="trends-table-wrap">
+    <table id="trendTable" class="table table-compact">
+      <thead>
+        <tr>
+          <th class="sortable" data-key="categoria">Categorías <span class="sort-caret">↕</span></th>
+          <th class="sortable" data-key="productos">Productos <span class="sort-caret">↕</span></th>
+          <th class="sortable" data-key="unidades">Unidades <span class="sort-caret">↕</span></th>
+          <th class="sortable" data-key="ingresos">Ingresos <span class="sort-caret">↕</span></th>
+          <th class="sortable" data-key="precio">Precio <span class="sort-caret">↕</span></th>
+          <th class="sortable" data-key="rating">Rating <span class="sort-caret">↕</span></th>
+        </tr>
+      </thead>
+      <tbody><!-- mantiene el renderizado existente de filas --></tbody>
+    </table>
+  </div>
 </section>
 
 <section id="section-products">
@@ -260,7 +261,7 @@ body.dark .skeleton{background:#333;}
 <script type="module" src="/static/js/manage-groups.js"></script>
 <script src="/static/js/winner_score.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
 <script type="module" src="/static/js/trends-summary.js"></script>
 <script type="module">
 import * as api from "/static/js/net.js";

--- a/product_research_app/static/js/trends-summary.js
+++ b/product_research_app/static/js/trends-summary.js
@@ -27,6 +27,19 @@ const btnLog = document.getElementById('btn-log-trends');
 
 let currentData = null;
 let paretoLog = false;
+const echarts = window.echarts;
+let topCategoriesChart = null;
+let paretoChart = null;
+let chartsResizeBound = false;
+
+function bindChartsResize() {
+  if (chartsResizeBound) return;
+  window.addEventListener('resize', () => {
+    if (topCategoriesChart) topCategoriesChart.resize();
+    if (paretoChart) paretoChart.resize();
+  });
+  chartsResizeBound = true;
+}
 
 if ($btnAplicar) {
   $btnAplicar.addEventListener('click', function(ev){
@@ -70,155 +83,217 @@ function renderTrends(summary){
 }
 
 function renderCategoriasTable(data){
-  const tbody = document.querySelector('#tbl-categorias tbody');
-  if(!tbody) return;
+  const tbody = document.querySelector('#trendTable tbody');
+  if (!tbody) return;
   const rows = [...(data.top_categories || data.categories || [])];
+  const toNumber = (value) => {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  };
   let html = '';
   rows.forEach(c => {
-    const productos = c.products_count || c.products || c.unique_products || 0;
-    const unidades = c.units || 0;
-    const ingresos = c.revenue || 0;
-    const precio = c.avg_price || 0;
-    const rating = c.avg_rating || 0;
-    html += `<tr><td>${c.path || c.category || ''}</td><td>${fmtInt(productos)}</td><td>${fmtInt(unidades)}</td><td>${formatMoney(ingresos)}</td><td>${fmtPrice(precio)}</td><td>${fmtFloat2(rating)}</td></tr>`;
+    const categoria = c.path || c.category || '';
+    const productos = toNumber(c.products_count ?? c.products ?? c.unique_products ?? 0);
+    const unidades = toNumber(c.units ?? 0);
+    const ingresos = toNumber(c.revenue ?? 0);
+    const precio = toNumber(c.avg_price ?? 0);
+    const rating = toNumber(c.avg_rating ?? 0);
+    html += `<tr>`
+      + `<td>${categoria}</td>`
+      + `<td data-raw="${productos}">${fmtInt(productos)}</td>`
+      + `<td data-raw="${unidades}">${fmtInt(unidades)}</td>`
+      + `<td data-raw="${ingresos}">${formatMoney(ingresos)}</td>`
+      + `<td data-raw="${precio}">${fmtPrice(precio)}</td>`
+      + `<td data-raw="${rating}">${fmtFloat2(rating)}</td>`
+      + `</tr>`;
   });
   tbody.innerHTML = html;
+  const table = document.getElementById('trendTable');
+  if (table) {
+    table.querySelectorAll('th.sortable .sort-caret').forEach(el => {
+      el.textContent = '↕';
+    });
+    table.querySelectorAll('th.sortable').forEach(th => {
+      if (typeof th._resetSort === 'function') th._resetSort();
+    });
+  }
 }
 
 function renderTopCategoriesBar(data) {
+  if (!echarts) return;
   const top = [...(data.top_categories || data.categories || [])].slice(0, 10);
   const labels = top.map(x => x.path || x.category);
-  const values = top.map(x => x.revenue);
-  const ctx = document.getElementById('chart-top-categories');
-  if (!ctx) return;
-  if (ctx._chart) { ctx._chart.destroy(); }
+  const values = top.map(x => Number(x.revenue) || 0);
+  const chartDom = document.getElementById('chart-left');
+  if (!chartDom) return;
 
-  ctx._chart = new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels,
-      datasets: [{ data: values, borderWidth: 0 }]
-    },
-    options: {
-      indexAxis: 'y',
-      maintainAspectRatio: false,
-      plugins: {
-        legend: { display: false },
-        tooltip: {
-          callbacks: {
-            label: (tt) => `Ingresos: ${formatMoney(tt.parsed.x)}`
-          }
-        }
-      },
-      scales: {
-        x: { grid: { display: false }, ticks: { callback: (v)=> formatMoney(v) } },
-        y: { grid: { display: false } }
+  if (!topCategoriesChart) {
+    topCategoriesChart = echarts.init(chartDom, null, { renderer: 'canvas' });
+  }
+
+  const option = {
+    backgroundColor: 'transparent',
+    grid: { top: 30, right: 30, bottom: 20, left: 140, containLabel: true },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      formatter: (params) => {
+        const item = params && params[0];
+        if (!item) return '';
+        return `${item.name}<br>${item.marker} Ingresos: ${formatMoney(item.value)}`;
       }
-    }
-  });
+    },
+    xAxis: {
+      type: 'value',
+      splitLine: { show: false },
+      axisLabel: {
+        fontSize: 12,
+        formatter: (value) => formatMoney(value)
+      }
+    },
+    yAxis: {
+      type: 'category',
+      inverse: true,
+      data: labels,
+      axisLabel: { interval: 0, fontSize: 12 },
+      axisTick: { show: false }
+    },
+    series: [
+      {
+        name: 'Ingresos',
+        type: 'bar',
+        barWidth: '55%',
+        data: values,
+        itemStyle: { borderRadius: [0, 6, 6, 0] },
+        emphasis: { focus: 'series' }
+      }
+    ]
+  };
+
+  topCategoriesChart.setOption(option, true);
+  bindChartsResize();
 }
 
 function renderPareto(data) {
-  if (!data) return;
+  if (!data || !echarts) return;
   const src = [...(data.top_categories || data.categories || [])];
-  src.sort((a,b) => (b.revenue||0) - (a.revenue||0));
+  src.sort((a, b) => (Number(b.revenue) || 0) - (Number(a.revenue) || 0));
   const top = src.slice(0, 10);
 
   const labels = top.map(x => x.path || x.category);
-  const ingresos = top.map(x => x.revenue || 0);
-  const total = ingresos.reduce((s,n)=>s+n, 0) || 1;
+  const ingresos = top.map(x => Number(x.revenue) || 0);
+  const total = ingresos.reduce((sum, value) => sum + value, 0) || 1;
   let acc = 0;
-  const acumuladoPct = ingresos.map(v => { acc += v; return +(acc/total*100).toFixed(1); });
-
-  const ctx = document.getElementById('chart-pareto');
-  if (!ctx) return;
-  if (ctx._chart) { ctx._chart.destroy(); }
-
-  ctx._chart = new Chart(ctx, {
-    data: {
-      labels,
-      datasets: [
-        {
-          type: 'bar',
-          label: 'Ingresos',
-          data: ingresos,
-          yAxisID: 'y',
-          borderWidth: 0
-        },
-        {
-          type: 'line',
-          label: '% acumulado',
-          data: acumuladoPct,
-          yAxisID: 'y1',
-          tension: 0.3,
-          pointRadius: 2
-        }
-      ]
-    },
-    options: {
-      maintainAspectRatio: false,
-      plugins: {
-        legend: { display: true },
-        tooltip: {
-          callbacks: {
-            label: (tt) => tt.datasetIndex === 0
-              ? `Ingresos: ${formatMoney(tt.parsed.y)}`
-              : `% acumulado: ${tt.parsed.y}%`
-          }
-        }
-      },
-      scales: {
-        y:  { position: 'left', type: paretoLog ? 'logarithmic' : 'linear', grid: { display:false }, ticks: { callback: (v)=> formatMoney(v) } },
-        y1: { position: 'right', grid: { display:false }, min: 0, max: 100, ticks: { callback: (v)=> v + '%' } },
-        x:  { grid: { display:false } }
-      }
-    }
+  const acumuladoPct = ingresos.map(v => {
+    acc += v;
+    const pct = (acc / total) * 100;
+    return Number.isFinite(pct) ? +pct.toFixed(1) : 0;
   });
-}
 
-(function enableSortableCategorias(){
-  const table = document.getElementById('tbl-categorias');
-  if (!table) return;
-  const thead = table.querySelector('thead');
-  const tbody = table.querySelector('tbody');
-  if (!thead || !tbody) return;
+  const paretoDom = document.getElementById('chart-right');
+  if (!paretoDom) return;
 
-  const parseNumber = (s) => {
-    if (s == null) return NaN;
-    const t = String(s).replace(/\./g,'').replace(/,/g,'.').replace(/[^\d.-]/g,'').trim();
-    const n = parseFloat(t);
-    return isNaN(n) ? NaN : n;
+  if (!paretoChart) {
+    paretoChart = echarts.init(paretoDom, null, { renderer: 'canvas' });
+  }
+
+  const barData = ingresos.map(v => (paretoLog && v <= 0 ? null : v));
+  const yAxisLeft = {
+    type: paretoLog ? 'log' : 'value',
+    name: 'Ingresos',
+    axisLabel: {
+      fontSize: 12,
+      formatter: (value) => formatMoney(value)
+    }
+  };
+  if (!paretoLog) yAxisLeft.min = 0;
+
+  const paretoOption = {
+    backgroundColor: 'transparent',
+    grid: { top: 50, right: 40, bottom: 90, left: 60, containLabel: true },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      formatter: (params) => {
+        if (!Array.isArray(params) || params.length === 0) return '';
+        const lines = [params[0].name];
+        params.forEach(item => {
+          if (item.seriesName === 'Ingresos') {
+            lines.push(`${item.marker} ${item.seriesName}: ${formatMoney(item.value)}`);
+          } else {
+            const pct = Number(item.value) || 0;
+            lines.push(`${item.marker} ${item.seriesName}: ${pct.toLocaleString('es-ES', { maximumFractionDigits: 1 })}%`);
+          }
+        });
+        return lines.join('<br>');
+      }
+    },
+    legend: { top: 8, textStyle: { fontSize: 12 } },
+    dataZoom: [
+      { type: 'slider', xAxisIndex: 0, height: 16, bottom: 50 },
+      { type: 'inside', xAxisIndex: 0 }
+    ],
+    xAxis: {
+      type: 'category',
+      data: labels,
+      axisLabel: { interval: 0, rotate: 28, fontSize: 11, margin: 12 },
+      axisTick: { alignWithLabel: true }
+    },
+    yAxis: [
+      yAxisLeft,
+      {
+        type: 'value',
+        name: '% acumulado',
+        min: 0,
+        max: 100,
+        position: 'right',
+        axisLabel: { formatter: '{value} %', fontSize: 12 }
+      }
+    ],
+    series: [
+      { name: 'Ingresos', type: 'bar', barWidth: '55%', data: barData, emphasis: { focus: 'series' } },
+      { name: '% acumulado', type: 'line', yAxisIndex: 1, smooth: true, symbolSize: 6, lineStyle: { width: 3 }, data: acumuladoPct }
+    ]
   };
 
-  const getCellValue = (tr, idx) => tr.children[idx]?.textContent?.trim() || '';
+  paretoChart.setOption(paretoOption, true);
+  bindChartsResize();
+}
 
-  thead.addEventListener('click', (e) => {
-    const th = e.target.closest('th[data-sort-key]');
-    if (!th) return;
-    const idx = Array.from(th.parentNode.children).indexOf(th);
+// BEGIN: TABLE SORT
+(function makeTableSortable() {
+  const table = document.getElementById('trendTable');
+  if (!table) return;
 
-    thead.querySelectorAll('th').forEach(h => h.classList.remove('sort-asc','sort-desc'));
-    const asc = !th.classList.contains('sort-asc');
-    th.classList.add(asc ? 'sort-asc' : 'sort-desc');
+  const tbody = table.querySelector('tbody');
+  const getCell = (row, idx) => row.children[idx];
+  const getValue = (cell) => cell?.getAttribute('data-raw') ?? cell?.innerText?.trim() ?? '';
 
-    const rows = Array.from(tbody.querySelectorAll('tr'));
-    const numeric = ['Productos','Unidades','Ingresos','Precio','Rating']
-      .includes(th.textContent.trim());
+  const toComparable = (v) => {
+    const s = String(v).replace(/\./g, '').replace(',', '.'); // 1.234,56 -> 1234.56
+    const n = Number(s);
+    return Number.isFinite(n) ? n : String(v).toLowerCase();
+  };
 
-    rows.sort((a,b) => {
-      const va = getCellValue(a, idx);
-      const vb = getCellValue(b, idx);
-      if (numeric) {
-        const na = parseNumber(va);
-        const nb = parseNumber(vb);
-        return asc ? (na-nb) : (nb-na);
-      }
-      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
+  table.querySelectorAll('th.sortable').forEach((th, idx) => {
+    let asc = true;
+    th.addEventListener('click', () => {
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      rows.sort((a, b) => {
+        const va = toComparable(getValue(getCell(a, idx)));
+        const vb = toComparable(getValue(getCell(b, idx)));
+        if (typeof va === 'number' && typeof vb === 'number') return asc ? va - vb : vb - va;
+        return asc ? String(va).localeCompare(String(vb)) : String(vb).localeCompare(String(va));
+      });
+      table.querySelectorAll('th.sortable .sort-caret').forEach(el => el.textContent = '↕');
+      const caret = th.querySelector('.sort-caret'); if (caret) caret.textContent = asc ? '↑' : '↓';
+      rows.forEach(r => tbody.appendChild(r));
+      asc = !asc;
     });
-
-    rows.forEach(r => tbody.appendChild(r));
+    th._resetSort = () => { asc = true; };
   });
 })();
+// END: TABLE SORT
 
 function showTrendsSection(){
   const $trends = document.querySelector('#section-trends');
@@ -250,7 +325,7 @@ function showTrendsSection(){
     })();
   }
 
-  const firstChart = document.querySelector('#chart-top-categories, #card-top-categories');
+  const firstChart = document.querySelector('#chart-left, #card-top-categories');
   if (firstChart && typeof firstChart.scrollIntoView === 'function') {
     firstChart.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }


### PR DESCRIPTION
## Summary
- rework the trends section markup to use a responsive grid, dedicated chart containers, and a compact scrollable table wrapper
- migrate the trends charts to ECharts with responsive resizing, updated pareto configuration, and reusable number formatting
- add reusable compact table styling and client-side sortable headers that understand localized numeric formats

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c83c61d4b08328af97fd4c3e1ed51c