### PR TITLE
Fix trends view layout and data updates

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -1036,18 +1036,22 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
 #top-right {
   display: flex;
   flex-direction: column;
-  contain: layout paint size; /* rompe bucles de resize */
+  contain: content;
 }
 
 /* Altura fija y estabilidad de charts: evita que queden ocultos */
 .card { position: relative; }
-.chart-canvas{
-  display:block;
-  width:100% !important;
-  height:var(--h,420px) !important;  /* altura explícita */
+.chart-wrap{
+  position: relative;
+  width: 100%;
+  height: 420px;
 }
-#topCategoriesChart{ --h:360px; }
-#paretoRevenueChart{ --h:420px; }
+.chart-wrap--sm{ height: 360px; }
+.chart-wrap > canvas{
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+}
 
 .two-col {
   display: grid;
@@ -1065,7 +1069,7 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
 /* Tabla compacta sin scroll horizontal */
 .table--compact{
   font-size:12.5px;
-  overflow:hidden;               /* corta scroll horizontal del contenedor */
+  overflow:hidden;
 }
 .table--compact thead th{
   position:sticky; top:0; z-index:2;
@@ -1076,8 +1080,8 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
   display:block;
   max-height:320px;
   overflow-y:auto;
-  overflow-x:hidden;             /* <- quita el slider horizontal */
-  scrollbar-gutter: stable both-edges; /* alinea thead/tbody con scrollbar */
+  overflow-x:hidden;
+  scrollbar-gutter: stable both-edges;
 }
 .table--compact thead, .table--compact tbody tr{
   display:table; width:100%; table-layout:fixed;
@@ -1086,7 +1090,7 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
   padding:6px 10px;
   overflow:hidden;
   text-overflow:ellipsis;
-  white-space:nowrap;            /* por defecto en celdas normales */
+  white-space:nowrap;
 }
 /* Categorías en varias líneas (wrap) */
 .table--compact td:first-child{

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -166,14 +166,18 @@ body.dark .skeleton{background:#333;}
   <div id="trends-status"></div>
   <section id="trends" class="trends-grid" hidden>
     <div class="card" id="top-left">
-      <canvas id="topCategoriesChart" class="chart-canvas"></canvas>
+      <div class="chart-wrap chart-wrap--sm">
+        <canvas id="topCategoriesChart"></canvas>
+      </div>
     </div>
 
     <div class="card" id="top-right">
       <div class="chart-header">
         <h4>Pareto de ingresos (Top 15)</h4>
       </div>
-      <canvas id="paretoRevenueChart" class="chart-canvas"></canvas>
+      <div class="chart-wrap">
+        <canvas id="paretoRevenueChart"></canvas>
+      </div>
     </div>
   </section>
 
@@ -668,8 +672,15 @@ function renderTable() {
   }
   // Clear body
   tbody.innerHTML = '';
+  const visibleProducts = Array.isArray(products) ? [...products] : [];
+  window.__visibleProducts = visibleProducts;
+  const allSource = Array.isArray(allProducts) && allProducts.length ? allProducts : visibleProducts;
+  window.__allProducts = allSource;
+  document.dispatchEvent(new CustomEvent('visible-products-changed', {
+    detail: { count: visibleProducts.length }
+  }));
   // Render rows
-    products.forEach(item => {
+  products.forEach(item => {
     const tr = document.createElement('tr');
     if (item.isDuplicate) {
       tr.classList.add('is-duplicate');

--- a/product_research_app/static/js/trends-insights.js
+++ b/product_research_app/static/js/trends-insights.js
@@ -104,15 +104,20 @@ function writeInsights(lines){
 }
 
 function getData() {
-  const agg = window.__latestTrendsData?.categoriesAgg || [];
-  const all = window.__latestTrendsData?.allProducts || [];
-  return { agg, all };
+  const scope = window.__latestTrendsData;
+  if (scope?.categoriesAgg?.length || scope?.allProducts?.length) {
+    return scope;
+  }
+  if (typeof window.computeTrendsScope === 'function') {
+    return window.computeTrendsScope();
+  }
+  return { categoriesAgg: [], allProducts: [] };
 }
 
 document.addEventListener('click', (ev) => {
   if (ev.target?.id !== 'btnLocalInsights') return;
-  const { agg, all } = getData();
-  const lines = [...categoryBullets(agg), ...productBullets(all)];
+  const { categoriesAgg, allProducts } = getData();
+  const lines = [...categoryBullets(categoriesAgg), ...productBullets(allProducts)];
   writeInsights(lines);
 });
 


### PR DESCRIPTION
## Summary
- wrap the trends canvases in fixed-height containers and adjust table styling to prevent chart compression and keep the category grid tidy
- expose the currently visible products to the trends modules and recompute category aggregates, chart updates, and toggle behaviour based on the active product set
- refresh insights generation to rely on the latest visible data and use the requested separator formatting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c87a6847448328915bb62f4ca960d9