### PR TITLE
refactor: queue post-import AI tasks

### DIFF
--- a/product_research_app/services/importer_unified.py
+++ b/product_research_app/services/importer_unified.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import pandas as pd
+
+from . import importer_fast
+
+StatusCallback = Callable[..., None]
+
+
+def _safe_emit(cb: StatusCallback, **kwargs: Any) -> None:
+    try:
+        cb(**kwargs)
+    except Exception:
+        # Status callbacks must never break the import flow.
+        pass
+
+
+def import_csv(bytes_data: bytes, *, source: str, status_cb: StatusCallback) -> List[Dict[str, Any]]:
+    """Parse CSV bytes into a list of dictionaries."""
+    _safe_emit(status_cb, stage="parse_csv", done=0, total=0)
+    text = bytes_data.decode("utf-8", errors="ignore")
+    reader = csv.DictReader(io.StringIO(text))
+    records: List[Dict[str, Any]] = []
+    for idx, row in enumerate(reader, start=1):
+        records.append(dict(row))
+        if idx % 500 == 0:
+            _safe_emit(status_cb, stage="parse_csv", done=idx, total=0)
+    total = len(records)
+    _safe_emit(status_cb, stage="parse_csv", done=total, total=total)
+    return records
+
+
+def import_xlsx(bytes_data: bytes, *, source: str, status_cb: StatusCallback) -> List[Dict[str, Any]]:
+    """Parse XLSX bytes into a list of dictionaries using pandas."""
+    _safe_emit(status_cb, stage="parse_xlsx", done=0, total=0)
+    df = pd.read_excel(io.BytesIO(bytes_data), dtype=str)
+    if df.empty:
+        _safe_emit(status_cb, stage="parse_xlsx", done=0, total=0)
+        return []
+    df = df.where(pd.notnull(df), None)
+    records_raw = df.to_dict("records")
+    total = len(records_raw)
+    records: List[Dict[str, Any]] = []
+    for idx, row in enumerate(records_raw, start=1):
+        records.append(dict(row))
+        if idx % 500 == 0 or idx == total:
+            _safe_emit(status_cb, stage="parse_xlsx", done=idx, total=total)
+    if total == 0:
+        _safe_emit(status_cb, stage="parse_xlsx", done=0, total=0)
+    return records
+
+
+def import_records(records: List[Dict[str, Any]], *, status_cb: StatusCallback) -> int:
+    """Bulk insert the prepared records using the fast importer."""
+
+    def _wrapped_status_cb(**kwargs: Any) -> None:
+        stage = kwargs.get("stage")
+        if stage == "prepare":
+            kwargs["stage"] = "db_bulk_prepare"
+        elif stage == "insert":
+            kwargs["stage"] = "db_bulk_insert"
+        elif stage == "commit":
+            kwargs["stage"] = "db_bulk_commit"
+        _safe_emit(status_cb, **kwargs)
+
+    return importer_fast.fast_import_records(records, status_cb=_wrapped_status_cb)
+
+
+def run_import(
+    file_bytes: bytes,
+    filename: str,
+    status_cb: StatusCallback,
+    *,
+    import_token: Optional[str] = None,
+) -> int:
+    """Dispatch CSV/XLSX imports and return the number of inserted rows."""
+    ext = Path(filename).suffix.lower()
+    source = filename
+    if ext == ".csv":
+        records = import_csv(file_bytes, source=source, status_cb=status_cb)
+    elif ext in {".xlsx", ".xls"}:
+        records = import_xlsx(file_bytes, source=source, status_cb=status_cb)
+    else:
+        raise ValueError(f"Unsupported file type: {ext}")
+
+    for record in records:
+        record.setdefault("winner_score", "0")
+        if source:
+            record.setdefault("source", source)
+        if import_token:
+            # The token is stored temporarily in ``extra`` so we can collect the
+            # product IDs that were upserted during this batch without running
+            # any synchronous GPT work.  See ``consume_import_token`` in the
+            # database layer for cleanup.
+            record.setdefault("_import_token", import_token)
+
+    if not records:
+        return 0
+
+    return import_records(records, status_cb=status_cb)
+
+
+__all__ = [
+    "import_csv",
+    "import_xlsx",
+    "import_records",
+    "run_import",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4
 Pillow
 openpyxl
+pandas

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,11 @@
+# Scripts y utilidades
+
+## Importador unificado
+
+El endpoint `/upload` ahora acepta archivos `.csv` y `.xlsx` con el mismo flujo rápido:
+
+- Los Excel se leen con `pandas` y se convierten a registros en memoria.
+- Los datos se insertan en bloque mediante `importer_fast.fast_import_records`.
+- El progreso reporta etapas como `parse_xlsx` y `db_bulk_insert` para que la barra avance.
+
+No se lanzan tareas de IA ni de scoring durante la importación masiva; solo se cargan los registros. Usa el estatus (`task_id`) que devuelve `/upload` para seguir el avance desde el frontend.


### PR DESCRIPTION
## Summary
- introduce an `ai_task_queue` table and helper functions to collect product ids per import token, dedupe enqueue requests, and track pending AI work
- update the unified importer and `/upload` handler to tag batch inserts with import tokens, push post-import AI tasks to the queue, and move GPT work off the upload thread
- add `/api/ai/run_post_import` to drain queued desire/imputation tasks via the GPT orchestrator and expand the flow tests to cover queue dedupe and endpoint behavior

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9cfc7b17883289872b6c8f7947124