### PR TITLE
feat: run post import AI tasks automatically

### DIFF
--- a/product_research_app/services/importer_unified.py
+++ b/product_research_app/services/importer_unified.py
@@ -5,7 +5,10 @@ import io
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-import pandas as pd
+try:  # pragma: no cover - optional dependency
+    import pandas as pd
+except Exception:  # pragma: no cover - gracefully handle missing pandas
+    pd = None  # type: ignore[assignment]
 
 from . import importer_fast
 
@@ -37,6 +40,9 @@ def import_csv(bytes_data: bytes, *, source: str, status_cb: StatusCallback) -> 
 
 def import_xlsx(bytes_data: bytes, *, source: str, status_cb: StatusCallback) -> List[Dict[str, Any]]:
     """Parse XLSX bytes into a list of dictionaries using pandas."""
+    if pd is None:
+        _safe_emit(status_cb, stage="parse_xlsx", done=0, total=0)
+        raise RuntimeError("pandas is required for XLSX imports")
     _safe_emit(status_cb, stage="parse_xlsx", done=0, total=0)
     df = pd.read_excel(io.BytesIO(bytes_data), dtype=str)
     if df.empty:

--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -37,6 +37,28 @@ def setup_env(tmp_path, monkeypatch):
 
     monkeypatch.setattr(db, "get_db", _fake_get_db)
     monkeypatch.setattr(importer_fast, "get_db", _fake_get_db)
+
+    def _fake_import_xlsx(bytes_data, *, source, status_cb):
+        from openpyxl import load_workbook
+
+        status_cb(stage="parse_xlsx", done=0, total=0)
+        wb = load_workbook(io.BytesIO(bytes_data), read_only=True)
+        ws = wb.active
+        rows = list(ws.iter_rows(values_only=True))
+        if not rows:
+            status_cb(stage="parse_xlsx", done=0, total=0)
+            return []
+        headers = [str(h) for h in rows[0]]
+        records = []
+        for idx, row in enumerate(rows[1:], start=1):
+            rec = {headers[i]: row[i] for i in range(len(headers))}
+            records.append(rec)
+            if idx % 500 == 0:
+                status_cb(stage="parse_xlsx", done=idx, total=len(rows) - 1)
+        status_cb(stage="parse_xlsx", done=len(records), total=len(records))
+        return records
+
+    monkeypatch.setattr(importer_unified, "import_xlsx", _fake_import_xlsx)
     return conn
 
 def make_xlsx(path: Path, rows: List[List[object]]):
@@ -189,6 +211,87 @@ def test_handle_ai_run_post_import(tmp_path, monkeypatch):
     prod_a = row_to_dict(database.get_product(conn, pid_a))
     assert prod_a.get("desire") == f"Desire {pid_a}"
     assert prod_a.get("desire_magnitude") == "High"
+
+
+def test_run_post_import_auto(tmp_path, monkeypatch):
+    conn = setup_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(config, "get_api_key", lambda: "sk-test")
+    monkeypatch.setattr(config, "get_model", lambda: "gpt-test")
+
+    pid_a = database.insert_product(
+        conn,
+        name="ProdA",
+        description="",
+        category="Home",
+        price=10.0,
+        currency="USD",
+        image_url="",
+        source="",
+        extra={"rating": 4.2},
+        product_id=1,
+    )
+    pid_b = database.insert_product(
+        conn,
+        name="ProdB",
+        description="",
+        category="Kitchen",
+        price=20.0,
+        currency="USD",
+        image_url="",
+        source="",
+        extra={"rating": 3.5},
+        product_id=2,
+    )
+
+    def fake_generate_batch_columns(api_key, model, items):
+        ok = {
+            str(item["id"]): {
+                "desire": f"Auto Desire {item['id']}",
+                "desire_magnitude": "High",
+                "awareness_level": "Most Aware",
+                "competition_level": "Low",
+            }
+            for item in items
+        }
+        return ok, {}, {"total_tokens": 0}, 0.1
+
+    winner_calls = []
+
+    def fake_generate_winner_scores(conn_arg, product_ids=None, weights=None, debug=False):
+        ids = list(product_ids or [])
+        winner_calls.append(ids)
+        return {"processed": len(ids), "updated": len(ids)}
+
+    monkeypatch.setattr(gpt, "generate_batch_columns", fake_generate_batch_columns)
+    monkeypatch.setattr(winner_score, "generate_winner_scores", fake_generate_winner_scores)
+
+    task_id = "task-auto"
+    web_app._update_import_status(
+        task_id,
+        state="RUNNING",
+        stage="ai_post",
+        post_import_ready=True,
+        ai_progress=web_app._empty_ai_progress(),
+    )
+
+    web_app._run_post_import_auto(task_id, [pid_a, pid_b])
+
+    status = web_app._get_import_status(task_id)
+    assert status["state"] == "DONE"
+    assert status["stage"] == "done"
+    assert status["post_import_ready"] is False
+    progress = status["ai_progress"]
+    assert progress["desire"]["processed"] == 2
+    assert progress["imputacion"]["processed"] == 2
+    assert progress["winner_score"]["processed"] == 2
+
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM ai_task_queue WHERE state='done'")
+    assert cur.fetchone()[0] == 6
+
+    prod_a = row_to_dict(database.get_product(conn, pid_a))
+    assert prod_a.get("desire") == f"Auto Desire {pid_a}"
+    assert winner_calls and set(winner_calls[0]) == {pid_a, pid_b}
 
 def test_scoring_v2_generate_cases(tmp_path, monkeypatch):
     conn = setup_env(tmp_path, monkeypatch)


### PR DESCRIPTION
## Summary
- trigger post-import AI tasks automatically once the bulk importer finishes and track progress in import status responses
- add helpers to normalize AI progress, drain the task queue per import in the background, and expose queue state via `_import_status`
- add database helper for per-import AI queue lookups, make pandas optional for XLSX parsing, and extend tests for the automated workflow

## Testing
- pytest product_research_app/tests/test_app_flow.py


------
https://chatgpt.com/codex/tasks/task_e_68c9e161ce6083289697c037506e277e