### PR TITLE
Refine trends section layout and insights

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -1022,6 +1022,7 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
 }
 
 
+/* Layout tendencias */
 .trends-grid {
   display: grid;
   grid-template-columns: 0.9fr 1.1fr;
@@ -1042,14 +1043,27 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
 }
 
 #top-left canvas,
-#top-right canvas {
+#top-right canvas,
+#paretoRevenueChart {
+  width: 100%;
+  height: 100%;
   flex: 1 1 auto;
 }
 
-.compact-wrap {
-  padding: 0;
+.two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
 }
 
+@media (max-width: 960px) {
+  .trends-grid,
+  .two-col {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Tabla compacta (ya existía) */
 .table--compact {
   font-size: 12.5px;
 }
@@ -1067,7 +1081,7 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
 
 .table--compact tbody {
   display: block;
-  max-height: 340px;
+  max-height: 320px;
   overflow: auto;
 }
 
@@ -1076,10 +1090,6 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
   display: table;
   width: 100%;
   table-layout: fixed;
-}
-
-.table--compact tr {
-  height: auto;
 }
 
 .table--compact td {
@@ -1105,4 +1115,36 @@ th[aria-sort="ascending"]::after {
 th[aria-sort="descending"]::after {
   content: " ▼";
   opacity: 0.6;
+}
+
+/* Insights */
+.insights-toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.insights-content {
+  font-size: 13px;
+  line-height: 1.45;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.muted {
+  opacity: 0.7;
+}
+
+/* Cards */
+.card {
+  background: #121426;
+  border: 1px solid #222642;
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.chart-header h4 {
+  margin: 0 0 8px 0;
+  font-weight: 600;
+  font-size: 14px;
 }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -103,7 +103,7 @@ body.dark .skeleton{background:#333;}
       <input type="file" id="fileInput" style="display:none;" />
       <button id="uploadBtn" title="Subir archivo">📤</button>
       <button id="refreshBtn" title="Actualizar lista">🔄</button>
-      <button id="btn-ver-tendencias" title="Ver tendencias">📊</button>
+      <button id="btn-ver-tendencias" title="Ver tendencias" data-action="toggle-trends">📊</button>
       <button id="darkToggle" title="Modo oscuro">🌙</button>
       <button id="configBtn" title="Configuración avanzada">⚙️</button>
     </div>
@@ -164,29 +164,46 @@ body.dark .skeleton{background:#333;}
     <button id="btn-aplicar-tendencias" aria-label="Aplicar filtros">Aplicar</button>
   </div>
   <div id="trends-status"></div>
-  <section id="trends" class="trends-grid">
-    <div id="top-left" class="card">
+  <section id="trends" class="trends-grid" hidden>
+    <div class="card" id="top-left">
       <canvas id="topCategoriesChart"></canvas>
     </div>
-    <div id="top-right" class="card">
-      <canvas id="priceIncomeScatter"></canvas>
+
+    <div class="card" id="top-right">
+      <div class="chart-header">
+        <h4>Pareto de ingresos (Top 15)</h4>
+      </div>
+      <canvas id="paretoRevenueChart"></canvas>
     </div>
   </section>
-  <div class="card compact-wrap">
-    <table id="trendsTable" class="table table--compact">
-      <thead>
-        <tr>
-          <th data-key="path" data-type="text">Categorías</th>
-          <th data-key="products" data-type="num">Productos</th>
-          <th data-key="units" data-type="num">Unidades</th>
-          <th data-key="revenue" data-type="num">Ingresos</th>
-          <th data-key="price" data-type="num">Precio</th>
-          <th data-key="rating" data-type="num">Rating</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-  </div>
+
+  <section id="trends-bottom" class="two-col" hidden>
+    <div class="card">
+      <table id="trendsTable" class="table table--compact">
+        <thead>
+          <tr>
+            <th data-key="path" data-type="text">Categorías</th>
+            <th data-key="products" data-type="num">Productos</th>
+            <th data-key="units" data-type="num">Unidades</th>
+            <th data-key="revenue" data-type="num">Ingresos</th>
+            <th data-key="price" data-type="num">Precio</th>
+            <th data-key="rating" data-type="num">Rating</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+
+    <aside class="card" id="trendsInsights">
+      <div class="insights-toolbar">
+        <button id="btnLocalInsights" class="btn btn--sm">Generar insights (local)</button>
+        <button id="btnGptInsights" class="btn btn--sm">Pedir a GPT</button>
+      </div>
+      <div id="insightsContent" class="insights-content">
+        <p class="muted">Aquí aparecerán hallazgos relevantes sobre las categorías (tendencias, outliers, pareto…).</p>
+      </div>
+    </aside>
+  </section>
 </section>
 
 <section id="section-products">
@@ -260,6 +277,7 @@ body.dark .skeleton{background:#333;}
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script type="module" src="/static/js/trends-summary.js"></script>
+<script type="module" src="/static/js/trends-insights.js" defer></script>
 <script type="module" src="/static/js/table-sort.js" defer></script>
 <script type="module">
 import * as api from "/static/js/net.js";

--- a/product_research_app/static/js/trends-insights.js
+++ b/product_research_app/static/js/trends-insights.js
@@ -1,0 +1,76 @@
+// Generador de insights heurísticos (sin GPT)
+function localInsights(categories) {
+  if (!categories || !categories.length) return ['Sin datos de categorías.'];
+
+  const sortedRev = [...categories].sort((a, b) => Number(b.revenue || 0) - Number(a.revenue || 0));
+  const totalRevenue = sortedRev.reduce((s, r) => s + Number(r.revenue || 0), 0) || 1;
+  const top3 = sortedRev
+    .slice(0, 3)
+    .map((c) => `${c.path || c.name} (${(100 * Number(c.revenue || 0) / totalRevenue).toFixed(1)}%)`);
+
+  const avgPrice = categories.reduce((s, c) => s + Number(c.price || 0), 0) / categories.length || 0;
+  const highPrice = [...categories]
+    .sort((a, b) => Number(b.price || 0) - Number(a.price || 0))
+    .slice(0, 3)
+    .map((c) => `${c.path || c.name} (€${Number(c.price || 0).toFixed(2).replace('.', ',')})`);
+
+  return [
+    `Top 3 por ingresos: ${top3.join(' · ')}`,
+    `Precio medio ponderado aprox: €${avgPrice.toFixed(2).replace('.', ',')}`,
+    `Categorías con precio medio más alto: ${highPrice.join(' · ')}`
+  ];
+}
+
+function writeInsights(lines) {
+  const box = document.getElementById('insightsContent');
+  if (!box) return;
+  box.innerHTML = '<ul>' + lines.map((l) => `<li>${l}</li>`).join('') + '</ul>';
+}
+
+function buildGptPrompt(categories) {
+  const top = [...categories].sort((a, b) => Number(b.revenue || 0) - Number(a.revenue || 0)).slice(0, 10);
+  const bullets = top.map(
+    (c) =>
+      `- ${c.path || c.name}: ingresos=${Number(c.revenue || 0)}, unidades=${Number(c.units || 0)}, precio_medio=${Number(
+        c.price || 0
+      )}, rating=${Number(c.rating || 0)}`
+  );
+  return `Analiza estas categorías (ecommerce). Resume oportunidades, riesgos y quick wins en 6 viñetas concisas, priorizando ROI:\n${bullets.join(
+    '\n'
+  )}`;
+}
+
+async function trySendToExistingGpt(prompt) {
+  // 1) Intenta encontrar input/botón existentes en la UI
+  const input = [...document.querySelectorAll('input,textarea')].find((el) => /gpt/i.test(el.placeholder || ''));
+  const sendBtn = [...document.querySelectorAll('button')].find((b) => /enviar consulta a gpt/i.test(b.textContent || ''));
+
+  if (input && sendBtn) {
+    input.value = prompt;
+    sendBtn.click();
+    return true;
+  }
+
+  // 2) Si no hay UI accesible, copia al portapapeles
+  try {
+    await navigator.clipboard.writeText(prompt);
+    toast?.info?.('Prompt copiado. Pégalo en tu módulo GPT.'); // si existe toast()
+  } catch (_) {}
+  return false;
+}
+
+function getCategoriesAgg() {
+  return window.__latestTrendsData?.categoriesAgg || [];
+}
+
+document.addEventListener('click', async (ev) => {
+  if (ev.target?.id === 'btnLocalInsights') {
+    writeInsights(localInsights(getCategoriesAgg()));
+  }
+  if (ev.target?.id === 'btnGptInsights') {
+    const prompt = buildGptPrompt(getCategoriesAgg());
+    await trySendToExistingGpt(prompt);
+  }
+});
+
+export {};

--- a/product_research_app/static/js/trends-summary.js
+++ b/product_research_app/static/js/trends-summary.js
@@ -1,6 +1,27 @@
-import { fmtInt, fmtPrice, fmtFloat2 } from './format.js';
+const fmt = {
+  money: (v) => {
+    if (!isFinite(v)) return v;
+    if (v >= 1e6) return '€ ' + (v / 1e6).toFixed(2).replace('.', ',') + ' M';
+    if (v >= 1e3) return '€ ' + (v / 1e3).toFixed(1).replace('.', ',') + ' K';
+    return '€ ' + v.toFixed(2).replace('.', ',');
+  },
+  percent: (p) => (p * 100).toFixed(1).replace('.', ',') + '%'
+};
 
-let priceIncomeChart;
+let topCategoriesChart = null;
+let paretoChart = null;
+
+const $desde = document.querySelector('#fecha-desde');
+const $hasta = document.querySelector('#fecha-hasta');
+const $btnAplicar = document.querySelector('#btn-aplicar-tendencias');
+const $status = document.querySelector('#trends-status');
+
+if ($btnAplicar) {
+  $btnAplicar.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    fetchTrends();
+  });
+}
 
 function toISOFromDDMMYYYY(v) {
   const s = (v || '').trim();
@@ -9,6 +30,7 @@ function toISOFromDDMMYYYY(v) {
   const [, dd, mm, yyyy] = m;
   return `${yyyy}-${mm}-${dd}`;
 }
+
 function formatDDMMYYYY(d) {
   const dd = String(d.getDate()).padStart(2, '0');
   const mm = String(d.getMonth() + 1).padStart(2, '0');
@@ -16,7 +38,88 @@ function formatDDMMYYYY(d) {
   return `${dd}/${mm}/${yyyy}`;
 }
 
-function fmtMoney(v){
+function ensureDefaultDates() {
+  try {
+    const today = new Date();
+    const from = new Date(today);
+    from.setDate(today.getDate() - 29);
+    if ($desde && !$desde.value) $desde.value = formatDDMMYYYY(from);
+    if ($hasta && !$hasta.value) $hasta.value = formatDDMMYYYY(today);
+  } catch (_) {}
+}
+
+async function fetchTrends() {
+  ensureDefaultDates();
+  try {
+    if ($status) $status.textContent = 'Cargando...';
+    const fISO = $desde ? toISOFromDDMMYYYY($desde.value) : null;
+    const tISO = $hasta ? toISOFromDDMMYYYY($hasta.value) : null;
+    const url = new URL('/api/trends/summary', window.location.origin);
+    if (fISO) url.searchParams.set('from', fISO);
+    if (tISO) url.searchParams.set('to', tISO);
+    const res = await fetch(url.toString(), { credentials: 'same-origin' });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const json = await res.json();
+    handleTrendsResponse(json);
+  } catch (e) {
+    (window.toast?.error || alert).call(window.toast || window, 'No se pudieron cargar las tendencias.');
+  } finally {
+    if ($status) $status.textContent = '';
+  }
+}
+
+function handleTrendsResponse(summary) {
+  if (!summary) return;
+  const categoriesRaw = summary.categoriesAgg || summary.top_categories || summary.categories || [];
+  renderTrends(categoriesRaw, getAllProductsSnapshot());
+}
+
+function getAllProductsSnapshot() {
+  const arr = window.allProducts;
+  return Array.isArray(arr) ? arr : [];
+}
+
+function toNumber(value) {
+  if (value == null || value === '') return 0;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+  if (typeof value === 'string') {
+    const text = value
+      .replace(/[€$]/g, '')
+      .replace(/\s+/g, '')
+      .replace(/\./g, '')
+      .replace(/,/g, '.');
+    const num = Number(text);
+    return Number.isFinite(num) ? num : 0;
+  }
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function normalizeCategories(list) {
+  if (!Array.isArray(list)) return [];
+  return list.map((item) => {
+    const path = item.path || item.category || item.name || '';
+    const name = item.name || path;
+    const revenue = toNumber(item.revenue ?? item.total_revenue ?? item.sum_revenue ?? item.value);
+    const units = toNumber(item.units ?? item.total_units ?? item.sum_units ?? item.quantity);
+    const productsRaw = item.products ?? item.products_count ?? item.unique_products ?? item.count;
+    const products = Number.isFinite(Number(productsRaw)) ? Number(productsRaw) : 0;
+    const price = toNumber(item.price ?? item.avg_price ?? item.average_price);
+    const rating = toNumber(item.rating ?? item.avg_rating ?? item.average_rating);
+    return {
+      ...item,
+      path,
+      name,
+      revenue,
+      units,
+      products,
+      price,
+      rating
+    };
+  });
+}
+
+function fmtMoney(v) {
   const n = Number(v);
   if (!Number.isFinite(n) || n === 0) return '0';
   const abs = Math.abs(n);
@@ -42,122 +145,33 @@ function fmtMoney(v){
   }
   const formatted = scaled.toLocaleString('es-ES', {
     minimumFractionDigits,
-    maximumFractionDigits,
+    maximumFractionDigits
   });
   return `${formatted}${suffix}`.trim();
 }
 
-function buildScatterData(allProducts){
-  if (!Array.isArray(allProducts)) return [];
-  const parseValue = (value) => {
-    if (value == null) return null;
-    if (typeof value === 'number') {
-      return Number.isFinite(value) ? value : null;
-    }
-    const text = String(value)
-      .replace(/[€$]/g, '')
-      .replace(/\s+/g, '')
-      .replace(/\./g, '')
-      .replace(/,/g, '.');
-    const num = Number(text);
-    return Number.isFinite(num) ? num : null;
-  };
-  return allProducts
-    .map(item => {
-      if (!item) return null;
-      const priceRaw = item.price ?? item.avg_price ?? (item.extras && (item.extras['Avg. Unit Price($)'] ?? item.extras['Avg Unit Price($)'] ?? item.extras['Avg. Unit Price'] ?? item.extras.price));
-      const revenueRaw = item.revenue ?? (item.extras && (item.extras['Revenue($)'] ?? item.extras['Revenue'] ?? item.extras.revenue));
-      const price = parseValue(priceRaw);
-      const revenue = parseValue(revenueRaw);
-      if (!Number.isFinite(price) || !Number.isFinite(revenue) || price <= 0 || revenue <= 0) {
-        return null;
-      }
-      const name = item.name || item.path || item.category || '';
-      return { x: price, y: revenue, _name: name };
-    })
-    .filter(Boolean);
-}
-
-const $desde = document.querySelector('#fecha-desde');
-const $hasta = document.querySelector('#fecha-hasta');
-const $btnAplicar = document.querySelector('#btn-aplicar-tendencias');
-let currentData = null;
-
-if ($btnAplicar) {
-  $btnAplicar.addEventListener('click', function(ev){
-    ev.preventDefault();
-    if (typeof fetchTrends === 'function') fetchTrends();
-  });
-}
-
-async function fetchTrends(){
-  const $status = document.querySelector('#trends-status');
-  try {
-    if ($status) $status.textContent = 'Cargando...';
-    const fISO = $desde ? toISOFromDDMMYYYY($desde.value) : null;
-    const tISO = $hasta ? toISOFromDDMMYYYY($hasta.value) : null;
-    const url = new URL('/api/trends/summary', window.location.origin);
-    if (fISO) url.searchParams.set('from', fISO);
-    if (tISO) url.searchParams.set('to', tISO);
-    const res = await fetch(url.toString(), { credentials: 'same-origin' });
-    if (!res.ok) throw new Error('HTTP '+res.status);
-    const json = await res.json();
-    currentData = json;
-    renderTrends(json);
-    renderCategoriasTable(json);
-  } catch(e){
-    (window.toast?.error || alert).call(window.toast||window, 'No se pudieron cargar las tendencias.');
-  } finally {
-    if ($status) $status.textContent = '';
-  }
-}
-
-function renderTrends(summary){
-  if(!summary) return;
-  renderTopCategoriesBar(summary);
-  const products = Array.isArray(window.allProducts) ? window.allProducts : [];
-  renderPriceIncomeScatter(products);
-}
-
-function renderCategoriasTable(data){
-  const tbody = document.querySelector('#trendsTable tbody');
-  if(!tbody) return;
-  const rows = [...(data.top_categories || data.categories || [])];
-  let html = '';
-  rows.forEach(c => {
-    const productos = c.products_count || c.products || c.unique_products || 0;
-    const unidades = c.units || 0;
-    const ingresos = c.revenue || 0;
-    const precio = c.avg_price || 0;
-    const rating = c.avg_rating || 0;
-    const path = c.path || c.category || '';
-    html += `<tr>`
-      + `<td>${path}</td>`
-      + `<td>${fmtInt(productos)}</td>`
-      + `<td>${fmtInt(unidades)}</td>`
-      + `<td>€ ${fmtMoney(ingresos)}</td>`
-      + `<td>€ ${fmtPrice(precio)}</td>`
-      + `<td>${fmtFloat2(rating)}</td>`
-      + `</tr>`;
-  });
-  tbody.innerHTML = html;
-  const thead = document.querySelector('#trendsTable thead');
-  thead?.querySelectorAll('th[aria-sort]').forEach(th => th.removeAttribute('aria-sort'));
-}
-
-function renderTopCategoriesBar(data) {
-  const top = [...(data.top_categories || data.categories || [])].slice(0, 10);
-  const labels = top.map(x => x.path || x.category);
-  const values = top.map(x => x.revenue);
+function renderTopCategoriesBar(categoriesAgg) {
   const ctx = document.getElementById('topCategoriesChart');
   if (!ctx) return;
-  if (ctx._chart) { ctx._chart.destroy(); }
+  const top = (Array.isArray(categoriesAgg) ? categoriesAgg : []).slice(0, 10);
+  const labels = top.map((x) => x.path || x.category || x.name || '');
+  const values = top.map((x) => Number(x.revenue) || 0);
 
-  ctx._chart = new Chart(ctx, {
+  if (topCategoriesChart) {
+    topCategoriesChart.destroy();
+    topCategoriesChart = null;
+  }
+
+  topCategoriesChart = new Chart(ctx, {
     type: 'bar',
     data: {
       labels,
-      datasets: [{ data: values, borderWidth: 0 }]
+      datasets: [
+        {
+          data: values,
+          borderWidth: 0
+        }
+      ]
     },
     options: {
       indexAxis: 'y',
@@ -171,157 +185,169 @@ function renderTopCategoriesBar(data) {
         }
       },
       scales: {
-        x: { grid: { display: false }, ticks: { callback: (v)=> fmtMoney(v) } },
+        x: { grid: { display: false }, ticks: { callback: (v) => fmtMoney(v) } },
         y: { grid: { display: false } }
       }
     }
   });
 }
 
-function renderPriceIncomeScatter(products){
-  const canvas = document.getElementById('priceIncomeScatter');
-  if (!canvas) return;
-  const points = buildScatterData(products);
-  if (priceIncomeChart) {
-    priceIncomeChart.destroy();
-    priceIncomeChart = null;
-  }
-  if (!points.length) {
-    return;
-  }
+// Devuelve las top N categorías por ingresos con acumulado
+function buildParetoData(categories, N = 15) {
+  const rows = categories
+    .map((c) => ({ name: c.path || c.name, revenue: Number(c.revenue || 0) }))
+    .filter((r) => r.revenue > 0)
+    .sort((a, b) => b.revenue - a.revenue)
+    .slice(0, N);
 
-  priceIncomeChart = new Chart(canvas, {
-    type: 'scatter',
+  const total = rows.reduce((s, r) => s + r.revenue, 0) || 1;
+  let acc = 0;
+  const labels = [];
+  const bars = [];
+  const cumu = [];
+  rows.forEach((r) => {
+    labels.push(r.name);
+    bars.push(r.revenue);
+    acc += r.revenue;
+    cumu.push((acc / total) * 100);
+  });
+  return { labels, bars, cumu };
+}
+
+function renderRightPareto(categoriesAgg) {
+  const el = document.getElementById('paretoRevenueChart');
+  if (!el) return;
+  const ctx = el.getContext('2d');
+  const { labels, bars, cumu } = buildParetoData(Array.isArray(categoriesAgg) ? categoriesAgg : [], 15);
+
+  if (paretoChart) paretoChart.destroy();
+
+  paretoChart = new Chart(ctx, {
     data: {
+      labels,
       datasets: [
         {
-          data: points,
-          label: '',
-          pointBackgroundColor: '#6c8cff',
-          pointBorderColor: '#6c8cff',
-          pointRadius: 2.5,
-          pointHoverRadius: 6,
-          pointHitRadius: 8,
+          type: 'bar',
+          label: 'Ingresos',
+          data: bars,
+          yAxisID: 'y',
+          borderWidth: 0
+        },
+        {
+          type: 'line',
+          label: '% acumulado',
+          data: cumu,
+          yAxisID: 'y1',
+          tension: 0.25,
+          pointRadius: 0,
+          pointHitRadius: 6
         }
       ]
     },
     options: {
-      responsive: true,
       maintainAspectRatio: false,
-      layout: { padding: 8 },
+      responsive: true,
       plugins: {
-        legend: { display: false },
+        legend: { display: true },
         tooltip: {
-          displayColors: false,
           callbacks: {
-            title(items) {
-              const raw = items?.[0]?.raw || {};
-              const price = Number(raw.x);
-              const revenue = Number(raw.y);
-              return `€ ${fmtMoney(price)} · ${fmtMoney(revenue)}`;
-            },
-            label(ctx) {
-              const raw = ctx.raw || {};
-              return raw._name || '';
+            label: (ctx) => {
+              if (ctx.dataset.type === 'line') return '% acumulado: ' + ctx.formattedValue + '%';
+              return 'Ingresos: ' + fmt.money(ctx.raw);
             }
           }
         }
       },
       scales: {
-        x: {
-          type: 'logarithmic',
-          title: { display: true, text: 'Precio' },
-          ticks: {
-            callback(value) {
-              const num = Number(value);
-              return num > 0 ? `€ ${fmtMoney(num)}` : '';
-            }
-          },
-          grid: { color: 'rgba(255,255,255,0.05)' }
-        },
         y: {
-          type: 'logarithmic',
-          title: { display: true, text: 'Ingresos' },
+          beginAtZero: true,
           ticks: {
-            callback(value) {
-              const num = Number(value);
-              return num > 0 ? `€ ${fmtMoney(num)}` : '';
-            }
-          },
-          grid: { color: 'rgba(255,255,255,0.08)' }
+            callback: (v) => fmt.money(v)
+          }
+        },
+        y1: {
+          beginAtZero: true,
+          position: 'right',
+          grid: { drawOnChartArea: false },
+          min: 0,
+          max: 100,
+          ticks: { callback: (v) => v + '%' }
+        },
+        x: { ticks: { autoSkip: true, maxRotation: 0 } }
+      }
+    }
+  });
+}
+
+// Ajusta fillTrendsTable para usar SOLO categoriesAgg (sin productos)
+function fillTrendsTable(categoriesAgg) {
+  const tbody = document.querySelector('#trendsTable tbody');
+  if (!tbody) return;
+  const frag = document.createDocumentFragment();
+
+  categoriesAgg.forEach((c) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${c.path || c.name || ''}</td>
+      <td>${c.products ?? ''}</td>
+      <td>${Number(c.units || 0).toLocaleString('es-ES')}</td>
+      <td>${fmt.money(Number(c.revenue || 0))}</td>
+      <td>${Number(c.price || 0).toFixed(2).replace('.', ',')}</td>
+      <td>${Number(c.rating || 0).toFixed(2).replace('.', ',')}</td>
+    `;
+    frag.appendChild(tr);
+  });
+
+  tbody.replaceChildren(frag);
+  const thead = document.querySelector('#trendsTable thead');
+  thead?.querySelectorAll('th[aria-sort]').forEach((th) => th.removeAttribute('aria-sort'));
+}
+
+// Llama a esta función desde tu flujo principal tras obtener datos
+export function renderTrends(categoriesAgg, allProducts) {
+  const normalized = normalizeCategories(Array.isArray(categoriesAgg) ? categoriesAgg : []);
+  const products = Array.isArray(allProducts) ? allProducts : getAllProductsSnapshot();
+  window.__latestTrendsData = { categoriesAgg: normalized, allProducts: products };
+  renderTopCategoriesBar(normalized);
+  renderRightPareto(normalized);
+  fillTrendsTable(normalized);
+}
+
+export function mountTrendsToggle() {
+  document.addEventListener(
+    'click',
+    (ev) => {
+      const btn = ev.target.closest('[data-action="toggle-trends"]');
+      if (!btn) return;
+
+      const container = document.getElementById('section-trends');
+      const sec1 = document.getElementById('trends');
+      const sec2 = document.getElementById('trends-bottom');
+      const opening = container ? container.hasAttribute('hidden') : false;
+
+      if (opening) {
+        container?.removeAttribute('hidden');
+        sec1?.removeAttribute('hidden');
+        sec2?.removeAttribute('hidden');
+        ensureDefaultDates();
+        if (window.__latestTrendsData) {
+          const data = window.__latestTrendsData.categoriesAgg || [];
+          renderTopCategoriesBar(data);
+          renderRightPareto(data);
+          fillTrendsTable(data);
+        } else {
+          fetchTrends();
         }
-      }
-    }
-  });
-}
-
-const scheduleScatterUpdate = typeof queueMicrotask === 'function'
-  ? queueMicrotask
-  : (cb) => Promise.resolve().then(cb);
-
-try {
-  const initial = Array.isArray(window.allProducts) ? window.allProducts : [];
-  let allProductsValue = initial;
-  Object.defineProperty(window, 'allProducts', {
-    configurable: true,
-    get() {
-      return allProductsValue;
-    },
-    set(value) {
-      allProductsValue = value;
-      scheduleScatterUpdate(() => {
-        const arr = Array.isArray(value) ? value : [];
-        renderPriceIncomeScatter(arr);
-      });
-    }
-  });
-  if (initial.length) {
-    scheduleScatterUpdate(() => renderPriceIncomeScatter(initial));
-  }
-} catch (err) {
-  // ignore if property cannot be redefined
-}
-
-function showTrendsSection(){
-  const $trends = document.querySelector('#section-trends');
-  const $list = document.querySelector('#section-products');
-  if ($trends) $trends.hidden = false;
-  if ($list) $list.hidden = true;
-
-  const $desde = document.querySelector('#fecha-desde');
-  const $hasta = document.querySelector('#fecha-hasta');
-  try {
-    const today = new Date();
-    const from = new Date(today); from.setDate(today.getDate() - 29);
-    if ($desde && !$desde.value) $desde.value = formatDDMMYYYY(from);
-    if ($hasta && !$hasta.value) $hasta.value = formatDDMMYYYY(today);
-  } catch(_) {}
-
-  if (typeof fetchTrends === 'function') {
-    fetchTrends();
-  } else {
-    (async function(){
-      const url = new URL('/api/trends/summary', window.location.origin);
-      const res = await fetch(url.toString(), { credentials:'same-origin' });
-      if (res.ok) {
-        const json = await res.json();
-        if (typeof renderTrends === 'function') renderTrends(json);
+        sec1?.scrollIntoView({ behavior: 'smooth', block: 'start' });
       } else {
-        (window.toast?.error || alert).call(window.toast||window, 'No se pudieron cargar las tendencias.');
+        container?.setAttribute('hidden', '');
+        sec1?.setAttribute('hidden', '');
+        sec2?.setAttribute('hidden', '');
       }
-    })();
-  }
-
-  const firstChart = document.querySelector('#top-left, #topCategoriesChart');
-  if (firstChart && typeof firstChart.scrollIntoView === 'function') {
-    firstChart.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }
+    },
+    { passive: true }
+  );
 }
 
-document.addEventListener('click', function(e){
-  const btn = e.target.closest('#btn-ver-tendencias, .btn-ver-tendencias, [data-action="show-trends"]');
-  if (!btn) return;
-  e.preventDefault();
-  showTrendsSection();
-});
-export {};
+mountTrendsToggle();
+


### PR DESCRIPTION
## Summary
- restructure the trends section markup to host the Pareto revenue chart, compact category table, and insights panel
- refresh trends styling for the new grid/two-column layout, compact table tweaks, and insights UI affordances
- replace the scatter chart logic with Pareto rendering, add toggle handling utilities, and wire a new insights helper module

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c860c8f53c832893333ced11e30994