### PR TITLE
fix: normalize awareness filter handling

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -93,6 +93,18 @@ body.dark .drawer.right {
   border-left: 1px solid #243150;
 }
 
+.filters-grid{
+  display:grid;
+  grid-template-columns: 1fr 1fr;
+  gap:10px 12px;
+  align-items:center;
+}
+.filters-grid label{ font-size:12.5px; opacity:.9; }
+.filters-grid input, .filters-grid select{
+  width:100%; padding:6px 8px; border-radius:6px; border:1px solid #2a2f55;
+  background:#0f1223; color:#e9ecff;
+}
+
 .hidden { display: none; }
 .col-hidden{ display:none; }
 

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -262,13 +262,85 @@ body.dark .skeleton{background:#333;}
     <h3>Filtros</h3>
     <button id="closeFilters">×</button>
   </div>
-  <div style="display:flex; flex-direction:column; gap:8px;">
-    <label>Precio mín<br><input type="number" id="filterPriceMin"></label>
-    <label>Precio máx<br><input type="number" id="filterPriceMax"></label>
-    <label>Fecha desde<br><input type="date" id="filterDateMin"></label>
-    <label>Fecha hasta<br><input type="date" id="filterDateMax"></label>
-    <label>Rating mín<br><input type="number" id="filterRatingMin" step="0.1" min="0" max="5"></label>
-    <label>Categoría<br><input type="text" id="filterCategory"></label>
+  <div class="filters-grid">
+    <!-- ID -->
+    <label>ID</label>
+    <input id="f-id" placeholder="e.g. 1,3-7">
+
+    <!-- Categoría -->
+    <label>Categoría</label>
+    <input id="f-category" placeholder="contiene…">
+
+    <!-- Price -->
+    <label>Precio mín</label>
+    <input id="f-price-min" inputmode="decimal" placeholder="€">
+    <label>Precio máx</label>
+    <input id="f-price-max" inputmode="decimal" placeholder="€">
+
+    <!-- Rating -->
+    <label>Rating mín</label>
+    <input id="f-rating-min" inputmode="decimal" placeholder="0–5">
+    <label>Rating máx</label>
+    <input id="f-rating-max" inputmode="decimal" placeholder="0–5">
+
+    <!-- Unidades vendidas -->
+    <label>Unidades mín</label>
+    <input id="f-units-min" inputmode="numeric" placeholder="K/M ok">
+    <label>Unidades máx</label>
+    <input id="f-units-max" inputmode="numeric" placeholder="K/M ok">
+
+    <!-- Ingresos -->
+    <label>Ingresos mín</label>
+    <input id="f-revenue-min" inputmode="decimal" placeholder="€ K/M ok">
+    <label>Ingresos máx</label>
+    <input id="f-revenue-max" inputmode="decimal" placeholder="€ K/M ok">
+
+    <!-- Tasa de conversión -->
+    <label>Conv. mín</label>
+    <input id="f-conv-min" inputmode="decimal" placeholder="%">
+    <label>Conv. máx</label>
+    <input id="f-conv-max" inputmode="decimal" placeholder="%">
+
+    <!-- Fecha lanzamiento -->
+    <label>Fecha desde</label>
+    <input id="f-date-from" type="date">
+    <label>Fecha hasta</label>
+    <input id="f-date-to" type="date">
+
+    <!-- Rango Fechas (columna texto) -->
+    <label>Rango Fechas</label>
+    <input id="f-range-text" placeholder="contiene…">
+
+    <!-- Desire magnitude -->
+    <label>Desire magnitude</label>
+    <select id="f-desire-mag">
+      <option value="">Cualquiera</option>
+      <option>Low</option><option>Medium</option><option>High</option>
+    </select>
+
+    <!-- Awareness level -->
+    <label>Awareness level</label>
+    <select id="f-awareness">
+      <option value="">Cualquiera</option>
+      <option value="unaware">Unaware</option>
+      <option value="problemaware">Problem-Aware</option>
+      <option value="solutionaware">Solution-Aware</option>
+      <option value="productaware">Product-Aware</option>
+      <option value="mostaware">Most Aware</option>
+    </select>
+
+    <!-- Competition level -->
+    <label>Competition level</label>
+    <select id="f-competition">
+      <option value="">Cualquiera</option>
+      <option>Low</option><option>Medium</option><option>High</option>
+    </select>
+
+    <!-- Winner Score -->
+    <label>Winner Score mín</label>
+    <input id="f-score-min" inputmode="numeric" placeholder="0–100">
+    <label>Winner Score máx</label>
+    <input id="f-score-max" inputmode="numeric" placeholder="0–100">
   </div>
   <div style="display:flex; gap:8px; margin-top:12px;">
     <button id="applyFilters" style="flex:1;">Aplicar</button>
@@ -295,6 +367,7 @@ body.dark .skeleton{background:#333;}
 <script type="module" src="/static/js/table-sort.js" defer></script>
 <script type="module" src="/static/js/help-tooltip.js" defer></script>
 <script type="module">
+import { applyFilters, readFilters } from '/static/js/filters-panel.js';
 import * as api from "/static/js/net.js";
 import * as groupsService from "/static/js/groups-service.js";
 const { fetchJson } = api;
@@ -376,6 +449,19 @@ let products = [];
 let sortField = null;
 let sortDir = 1;
 let sortType = 'string';
+
+function ensureAppState(){
+  window.appState = window.appState || {};
+  return window.appState;
+}
+
+function getActiveFilters(){
+  const state = ensureAppState();
+  if (state.filters) return state.filters;
+  const filters = readFilters();
+  state.filters = filters;
+  return filters;
+}
 function updateResultsBadge(total) {
   const meta = document.getElementById('listMeta');
   if (!meta) return;
@@ -387,6 +473,12 @@ window.updateResultsBadge = updateResultsBadge;
 window.allProducts = allProducts;
 window.products = products;
 const gridRoot = document.getElementById('productTable');
+
+document.addEventListener('filters-changed', (e) => {
+  if (e && e.detail) ensureAppState().filters = e.detail;
+  selection.clear();
+  renderTable();
+});
 
 function ecMakeMeasurer() {
   const el = document.createElement('span');
@@ -617,7 +709,7 @@ function isTrending(name) {
   return words.some(w => trendingWords.includes(w));
 }
 
-async function fetchProducts(preserve=true) {
+async function fetchProducts() {
   const prevSel = new Set(selection);
   const data = await fetchJson('/products');
   if(data.length && data[0].desire !== undefined && window.ensureColumnVisible){
@@ -629,14 +721,8 @@ async function fetchProducts(preserve=true) {
   sortField = 'id';
   sortDir = 1;
   sortType = 'number';
-  products = [...allProducts];
   window.allProducts = allProducts;
-  window.products = products;
-  if (typeof filtersState !== 'undefined' && preserve) {
-    applyFiltersFromState();
-  } else {
-    renderTable();
-  }
+  renderTable();
   const visibleIds = new Set(products.map(p => String(p.id)));
   selection.clear();
   for (const id of prevSel) {
@@ -653,6 +739,12 @@ async function reloadRows(ids){ await fetchProducts(); }
 function renderTable() {
   const headerRow = document.getElementById('headerRow');
   const tbody = document.querySelector('#productTable tbody');
+  const baseList = Array.isArray(allProducts) ? allProducts : [];
+  const filters = getActiveFilters();
+  const filtered = applyFilters(baseList, filters);
+  products = Array.isArray(filtered) ? [...filtered] : [];
+  sortProducts();
+  window.products = products;
   // Build header if empty
   if (!headerRow.hasChildNodes()) {
     // Add select column header (no label)
@@ -686,8 +778,7 @@ function renderTable() {
   tbody.innerHTML = '';
   const visibleProducts = Array.isArray(products) ? [...products] : [];
   window.__visibleProducts = visibleProducts;
-  const allSource = Array.isArray(allProducts) && allProducts.length ? allProducts : visibleProducts;
-  window.__allProducts = allSource;
+  window.__allProducts = baseList && baseList.length ? baseList : visibleProducts;
   document.dispatchEvent(new CustomEvent('visible-products-changed', {
     detail: { count: visibleProducts.length }
   }));
@@ -1404,11 +1495,8 @@ async function applyGroupFilter(id){
     currentGroupFilter = id;
     const data = await fetchJson('/list/' + id);
     allProducts = data;
-    products = [...allProducts];
     window.allProducts = allProducts;
-    window.products = products;
     selection.clear();
-    updateMasterState();
     renderTable();
     // refresh lists to highlight active group
     loadLists();
@@ -1435,6 +1523,6 @@ window.startProgress = startProgress;
 window.parseDate = parseDate;
 </script>
 <script type="module" src="/static/js/completar-ia.js"></script>
-<script src="/static/js/filters.js"></script>
+<script type="module" src="/static/js/filters-panel.js" defer></script>
 </body>
 </html>

--- a/product_research_app/static/js/filters-panel.js
+++ b/product_research_app/static/js/filters-panel.js
@@ -1,0 +1,400 @@
+const toNumber = (raw) => {
+  if (raw == null || raw === '') return NaN;
+  let s = String(raw).trim();
+  let mul = 1;
+  if (/m$/i.test(s)) { mul = 1e6; s = s.replace(/m/i,''); }
+  if (/k$/i.test(s)) { mul = 1e3; s = s.replace(/k/i,''); }
+  s = s.replace(/[€$]/g,'').replace(/\./g,'').replace(',', '.').replace('%','');
+  const v = parseFloat(s);
+  return isNaN(v) ? NaN : v * mul;
+};
+
+const normLevel = (s) => (s || '').toLowerCase().replace(/[\s-]/g, '');
+
+const toPercent = (raw) => {
+  const n = toNumber(raw);
+  return isNaN(n) ? NaN : n;
+};
+
+const parseIdQuery = (txt) => {
+  const out = new Set();
+  (txt||'').split(',').map(s=>s.trim()).forEach(tok=>{
+    if (!tok) return;
+    const m = tok.match(/^(\d+)\s*-\s*(\d+)$/);
+    if (m){ let a=+m[1], b=+m[2]; if (a>b) [a,b]=[b,a]; for(let i=a;i<=b;i++) out.add(i); }
+    else if (/^\d+$/.test(tok)) out.add(+tok);
+  });
+  return out;
+};
+
+const val = (id) => document.getElementById(id)?.value?.trim() ?? '';
+
+const awarenessLabel = (value) => {
+  if (!value) return '';
+  const select = document.getElementById('f-awareness');
+  if (!select) return value;
+  const option = Array.from(select.options).find(opt => opt.value === value);
+  return option?.textContent?.trim() || value;
+};
+
+export function readFilters(){
+  return {
+    ids: parseIdQuery(val('f-id')),
+    category: val('f-category').toLowerCase(),
+    priceMin: toNumber(val('f-price-min')),
+    priceMax: toNumber(val('f-price-max')),
+    ratingMin: toNumber(val('f-rating-min')),
+    ratingMax: toNumber(val('f-rating-max')),
+    unitsMin: toNumber(val('f-units-min')),
+    unitsMax: toNumber(val('f-units-max')),
+    revenueMin: toNumber(val('f-revenue-min')),
+    revenueMax: toNumber(val('f-revenue-max')),
+    convMin: toPercent(val('f-conv-min')),
+    convMax: toPercent(val('f-conv-max')),
+    dateFrom: val('f-date-from'),
+    dateTo: val('f-date-to'),
+    rangeText: val('f-range-text').toLowerCase(),
+    desireMag: val('f-desire-mag'),
+    awareness: normLevel(val('f-awareness')), // ya viene normalizado del select
+    competition: val('f-competition'),
+    scoreMin: toNumber(val('f-score-min')),
+    scoreMax: toNumber(val('f-score-max')),
+  };
+}
+
+const getAppState = () => {
+  window.appState = window.appState || {};
+  return window.appState;
+};
+
+const extraValue = (p, ...keys) => {
+  if (!p || !p.extras) return undefined;
+  for (const key of keys) {
+    if (p.extras[key] != null && p.extras[key] !== '') {
+      return p.extras[key];
+    }
+  }
+  return undefined;
+};
+
+const F = {
+  id: p => Number(p?.id ?? p?.ID ?? p?.idx ?? extraValue(p, 'ID') ?? NaN),
+  category: p => ((p?.category_path || p?.category || p?.path || extraValue(p, 'Category', 'Categoría')) || '').toLowerCase(),
+  price: p => toNumber(p?.price ?? extraValue(p, 'Price', 'Precio', 'Product Price')), 
+  rating: p => toNumber(p?.rating ?? extraValue(p, 'Product Rating', 'Rating')), 
+  units: p => toNumber(p?.units_sold ?? p?.units ?? p?.total_units ?? p?.quantity ?? extraValue(p, 'Item Sold', 'Units Sold', 'Orders', 'Sales Units', 'Quantity')),
+  revenue: p => toNumber(p?.revenue ?? extraValue(p, 'Revenue($)', 'Revenue', 'Ingresos', 'GMV')),
+  conv: p => toNumber(p?.conversion_rate ?? p?.conversion ?? extraValue(p, 'Conversion Rate', 'Conv Rate', 'Conversion %', 'CVR')),
+  date: p => (p?.launch_date || p?.date || extraValue(p, 'Launch Date', 'Fecha Lanzamiento', 'LaunchDate') || ''),
+  range: p => ((p?.range_label || p?.range || p?.date_range || extraValue(p, 'Date Range', 'Rango Fechas')) || '').toLowerCase(),
+  desireMag: p => (p?.desire_magnitude || p?.desireMag || extraValue(p, 'Desire Magnitude') || '').trim(),
+  awareness: p => (p?.awareness_level || p?.awareness || extraValue(p, 'Awareness Level') || '').trim(),
+  competition: p => (p?.competition_level || p?.competition || extraValue(p, 'Competition Level') || '').trim(),
+  score: p => toNumber(p?.winner_score ?? p?.score ?? extraValue(p, 'Winner Score')), 
+};
+
+const inRange = (v, min, max) => {
+  const hasMin = !isNaN(min);
+  const hasMax = !isNaN(max);
+  if (!hasMin && !hasMax) return true;
+  if (!Number.isFinite(v)) return false;
+  if (hasMin && v < min) return false;
+  if (hasMax && v > max) return false;
+  return true;
+};
+
+const inDate = (iso, from, to) => {
+  if (!iso) return false;
+  if (from && iso < from) return false;
+  if (to && iso > to) return false;
+  return true;
+};
+
+export function applyFilters(products, filters){
+  const list = Array.isArray(products) ? products : [];
+  const f = filters || readFilters();
+  const idSet = f.ids instanceof Set ? f.ids : parseIdQuery(f.ids);
+  return list.filter(p => {
+    if (idSet && idSet.size){
+      const pid = F.id(p);
+      if (!idSet.has(pid)) return false;
+    }
+    if (f.category && !F.category(p).includes(f.category)) return false;
+    if (!inRange(F.price(p),   f.priceMin,   f.priceMax)) return false;
+    if (!inRange(F.rating(p),  f.ratingMin,  f.ratingMax)) return false;
+    if (!inRange(F.units(p),   f.unitsMin,   f.unitsMax)) return false;
+    if (!inRange(F.revenue(p), f.revenueMin, f.revenueMax)) return false;
+    if (!inRange(F.conv(p),    f.convMin,    f.convMax)) return false;
+    if (!inRange(F.score(p),   f.scoreMin,   f.scoreMax)) return false;
+    if ((f.dateFrom || f.dateTo) && !inDate(F.date(p), f.dateFrom, f.dateTo)) return false;
+    if (f.rangeText && !F.range(p).includes(f.rangeText)) return false;
+    if (f.desireMag && F.desireMag(p) !== f.desireMag) return false;
+    if (f.awareness) {
+      if (normLevel(F.awareness(p)) !== f.awareness) return false;
+    }
+    if (f.competition && F.competition(p) !== f.competition) return false;
+    return true;
+  });
+}
+
+const drawerEl = () => document.getElementById('filtersDrawer');
+const toggleDrawer = () => {
+  const drawer = drawerEl();
+  if (!drawer) return;
+  drawer.classList.toggle('hidden');
+};
+const closeDrawer = () => {
+  const drawer = drawerEl();
+  if (!drawer) return;
+  drawer.classList.add('hidden');
+};
+
+const isTextInput = (el) => {
+  if (!el) return false;
+  const tag = el.tagName ? el.tagName.toLowerCase() : '';
+  return tag === 'input' || tag === 'textarea' || tag === 'select' || el.isContentEditable === true;
+};
+
+const fmtNumber = (n) => {
+  if (!Number.isFinite(n)) return '';
+  const abs = Math.abs(n);
+  if (abs >= 1e6) return `${(n / 1e6).toFixed(abs >= 1e8 ? 0 : 1).replace(/\.0$/, '')}M`;
+  if (abs >= 1e3) return `${(n / 1e3).toFixed(abs >= 1e5 ? 0 : 1).replace(/\.0$/, '')}K`;
+  return n.toLocaleString('es-ES', { maximumFractionDigits: n % 1 ? 2 : 0 });
+};
+const fmtCurrency = (n) => {
+  const base = fmtNumber(n);
+  return base ? `€${base}` : '';
+};
+const chipContainer = document.getElementById('activeFilterChips');
+
+function buildActiveChips(filters){
+  if (!chipContainer) return;
+  chipContainer.innerHTML = '';
+  const chips = [];
+  const pushChip = (label, clear) => {
+    if (!label || typeof clear !== 'function') return;
+    chips.push({ label, clear });
+  };
+
+  const idRaw = val('f-id');
+  if (filters.ids && filters.ids.size && idRaw) {
+    pushChip(`ID: ${idRaw}`, () => {
+      const el = document.getElementById('f-id');
+      if (el) el.value = '';
+    });
+  }
+
+  const categoryRaw = val('f-category');
+  if (categoryRaw) {
+    pushChip(`Categoría: ${categoryRaw}`, () => {
+      const el = document.getElementById('f-category');
+      if (el) el.value = '';
+    });
+  }
+
+  if (Number.isFinite(filters.priceMin)) {
+    pushChip(`Precio ≥ ${fmtCurrency(filters.priceMin)}`, () => {
+      const el = document.getElementById('f-price-min');
+      if (el) el.value = '';
+    });
+  }
+  if (Number.isFinite(filters.priceMax)) {
+    pushChip(`Precio ≤ ${fmtCurrency(filters.priceMax)}`, () => {
+      const el = document.getElementById('f-price-max');
+      if (el) el.value = '';
+    });
+  }
+
+  if (Number.isFinite(filters.ratingMin)) {
+    pushChip(`Rating ≥ ${fmtNumber(filters.ratingMin)}`, () => {
+      const el = document.getElementById('f-rating-min');
+      if (el) el.value = '';
+    });
+  }
+  if (Number.isFinite(filters.ratingMax)) {
+    pushChip(`Rating ≤ ${fmtNumber(filters.ratingMax)}`, () => {
+      const el = document.getElementById('f-rating-max');
+      if (el) el.value = '';
+    });
+  }
+
+  if (Number.isFinite(filters.unitsMin)) {
+    pushChip(`Unidades ≥ ${fmtNumber(filters.unitsMin)}`, () => {
+      const el = document.getElementById('f-units-min');
+      if (el) el.value = '';
+    });
+  }
+  if (Number.isFinite(filters.unitsMax)) {
+    pushChip(`Unidades ≤ ${fmtNumber(filters.unitsMax)}`, () => {
+      const el = document.getElementById('f-units-max');
+      if (el) el.value = '';
+    });
+  }
+
+  if (Number.isFinite(filters.revenueMin)) {
+    pushChip(`Ingresos ≥ ${fmtCurrency(filters.revenueMin)}`, () => {
+      const el = document.getElementById('f-revenue-min');
+      if (el) el.value = '';
+    });
+  }
+  if (Number.isFinite(filters.revenueMax)) {
+    pushChip(`Ingresos ≤ ${fmtCurrency(filters.revenueMax)}`, () => {
+      const el = document.getElementById('f-revenue-max');
+      if (el) el.value = '';
+    });
+  }
+
+  if (Number.isFinite(filters.convMin)) {
+    pushChip(`Conv. ≥ ${fmtNumber(filters.convMin)}%`, () => {
+      const el = document.getElementById('f-conv-min');
+      if (el) el.value = '';
+    });
+  }
+  if (Number.isFinite(filters.convMax)) {
+    pushChip(`Conv. ≤ ${fmtNumber(filters.convMax)}%`, () => {
+      const el = document.getElementById('f-conv-max');
+      if (el) el.value = '';
+    });
+  }
+
+  if (filters.dateFrom) {
+    pushChip(`Desde ${filters.dateFrom}`, () => {
+      const el = document.getElementById('f-date-from');
+      if (el) el.value = '';
+    });
+  }
+  if (filters.dateTo) {
+    pushChip(`Hasta ${filters.dateTo}`, () => {
+      const el = document.getElementById('f-date-to');
+      if (el) el.value = '';
+    });
+  }
+
+  const rangeRaw = val('f-range-text');
+  if (rangeRaw) {
+    pushChip(`Rango: ${rangeRaw}`, () => {
+      const el = document.getElementById('f-range-text');
+      if (el) el.value = '';
+    });
+  }
+
+  if (filters.desireMag) {
+    pushChip(`Desire: ${filters.desireMag}`, () => {
+      const el = document.getElementById('f-desire-mag');
+      if (el) el.value = '';
+    });
+  }
+  if (filters.awareness) {
+    pushChip(`Awareness: ${awarenessLabel(filters.awareness)}`, () => {
+      const el = document.getElementById('f-awareness');
+      if (el) el.value = '';
+    });
+  }
+  if (filters.competition) {
+    pushChip(`Competencia: ${filters.competition}`, () => {
+      const el = document.getElementById('f-competition');
+      if (el) el.value = '';
+    });
+  }
+
+  if (Number.isFinite(filters.scoreMin)) {
+    pushChip(`Score ≥ ${Math.round(filters.scoreMin)}`, () => {
+      const el = document.getElementById('f-score-min');
+      if (el) el.value = '';
+    });
+  }
+  if (Number.isFinite(filters.scoreMax)) {
+    pushChip(`Score ≤ ${Math.round(filters.scoreMax)}`, () => {
+      const el = document.getElementById('f-score-max');
+      if (el) el.value = '';
+    });
+  }
+
+  chips.forEach(({ label, clear }) => {
+    const chip = document.createElement('span');
+    chip.className = 'chip';
+    const text = document.createElement('span');
+    text.textContent = label;
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = '×';
+    btn.setAttribute('aria-label', 'Quitar filtro');
+    btn.addEventListener('click', () => {
+      clear();
+      const updated = readFilters();
+      getAppState().filters = updated;
+      document.dispatchEvent(new CustomEvent('filters-changed', { detail: updated }));
+    });
+    chip.append(text, btn);
+    chipContainer.appendChild(chip);
+  });
+}
+
+const btnFilters = document.getElementById('btnFilters');
+if (btnFilters) {
+  btnFilters.addEventListener('click', (e) => {
+    e.preventDefault();
+    toggleDrawer();
+  });
+}
+const closeBtn = document.getElementById('closeFilters');
+if (closeBtn) {
+  closeBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    closeDrawer();
+  });
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    closeDrawer();
+    return;
+  }
+  if (isTextInput(e.target)) return;
+  if (e.key === '/' && !e.metaKey && !e.ctrlKey) {
+    e.preventDefault();
+    document.getElementById('searchInput')?.focus();
+    return;
+  }
+  if (e.key && e.key.toLowerCase() === 'f' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    e.preventDefault();
+    toggleDrawer();
+    return;
+  }
+  if (e.key && e.key.toLowerCase() === 'g' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    e.preventDefault();
+    document.getElementById('groupSelect')?.focus();
+  }
+});
+
+document.addEventListener('click', (e) => {
+  const target = e.target;
+  if (!target) return;
+  const id = target.id;
+  const text = target.textContent?.trim();
+  if (id === 'applyFilters' || id === 'apply-filters' || /^Aplicar$/i.test(text || '')) {
+    const filters = readFilters();
+    getAppState().filters = filters;
+    document.dispatchEvent(new CustomEvent('filters-changed', { detail: filters }));
+    closeDrawer();
+  }
+  if (id === 'clearFilters' || id === 'clear-filters' || /^Limpiar$/i.test(text || '')) {
+    document.querySelectorAll('.filters-grid input').forEach(el => { el.value = ''; });
+    document.querySelectorAll('.filters-grid select').forEach(el => { el.value = ''; });
+    const filters = readFilters();
+    getAppState().filters = filters;
+    document.dispatchEvent(new CustomEvent('filters-changed', { detail: filters }));
+  }
+});
+
+const initialFilters = getAppState().filters || readFilters();
+getAppState().filters = initialFilters;
+buildActiveChips(initialFilters);
+
+document.addEventListener('filters-changed', (e) => {
+  const filters = e?.detail || readFilters();
+  buildActiveChips(filters);
+});
+
+export { buildActiveChips };


### PR DESCRIPTION
## Summary
- rebuild the filters drawer with the new grid-based inputs and additional metadata selectors
- add the filters-panel module to parse form values, manage the drawer UI, and expose applyFilters/readFilters helpers
- integrate the filtering pipeline into the table render flow and dispatch visible-products-changed after applying filters
- normalize the awareness filter options and comparison logic so all levels are matched consistently

## Testing
- no automated tests (frontend changes only)

------
https://chatgpt.com/codex/tasks/task_e_68c88b8b9b588328b7cff8d9cf3173c4