### PR TITLE
Optimize SQLite importer with batched upserts

### DIFF
--- a/product_research_app/app.py
+++ b/product_research_app/app.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import csv
+import io
+import logging
 import threading
 import time
-from typing import Any, Dict
+from itertools import islice
+from typing import Any, Dict, Iterable, Iterator
 
 from flask import Flask, request
 
+from product_research_app.db import get_db
 from product_research_app.services.importer_fast import fast_import_adaptive
+from product_research_app.utils.timing import phase
 
 
 app = Flask(__name__)
@@ -14,6 +20,79 @@ app = Flask(__name__)
 
 IMPORT_STATUS: Dict[str, Dict[str, Any]] = {}
 _IMPORT_LOCK = threading.Lock()
+
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_IDS_FOR_DEDUPE = 200_000
+
+
+def _chunked(iterable: Iterable[int], size: int) -> Iterator[list[int]]:
+    iterator = iter(iterable)
+    while True:
+        chunk = list(islice(iterator, size))
+        if not chunk:
+            break
+        yield chunk
+
+
+def _analyze_csv_bytes(csv_bytes: bytes) -> tuple[int, int, set[int]]:
+    column_count = 0
+    row_count = 0
+    id_candidates: set[int] = set()
+
+    if not csv_bytes:
+        return column_count, row_count, id_candidates
+
+    text_stream = io.StringIO(csv_bytes.decode("utf-8", errors="ignore"))
+    reader = csv.DictReader(text_stream)
+    if reader.fieldnames:
+        column_count = len(reader.fieldnames)
+
+    for row in reader:
+        row_count += 1
+        raw_id = row.get("id") or row.get("ID")
+        if raw_id in (None, ""):
+            continue
+        if len(id_candidates) >= _MAX_IDS_FOR_DEDUPE:
+            continue
+        try:
+            candidate = int(str(raw_id).strip())
+        except Exception:
+            continue
+        id_candidates.add(candidate)
+
+    return column_count, row_count, id_candidates
+
+
+def _count_existing_ids(candidates: set[int]) -> int:
+    if not candidates:
+        return 0
+
+    db = get_db()
+    total = 0
+    for chunk in _chunked(sorted(candidates), 900):
+        placeholders = ",".join("?" for _ in chunk)
+        query = f"SELECT COUNT(*) FROM products WHERE id IN ({placeholders})"
+        try:
+            row = db.execute(query, tuple(chunk)).fetchone()
+        except Exception:
+            continue
+        if row and row[0] is not None:
+            total += int(row[0])
+    return total
+
+
+def _enqueue_post_import_tasks(task_id: str, rows_imported: int) -> int:
+    """Placeholder for post-import asynchronous work."""
+
+    logger.debug(
+        "import_job[%s] post_import_queue noop rows_imported=%s",
+        task_id,
+        rows_imported,
+    )
+    return 0
 
 
 def _round_ms(delta: float) -> int:
@@ -36,6 +115,11 @@ def _baseline_status(task_id: str) -> Dict[str, Any]:
         "t_upsert": 0,
         "t_commit": 0,
         "t_optimize": 0,
+        "file_size_bytes": 0,
+        "row_count": 0,
+        "column_count": 0,
+        "total_ms": 0,
+        "phases": [],
     }
 
 
@@ -72,6 +156,34 @@ def _update_status(task_id: str, **updates: Any) -> Dict[str, Any]:
                 except Exception:
                     updates.pop(key, None)
 
+        for key in ("row_count", "column_count", "file_size_bytes", "total_ms"):
+            if key in updates:
+                try:
+                    updates[key] = int(updates[key])
+                except Exception:
+                    updates.pop(key, None)
+
+        if "phases" in updates:
+            try:
+                normalized = []
+                for item in updates["phases"] or []:
+                    if isinstance(item, dict):
+                        name = str(item.get("name", ""))
+                        ms_val = item.get("ms", 0)
+                    elif isinstance(item, (list, tuple)) and item:
+                        name = str(item[0])
+                        ms_val = item[1] if len(item) > 1 else 0
+                    else:
+                        continue
+                    try:
+                        ms_int = int(ms_val)
+                    except Exception:
+                        continue
+                    normalized.append({"name": name, "ms": ms_int})
+                updates["phases"] = normalized
+            except Exception:
+                updates.pop("phases", None)
+
         status.update(updates)
         if status.get("total", 0) < status.get("done", 0):
             status["total"] = status.get("done", 0)
@@ -90,29 +202,121 @@ def upload():
     if file is None:
         return {"error": "missing_file"}, 400
 
-    csv_bytes = file.read()
     task_id = str(int(time.time() * 1000))
     _update_status(task_id, filename=file.filename or None)
 
+    phase_records: list[Dict[str, int]] = []
+
+    def record_phase(info: Dict[str, Any]) -> None:
+        name = str(info.get("name", ""))
+        try:
+            ms_val = int(info.get("ms", 0))
+        except Exception:
+            ms_val = 0
+        phase_records.append({"name": name, "ms": ms_val})
+        _update_status(task_id, phases=[dict(item) for item in phase_records])
+
+    total_start = time.perf_counter()
+    csv_bytes = b""
+    read_phase: Dict[str, Any] | None = None
+    try:
+        with phase("read_file") as ph:
+            read_phase = ph
+            csv_bytes = file.read()
+    finally:
+        if read_phase is not None:
+            record_phase(read_phase)
+
+    file_size = len(csv_bytes or b"")
+    _update_status(task_id, file_size_bytes=file_size)
+
     def run():
         _update_status(task_id, state="running", stage="running")
-        try:
-            def cb(**payload):
-                _update_status(task_id, **payload)
+        row_count_source = 0
+        column_count = 0
+        existing_ids_count = 0
+        rows_imported = 0
+        id_candidates: set[int] = set()
+        optimize = None
 
-            optimize = fast_import_adaptive(csv_bytes, status_cb=cb)
+        def cb(**payload):
+            _update_status(task_id, **payload)
+
+        try:
+            parse_phase: Dict[str, Any] | None = None
+            try:
+                with phase("parse_csv") as ph:
+                    parse_phase = ph
+                    column_count, row_count_source, id_candidates = _analyze_csv_bytes(csv_bytes)
+            finally:
+                if parse_phase is not None:
+                    record_phase(parse_phase)
+            _update_status(
+                task_id,
+                row_count=row_count_source,
+                column_count=column_count,
+            )
+            logger.info(
+                "import_job[%s] parse_csv rows=%d columns=%d id_candidates=%d",
+                task_id,
+                row_count_source,
+                column_count,
+                len(id_candidates),
+            )
+
+            dedupe_phase: Dict[str, Any] | None = None
+            try:
+                with phase("dedupe_prepare") as ph:
+                    dedupe_phase = ph
+                    existing_ids_count = _count_existing_ids(id_candidates)
+            finally:
+                if dedupe_phase is not None:
+                    record_phase(dedupe_phase)
+            logger.info(
+                "import_job[%s] dedupe_prepare existing_ids=%d",
+                task_id,
+                existing_ids_count,
+            )
+            id_candidates.clear()
+
+            db_phase: Dict[str, Any] | None = None
+            try:
+                with phase("db_bulk_insert") as ph:
+                    db_phase = ph
+                    optimize = fast_import_adaptive(csv_bytes, status_cb=cb)
+            finally:
+                if db_phase is not None:
+                    record_phase(db_phase)
+
             rows_imported = int(getattr(optimize, "rows_imported", 0) or 0)
             snapshot = _get_status(task_id) or {}
             done_val = max(int(snapshot.get("done", 0) or 0), rows_imported)
             total_val = max(int(snapshot.get("total", 0) or 0), done_val)
-            _update_status(task_id, done=done_val, total=total_val, imported=rows_imported)
+            _update_status(
+                task_id,
+                done=done_val,
+                total=total_val,
+                imported=rows_imported,
+                row_count=row_count_source,
+                column_count=column_count,
+            )
             _update_status(task_id, state="done")
+
+            post_phase: Dict[str, Any] | None = None
+            try:
+                with phase("post_import_queue") as ph:
+                    post_phase = ph
+                    _enqueue_post_import_tasks(task_id, rows_imported)
+            finally:
+                if post_phase is not None:
+                    record_phase(post_phase)
 
             def do_opt():
                 t0 = time.time()
                 try:
                     _update_status(task_id, optimizing=True)
-                    optimize()
+                    if callable(optimize):
+                        optimize()
                 except Exception as exc:
                     _update_status(
                         task_id,
@@ -127,10 +331,32 @@ def upload():
                         t_optimize=_round_ms(time.time() - t0),
                     )
 
-            threading.Thread(target=do_opt, daemon=True).start()
+            if callable(optimize):
+                threading.Thread(target=do_opt, daemon=True).start()
 
         except Exception as exc:
+            logger.exception("import_job[%s] failed", task_id)
             _update_status(task_id, state="error", error=str(exc))
+        finally:
+            total_elapsed_ms = int(round((time.perf_counter() - total_start) * 1000))
+            _update_status(
+                task_id,
+                total_ms=total_elapsed_ms,
+                file_size_bytes=file_size,
+                row_count=row_count_source,
+                column_count=column_count,
+                phases=[dict(item) for item in phase_records],
+            )
+            logger.info(
+                "import_job[%s] summary rows=%d columns=%d file_size=%dB existing_ids=%d imported=%d total_ms=%d",
+                task_id,
+                row_count_source,
+                column_count,
+                file_size,
+                existing_ids_count,
+                rows_imported,
+                total_elapsed_ms,
+            )
 
     threading.Thread(target=run, daemon=True).start()
     return {"task_id": task_id}, 202
@@ -149,6 +375,11 @@ def import_status():
             "imported": 0,
             "error": None,
             "optimizing": False,
+            "file_size_bytes": 0,
+            "row_count": 0,
+            "column_count": 0,
+            "total_ms": 0,
+            "phases": [],
         }, 200
 
     status = _get_status(task_id)
@@ -162,6 +393,11 @@ def import_status():
             "imported": 0,
             "error": None,
             "optimizing": False,
+            "file_size_bytes": 0,
+            "row_count": 0,
+            "column_count": 0,
+            "total_ms": 0,
+            "phases": [],
         }, 200
 
     status.setdefault("task_id", task_id)

--- a/product_research_app/services/importer_fast.py
+++ b/product_research_app/services/importer_fast.py
@@ -2,529 +2,382 @@ from __future__ import annotations
 
 import csv
 import io
-import time
-from typing import Iterable, Iterator, Sequence
+import re
+from typing import Iterable, Mapping, Sequence
 
 from product_research_app.db import get_db
 
 
-def _count_lines(b: bytes) -> int:
-    """Return a quick line count estimate for CSV payloads."""
+PRODUCTS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS products (
+    id INTEGER PRIMARY KEY,
+    title TEXT,
+    price REAL,
+    units_sold REAL,
+    revenue REAL,
+    rating REAL,
+    desire TEXT,
+    competition TEXT,
+    oldness TEXT,
+    awareness TEXT,
+    category TEXT,
+    store TEXT,
+    description TEXT,
+    dateAdded TEXT
+);
+"""
 
-    if not b:
-        return 0
-    return max(b.count(b"\n") - 1, 0)
+PRODUCT_COLUMN_TYPES: dict[str, str] = {
+    "title": "TEXT",
+    "price": "REAL",
+    "units_sold": "REAL",
+    "revenue": "REAL",
+    "rating": "REAL",
+    "desire": "TEXT",
+    "competition": "TEXT",
+    "oldness": "TEXT",
+    "awareness": "TEXT",
+    "category": "TEXT",
+    "store": "TEXT",
+    "description": "TEXT",
+    "dateAdded": "TEXT",
+}
+
+UPSERT_SQL = """
+INSERT INTO products (
+    id, title, price, units_sold, revenue, rating, desire, competition,
+    oldness, awareness, category, store, description, dateAdded
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    title=excluded.title,
+    price=excluded.price,
+    units_sold=excluded.units_sold,
+    revenue=excluded.revenue,
+    rating=excluded.rating,
+    desire=excluded.desire,
+    competition=excluded.competition,
+    oldness=excluded.oldness,
+    awareness=excluded.awareness,
+    category=excluded.category,
+    store=excluded.store,
+    description=excluded.description,
+    dateAdded=excluded.dateAdded;
+"""
+
+FIELD_ALIASES: dict[str, tuple[str, ...]] = {
+    "id": ("id", "ID"),
+    "title": ("title", "name", "product", "producto"),
+    "price": ("price", "precio", "cost"),
+    "units_sold": (
+        "units_sold",
+        "unitsSold",
+        "units",
+        "unitssold",
+        "ventas",
+        "sold",
+        "orders",
+    ),
+    "revenue": ("revenue", "sales", "ingresos", "income"),
+    "rating": ("rating", "valoracion", "stars"),
+    "desire": ("desire", "desire_score", "deseo"),
+    "competition": ("competition", "competition_level", "saturacion"),
+    "oldness": ("oldness", "age", "edad", "antiguedad"),
+    "awareness": ("awareness", "awareness_level", "consciencia"),
+    "category": ("category", "categoria", "niche"),
+    "store": ("store", "tienda", "shop", "seller"),
+    "description": ("description", "descripcion", "desc"),
+    "dateAdded": ("dateAdded", "date_added", "added", "fecha"),
+}
 
 
-def _num(x):
-    if x is None:
-        return 0.0
-    s = str(x).strip()
-    mul = 1
-    if s.lower().endswith("m"):
-        mul, s = 1e6, s[:-1]
-    if s.lower().endswith("k"):
-        mul, s = 1e3, s[:-1]
-    s = (
-        s.replace("€", "")
+def _normalize_key(value: str) -> str:
+    return "".join(ch for ch in value.lower() if ch.isalnum())
+
+
+def _lookup(row: Mapping[str, object], sanitized: dict[str, str], field: str) -> object | None:
+    aliases = FIELD_ALIASES.get(field, ())
+    for alias in aliases:
+        key = sanitized.get(_normalize_key(alias))
+        if key is None:
+            continue
+        value = row.get(key)
+        if isinstance(value, str):
+            value = value.strip()
+        if value in (None, ""):
+            continue
+        return value
+    return None
+
+
+def _parse_number(value: object) -> float | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    multiplier = 1.0
+    last = text[-1].lower()
+    if last == "m":
+        multiplier = 1_000_000.0
+        text = text[:-1]
+    elif last == "k":
+        multiplier = 1_000.0
+        text = text[:-1]
+
+    text = (
+        text.replace("€", "")
         .replace("$", "")
         .replace("%", "")
-        .replace(".", "")
-        .replace(",", ".")
+        .replace("\u00a0", "")
+        .replace(" ", "")
     )
+    if not text:
+        return None
+
+    if "," in text and "." in text:
+        if text.rfind(",") > text.rfind("."):
+            decimal_sep, thousands_sep = ",", "."
+        else:
+            decimal_sep, thousands_sep = ".", ","
+        text = text.replace(thousands_sep, "")
+        text = text.replace(decimal_sep, ".")
+    elif text.count(",") > 1:
+        text = text.replace(",", "")
+    elif text.count(".") > 1:
+        text = text.replace(".", "")
+    else:
+        text = text.replace(",", ".")
+
     try:
-        return float(s) * mul
+        return float(text) * multiplier
+    except ValueError:
+        match = re.search(r"[-+]?\d+(?:\.\d+)?", text)
+        if match:
+            try:
+                return float(match.group(0)) * multiplier
+            except ValueError:
+                return None
+    return None
+
+
+def _parse_int(value: object) -> int | None:
+    num = _parse_number(value)
+    if num is None:
+        return None
+    try:
+        return int(round(num))
     except Exception:
-        return 0.0
+        return None
 
 
-def _rows_from_csv(csv_bytes: bytes) -> Iterator[tuple]:
-    txt = csv_bytes.decode("utf-8", errors="ignore")
-    rdr = csv.DictReader(io.StringIO(txt))
-    for r in rdr:
-        yield (
-            int(r.get("id") or r.get("ID") or 0),
-            r.get("name") or r.get("Nombre") or "",
-            r.get("category_path")
-            or r.get("Categoría")
-            or r.get("categoria")
-            or "",
-            _num(r.get("price")),
-            _num(r.get("rating")),
-            _num(r.get("units_sold") or r.get("unidades")),
-            _num(r.get("revenue") or r.get("ingresos")),
-            _num(r.get("conversion_rate") or r.get("tasa_conversion")),
-            (r.get("launch_date") or r.get("fecha_lanzamiento") or "")[:10],
-            r.get("date_range") or r.get("rango_fechas") or "",
-            r.get("desire_magnitude") or r.get("desireMag") or "",
-            r.get("awareness_level") or r.get("awareness") or "",
-            r.get("competition_level") or r.get("competition") or "",
-            None
-            if (r.get("winner_score") in (None, ""))
-            else int(_num(r.get("winner_score"))),
-            r.get("image_url") or r.get("imagen") or "",
-            r.get("desire") or "",
-        )
+def _coerce_text(value: object | None) -> str | None:
+    if value in (None, ""):
+        return None
+    return str(value).strip()
 
 
-def _rows_from_records(records: Iterable[dict]) -> Iterator[tuple]:
-    for r in records:
-        if not isinstance(r, dict):
+def _normalize_for_dedup(value: str | None) -> str:
+    if not value:
+        return ""
+    return " ".join(value.lower().split())
+
+
+def _row_from_mapping(
+    row: Mapping[str, object],
+    seen_ids: set[int],
+    seen_hashes: set[tuple[str, str]],
+) -> tuple[int, str, float | None, float | None, float | None, float | None, object | None,
+           object | None, object | None, object | None, str | None, str | None, str | None, str | None] | None:
+    sanitized = {}
+    for key in row.keys():
+        if key is None:
             continue
-        yield (
-            int(_num(r.get("id") or r.get("ID"))),
-            r.get("name") or r.get("Nombre") or "",
-            r.get("category_path")
-            or r.get("Categoría")
-            or r.get("categoria")
-            or r.get("category")
-            or "",
-            _num(r.get("price") or r.get("precio")),
-            _num(r.get("rating") or r.get("valoracion")),
-            _num(r.get("units_sold") or r.get("unidades") or r.get("units")),
-            _num(r.get("revenue") or r.get("ingresos") or r.get("sales")),
-            _num(
-                r.get("conversion_rate")
-                or r.get("tasa_conversion")
-                or r.get("conversion")
-            ),
-            (r.get("launch_date") or r.get("fecha_lanzamiento") or r.get("launchDate") or "")[
-                :10
-            ],
-            r.get("date_range")
-            or r.get("rango_fechas")
-            or r.get("Date Range")
-            or "",
-            r.get("desire_magnitude") or r.get("desireMag") or "",
-            r.get("awareness_level") or r.get("awareness") or "",
-            r.get("competition_level") or r.get("competition") or "",
-            None
-            if (r.get("winner_score") in (None, ""))
-            else int(_num(r.get("winner_score"))),
-            r.get("image_url") or r.get("imagen") or r.get("image") or "",
-            r.get("desire") or "",
-        )
+        norm = _normalize_key(str(key))
+        if not norm:
+            continue
+        sanitized.setdefault(norm, str(key))
 
+    product_id = _parse_int(_lookup(row, sanitized, "id"))
+    if product_id is None or product_id <= 0:
+        return None
+    if product_id in seen_ids:
+        return None
+    seen_ids.add(product_id)
 
-def _snapshot_and_drop(db, table: str = "products") -> tuple[Sequence[tuple], Sequence[tuple]]:
-    idx = db.execute(
-        "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name=? AND sql IS NOT NULL;",
-        (table,),
-    ).fetchall()
-    trg = db.execute(
-        "SELECT name, sql FROM sqlite_master WHERE type='trigger' AND tbl_name=?;",
-        (table,),
-    ).fetchall()
-    for (name, _) in idx:
-        db.execute(f'DROP INDEX IF EXISTS "{name}";')
-    for (name, _) in trg:
-        db.execute(f'DROP TRIGGER IF EXISTS "{name}";')
-    return idx, trg
+    title_val = _coerce_text(_lookup(row, sanitized, "title")) or ""
+    store_val = _coerce_text(_lookup(row, sanitized, "store")) or ""
+    hash_key = (_normalize_for_dedup(title_val), _normalize_for_dedup(store_val))
+    if hash_key != ("", "") and hash_key in seen_hashes:
+        return None
+    seen_hashes.add(hash_key)
 
+    price_val = _parse_number(_lookup(row, sanitized, "price"))
+    units_val = _parse_number(_lookup(row, sanitized, "units_sold"))
+    revenue_val = _parse_number(_lookup(row, sanitized, "revenue"))
+    rating_val = _parse_number(_lookup(row, sanitized, "rating"))
 
-def _recreate(db, items: Sequence[tuple]) -> None:
-    for (name, sql) in items or ():
-        if sql:
-            db.execute(sql)
+    desire_val = _lookup(row, sanitized, "desire")
+    competition_val = _lookup(row, sanitized, "competition")
+    oldness_val = _lookup(row, sanitized, "oldness")
+    awareness_val = _lookup(row, sanitized, "awareness")
 
+    category_val = _coerce_text(_lookup(row, sanitized, "category"))
+    description_val = _coerce_text(_lookup(row, sanitized, "description"))
+    date_added_val = _coerce_text(_lookup(row, sanitized, "dateAdded"))
 
-def _round_ms(delta: float) -> int:
-    return max(int(round(delta * 1000)), 0)
-
-def _rows_from_records(records):
-  for r in records:
-    if not isinstance(r, dict):
-      continue
-    yield (
-      _int_or_default(r.get('id') or r.get('ID')),
-      r.get('name') or r.get('Nombre') or '',
-      r.get('category_path') or r.get('Categoría') or r.get('categoria') or r.get('category') or '',
-      _num(r.get('price') or r.get('precio')),
-      _num(r.get('rating') or r.get('valoracion')),
-      _num(r.get('units_sold') or r.get('unidades') or r.get('units')),
-      _num(r.get('revenue') or r.get('ingresos') or r.get('sales')),
-      _num(r.get('conversion_rate') or r.get('tasa_conversion') or r.get('conversion')),
-      (r.get('launch_date') or r.get('fecha_lanzamiento') or r.get('launchDate') or '')[:10],
-      r.get('date_range') or r.get('rango_fechas') or r.get('Date Range') or '',
-      r.get('desire_magnitude') or r.get('desireMag') or '',
-      r.get('awareness_level') or r.get('awareness') or '',
-      r.get('competition_level') or r.get('competition') or '',
-      None if (r.get('winner_score') in (None,'')) else int(_num(r.get('winner_score'))),
-      r.get('image_url') or r.get('imagen') or r.get('image') or '',
-      r.get('desire') or ''
+    return (
+        product_id,
+        title_val,
+        price_val,
+        units_val,
+        revenue_val,
+        rating_val,
+        desire_val,
+        competition_val,
+        oldness_val,
+        awareness_val,
+        category_val,
+        store_val or None,
+        description_val,
+        date_added_val,
     )
 
-def _push_pragmas(db):
-    original = {}
+
+def _prepare_rows(records: Iterable[Mapping[str, object]]) -> list[tuple]:
+    rows: list[tuple] = []
+    seen_ids: set[int] = set()
+    seen_hashes: set[tuple[str, str]] = set()
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+        prepared = _row_from_mapping(record, seen_ids, seen_hashes)
+        if prepared is None:
+            continue
+        rows.append(prepared)
+    return rows
+
+
+def _rows_from_csv(csv_bytes: bytes) -> list[tuple]:
+    text = csv_bytes.decode("utf-8", errors="ignore")
+    reader = csv.DictReader(io.StringIO(text))
+    return _prepare_rows(reader)
+
+
+def _ensure_products_schema(conn) -> None:
+    conn.execute(PRODUCTS_TABLE_SQL)
+    existing = {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(products)")
+    }
+    for column, col_type in PRODUCT_COLUMN_TYPES.items():
+        if column not in existing:
+            conn.execute(f"ALTER TABLE products ADD COLUMN {column} {col_type};")
+
+
+def _ensure_unique_index(conn) -> None:
+    conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_products_id ON products(id);")
+
+
+def _apply_pragmas(conn) -> dict[str, object]:
+    original: dict[str, object] = {}
     try:
-        original["journal_mode"] = db.execute("PRAGMA journal_mode;").fetchone()[0]
+        original["journal_mode"] = conn.execute("PRAGMA journal_mode;").fetchone()[0]
     except Exception:
         original["journal_mode"] = None
     try:
-        original["synchronous"] = db.execute("PRAGMA synchronous;").fetchone()[0]
+        original["synchronous"] = conn.execute("PRAGMA synchronous;").fetchone()[0]
     except Exception:
         original["synchronous"] = None
     try:
-        original["temp_store"] = db.execute("PRAGMA temp_store;").fetchone()[0]
+        original["temp_store"] = conn.execute("PRAGMA temp_store;").fetchone()[0]
     except Exception:
         original["temp_store"] = None
     try:
-        original["cache_size"] = db.execute("PRAGMA cache_size;").fetchone()[0]
-    except Exception:
-        original["cache_size"] = None
-    try:
-        original["locking_mode"] = db.execute("PRAGMA locking_mode;").fetchone()[0]
-    except Exception:
-        original["locking_mode"] = None
-    try:
-        original["foreign_keys"] = db.execute("PRAGMA foreign_keys;").fetchone()[0]
+        original["foreign_keys"] = conn.execute("PRAGMA foreign_keys;").fetchone()[0]
     except Exception:
         original["foreign_keys"] = None
-    try:
-        original["busy_timeout"] = db.execute("PRAGMA busy_timeout;").fetchone()[0]
-    except Exception:
-        original["busy_timeout"] = None
-    try:
-        original["mmap_size"] = db.execute("PRAGMA mmap_size;").fetchone()[0]
-    except Exception:
-        original["mmap_size"] = None
 
-    db.execute("PRAGMA journal_mode=WAL;")
-    db.execute("PRAGMA synchronous=OFF;")
-    db.execute("PRAGMA temp_store=MEMORY;")
-    db.execute("PRAGMA cache_size=-60000;")
-    db.execute("PRAGMA locking_mode=EXCLUSIVE;")
-    db.execute("PRAGMA foreign_keys=OFF;")
-    db.execute("PRAGMA busy_timeout=2000;")
-    db.execute("PRAGMA mmap_size=268435456;")
-
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.execute("PRAGMA synchronous=NORMAL;")
+    conn.execute("PRAGMA temp_store=MEMORY;")
+    conn.execute("PRAGMA foreign_keys=OFF;")
     return original
 
 
-def _restore_pragmas(db, original) -> None:
-    if not original:
-        return
+def _restore_pragmas(conn, original: dict[str, object]) -> None:
+    jm = original.get("journal_mode")
+    if jm and str(jm).upper() != "WAL":
+        conn.execute(f"PRAGMA journal_mode={jm};")
+    else:
+        conn.execute("PRAGMA journal_mode=WAL;")
+
+    sync = original.get("synchronous")
+    if sync is not None:
+        conn.execute(f"PRAGMA synchronous={sync};")
+
+    temp_store = original.get("temp_store")
+    if temp_store is not None:
+        conn.execute(f"PRAGMA temp_store={temp_store};")
+
+    fk = original.get("foreign_keys")
+    if fk in (0, 1):
+        conn.execute(f"PRAGMA foreign_keys={'ON' if fk else 'OFF'};")
+    else:
+        conn.execute("PRAGMA foreign_keys=ON;")
+
+
+def _import_rows(rows: Sequence[tuple], status_cb) -> int:
+    total = len(rows)
+    status_cb(total=total)
+
+    conn = get_db()
+    _ensure_products_schema(conn)
+    _ensure_unique_index(conn)
+
+    original_pragmas = _apply_pragmas(conn)
     try:
-        jm = original.get("journal_mode")
-        if jm:
-            db.execute(f"PRAGMA journal_mode={jm};")
-    except Exception:
-        pass
-    try:
-        sync = original.get("synchronous")
-        if sync is not None:
-            db.execute(f"PRAGMA synchronous={sync};")
-    except Exception:
-        pass
-    try:
-        temp_store = original.get("temp_store")
-        if temp_store is not None:
-            db.execute(f"PRAGMA temp_store={temp_store};")
-    except Exception:
-        pass
-    try:
-        cache_size = original.get("cache_size")
-        if cache_size is not None:
-            db.execute(f"PRAGMA cache_size={cache_size};")
-    except Exception:
-        pass
-    try:
-        locking_mode = original.get("locking_mode")
-        if locking_mode:
-            db.execute(f"PRAGMA locking_mode={locking_mode};")
-    except Exception:
-        pass
-    try:
-        fk = original.get("foreign_keys")
-        if fk is not None:
-            db.execute(f"PRAGMA foreign_keys={'ON' if fk else 'OFF'};")
-    except Exception:
-        pass
-    try:
-        busy = original.get("busy_timeout")
-        if busy is not None:
-            db.execute(f"PRAGMA busy_timeout={int(busy)};")
-    except Exception:
-        pass
-    try:
-        mmap = original.get("mmap_size")
-        if mmap is not None:
-            db.execute(f"PRAGMA mmap_size={int(mmap)};")
-    except Exception:
-        pass
+        rows_imported = 0
+        with conn:
+            cursor = conn.cursor()
+            try:
+                if rows:
+                    status_cb(stage="db_bulk_insert", done=0, total=total)
+                    cursor.executemany(UPSERT_SQL, rows)
+                    rows_imported = total
+                status_cb(
+                    stage="db_bulk_insert",
+                    done=rows_imported,
+                    total=total,
+                    imported=rows_imported,
+                )
+            finally:
+                cursor.close()
+    finally:
+        _restore_pragmas(conn, original_pragmas)
+
+    return total
 
 
-STAGING_SCHEMA = """
-CREATE TEMP TABLE IF NOT EXISTS staging_products (
-  id INTEGER PRIMARY KEY,
-  name TEXT, category_path TEXT, price REAL, rating REAL,
-  units_sold REAL, revenue REAL, conversion_rate REAL,
-  launch_date TEXT, date_range TEXT,
-  desire_magnitude TEXT, awareness_level TEXT, competition_level TEXT,
-  winner_score INTEGER, image_url TEXT, desire TEXT
-);
-DELETE FROM staging_products;
-"""
-
-
-UPSERT_DIRECT = """
-INSERT INTO products (
-  id, name, category_path, price, rating, units_sold, revenue,
-  conversion_rate, launch_date, date_range, desire_magnitude,
-  awareness_level, competition_level, winner_score, image_url, desire
-) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-ON CONFLICT(id) DO UPDATE SET
-  name=excluded.name,
-  category_path=excluded.category_path,
-  price=excluded.price,
-  rating=excluded.rating,
-  units_sold=excluded.units_sold,
-  revenue=excluded.revenue,
-  conversion_rate=excluded.conversion_rate,
-  launch_date=excluded.launch_date,
-  date_range=excluded.date_range,
-  desire_magnitude=excluded.desire_magnitude,
-  awareness_level=excluded.awareness_level,
-  competition_level=excluded.competition_level,
-  winner_score=COALESCE(excluded.winner_score, products.winner_score),
-  image_url=excluded.image_url,
-  desire=COALESCE(excluded.desire, products.desire);
-"""
-
-
-UPSERT_FROM_STAGING = """
-INSERT INTO products (
-  id, name, category_path, price, rating, units_sold, revenue,
-  conversion_rate, launch_date, date_range, desire_magnitude,
-  awareness_level, competition_level, winner_score, image_url, desire
-)
-SELECT
-  id, name, category_path, price, rating, units_sold, revenue,
-  conversion_rate, launch_date, date_range, desire_magnitude,
-  awareness_level, competition_level, winner_score, image_url, desire
-FROM staging_products
-ON CONFLICT(id) DO UPDATE SET
-  name=excluded.name,
-  category_path=excluded.category_path,
-  price=excluded.price,
-  rating=excluded.rating,
-  units_sold=excluded.units_sold,
-  revenue=excluded.revenue,
-  conversion_rate=excluded.conversion_rate,
-  launch_date=excluded.launch_date,
-  date_range=excluded.date_range,
-  desire_magnitude=excluded.desire_magnitude,
-  awareness_level=excluded.awareness_level,
-  competition_level=excluded.competition_level,
-  winner_score=COALESCE(excluded.winner_score, products.winner_score),
-  image_url=excluded.image_url,
-  desire=COALESCE(excluded.desire, products.desire);
-"""
-
-
-_BATCH_SIZE = 8000
-
-
-def _should_use_staging(n_rows_est: int, current_rows: int) -> bool:
-    if n_rows_est <= 0:
-        return False
-    if n_rows_est >= 1000:
-        return True
-    if n_rows_est < 200:
-        return False
-    base = max(current_rows, 1)
-    relative = n_rows_est / base
-    return relative > 0.03
-
-
-def _import_rows(
-    db,
-    rows: Iterator[tuple],
-    total_est: int,
-    status_cb,
-    use_staging: bool,
-    t0: float,
-):
-    total_hint = int(total_est or 0)
-    if total_hint < 0:
-        total_hint = 0
-    done = 0
-    actual_total = total_hint
-
-    def update_progress(stage: str | None = None, final: bool = False) -> None:
-        nonlocal actual_total
-        actual_total = max(actual_total, done)
-        payload = {"done": done, "total": actual_total}
-        if stage is not None:
-            payload["stage"] = stage
-        if final:
-            payload["imported"] = done
-        status_cb(**payload)
-
-    t_parse = time.time()
-    db.execute("BEGIN IMMEDIATE;")
-    try:
-        if use_staging:
-            db.executescript(STAGING_SCHEMA)
-            insert_staging = (
-                "INSERT INTO staging_products "
-                "(id,name,category_path,price,rating,units_sold,revenue,conversion_rate,"
-                "launch_date,date_range,desire_magnitude,awareness_level,competition_level,"
-                "winner_score,image_url,desire) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);"
-            )
-            batch = []
-            for row in rows:
-                batch.append(row)
-                if len(batch) >= _BATCH_SIZE:
-                    db.executemany(insert_staging, batch)
-                    done += len(batch)
-                    batch.clear()
-                    update_progress("staging")
-            if batch:
-                db.executemany(insert_staging, batch)
-                done += len(batch)
-                batch.clear()
-                update_progress("staging")
-
-            idx, trg = _snapshot_and_drop(db, "products")
-            t_staging = time.time()
-
-            db.execute("SAVEPOINT upsert_bulk;")
-            db.execute(UPSERT_FROM_STAGING)
-            db.execute("RELEASE upsert_bulk;")
-            t_upsert = time.time()
-            update_progress("upsert")
-
-            db.execute("COMMIT;")
-            t_commit = time.time()
-            update_progress("done", final=True)
-
-            status_cb(
-                t_parse=_round_ms(t_parse - t0),
-                t_staging=_round_ms(t_staging - t_parse),
-                t_upsert=_round_ms(t_upsert - t_staging),
-                t_commit=_round_ms(t_commit - t_upsert),
-            )
-
-            idx = list(idx or [])
-            trg = list(trg or [])
-            already = False
-
-            def optimize():
-                nonlocal already
-                if already:
-                    return
-                already = True
-                if idx or trg:
-                    db.execute("BEGIN;")
-                    try:
-                        _recreate(db, idx)
-                        _recreate(db, trg)
-                        db.execute("COMMIT;")
-                    except Exception:
-                        db.execute("ROLLBACK;")
-                        raise
-                db.execute("ANALYZE products;")
-
-            optimize.rows_imported = done
-            optimize.use_staging = True
-            return optimize
-
-        cur = db.cursor()
-        try:
-            batch = []
-            for row in rows:
-                batch.append(row)
-                if len(batch) >= _BATCH_SIZE:
-                    cur.executemany(UPSERT_DIRECT, batch)
-                    done += len(batch)
-                    batch.clear()
-                    update_progress("upsert")
-            if batch:
-                cur.executemany(UPSERT_DIRECT, batch)
-                done += len(batch)
-                batch.clear()
-                update_progress("upsert")
-        finally:
-            cur.close()
-
-        t_upsert = time.time()
-        db.execute("COMMIT;")
-        t_commit = time.time()
-        update_progress("done", final=True)
-
-        status_cb(
-            t_parse=_round_ms(t_parse - t0),
-            t_staging=0,
-            t_upsert=_round_ms(t_upsert - t_parse),
-            t_commit=_round_ms(t_commit - t_upsert),
-        )
-
-        already = False
-
-        def optimize():
-            nonlocal already
-            if already:
-                return
-            already = True
-
-        optimize.rows_imported = done
-        optimize.use_staging = False
-        return optimize
-
-    except Exception:
-        db.execute("ROLLBACK;")
-        raise
-
-
-def fast_import_adaptive(csv_bytes: bytes, status_cb=lambda **k: None):
-    """Import CSV data using an adaptive strategy.
-
-    Returns a callable ``optimize()`` that performs heavy post-processing
-    (index/trigger recreation and ANALYZE). Callers may execute the returned
-    callable in a background thread to keep the UI responsive.
-    """
-
+def fast_import_adaptive(csv_bytes: bytes, status_cb=lambda **_: None):
     if not isinstance(csv_bytes, (bytes, bytearray)):
         csv_bytes = bytes(csv_bytes)
 
-    db = get_db()
-    t0 = time.time()
-    n_rows_est = _count_lines(csv_bytes)
-    status_cb(total=n_rows_est)
+    rows = _rows_from_csv(csv_bytes)
+    rows_imported = _import_rows(rows, status_cb)
 
-    try:
-        cur_count = db.execute("SELECT COUNT(*) FROM products;").fetchone()[0]
-    except Exception:
-        cur_count = 0
+    def _optimize():
+        return None
 
-    use_staging = _should_use_staging(n_rows_est, cur_count)
-    pragmas = _push_pragmas(db)
-    optimize = None
-    try:
-        optimize = _import_rows(
-            db,
-            _rows_from_csv(csv_bytes),
-            n_rows_est,
-            status_cb,
-            use_staging,
-            t0,
-        )
-    finally:
-        _restore_pragmas(db, pragmas)
-
-    if optimize is None:
-        def _noop():
-            return None
-
-        _noop.rows_imported = 0
-        _noop.use_staging = False
-        optimize = _noop
-
-    return optimize
+    _optimize.rows_imported = rows_imported  # type: ignore[attr-defined]
+    return _optimize
 
 
-def fast_import(csv_bytes, status_cb=lambda **k: None, source=None):
+def fast_import(csv_bytes, status_cb=lambda **_: None, source=None):
     optimize = fast_import_adaptive(csv_bytes, status_cb=status_cb)
     try:
         optimize()
@@ -533,41 +386,9 @@ def fast_import(csv_bytes, status_cb=lambda **k: None, source=None):
     return int(getattr(optimize, "rows_imported", 0) or 0)
 
 
-def fast_import_records(records, status_cb=lambda **k: None, source=None):
+def fast_import_records(records: Iterable[Mapping[str, object]], status_cb=lambda **_: None, source=None):
     if not isinstance(records, Sequence):
         records = list(records)
-    total = len(records)
-    status_cb(total=total)
+    rows = _prepare_rows(records)
+    return _import_rows(rows, status_cb)
 
-    db = get_db()
-    t0 = time.time()
-    try:
-        cur_count = db.execute("SELECT COUNT(*) FROM products;").fetchone()[0]
-    except Exception:
-        cur_count = 0
-
-    use_staging = _should_use_staging(total, cur_count)
-    pragmas = _push_pragmas(db)
-    optimize = None
-    try:
-        optimize = _import_rows(
-            db,
-            _rows_from_records(records),
-            total,
-            status_cb,
-            use_staging,
-            t0,
-        )
-    finally:
-        _restore_pragmas(db, pragmas)
-
-    if optimize is None:
-        def _noop():
-            return None
-
-        _noop.rows_imported = 0
-        _noop.use_staging = False
-        optimize = _noop
-
-    optimize()
-    return int(getattr(optimize, "rows_imported", 0) or 0)

--- a/product_research_app/utils/timing.py
+++ b/product_research_app/utils/timing.py
@@ -1,0 +1,31 @@
+"""Timing utilities for coarse-grained profiling."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+from typing import Dict, Iterator
+
+_LOGGER = logging.getLogger("product_research_app.timing")
+
+
+@contextlib.contextmanager
+def phase(name: str) -> Iterator[Dict[str, int]]:
+    """Measure the duration of a logical phase.
+
+    The context manager logs the start and end of the phase and exposes the
+    measured duration in milliseconds via the yielded mapping.  The mapping is
+    mutated in-place when the context exits so callers can inspect ``["ms"]``
+    afterwards.
+    """
+
+    start = time.perf_counter()
+    payload: Dict[str, int] = {"name": name, "ms": 0}
+    _LOGGER.info("phase_start %s", name)
+    try:
+        yield payload
+    finally:
+        elapsed_ms = int(round((time.perf_counter() - start) * 1000))
+        payload["ms"] = elapsed_ms
+        _LOGGER.info("phase_end %s %sms", name, elapsed_ms)


### PR DESCRIPTION
## Summary
- ensure the products table exposes the expected columns and a unique index while defining the dedicated upsert SQL
- parse incoming CSV records into deduplicated tuples that feed a single executemany bulk upsert under tuned pragmas
- keep the adaptive importer API while restoring database pragmas after the import completes

## Testing
- pytest product_research_app/tests

------
https://chatgpt.com/codex/tasks/task_e_68c9ae6cc3388328b77e234af6600f19