### PR TITLE
feat: auto-adjust winner score weights with aggregates

### DIFF
--- a/product_research_app/ai/__init__.py
+++ b/product_research_app/ai/__init__.py
@@ -1,0 +1,5 @@
+"""AI utilities for Product Research Copilot."""
+
+__all__ = [
+    "runner",
+]

--- a/product_research_app/ai/runner.py
+++ b/product_research_app/ai/runner.py
@@ -1,0 +1,491 @@
+"""Background runner for post-import AI tasks.
+
+This module drains the ``ai_task_queue`` table in batches, executing the
+configured AI tasks while keeping concurrency under control.  The execution
+prioritises cheap operations (``desire`` first, then ``imputacion`` and finally
+``winner_score``) and reports progress back to interested listeners so the
+frontend can reflect real-time status updates.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import logging
+import threading
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Dict, List, Mapping, Optional, Sequence
+
+from .. import config, database, gpt
+from ..services import aggregates as aggregates_service
+from ..services import config as winner_config
+from ..services import winner_score
+from ..utils.db import row_to_dict, rget
+
+logger = logging.getLogger(__name__)
+
+APP_DIR = Path(__file__).resolve().parents[1]
+DB_PATH = APP_DIR / "data.sqlite3"
+
+_TASK_ORDER: Sequence[str] = ("desire", "imputacion", "winner_score")
+_GPT_TASKS = {"desire", "imputacion"}
+_MAX_ATTEMPTS = 3  # first run + 2 retries
+_GPT_CALL_SEMAPHORE = threading.Semaphore(3)
+
+_ProgressCallback = Callable[[str, str, Mapping[str, int]], None]
+_PROGRESS_CALLBACKS: Dict[str, _ProgressCallback] = {}
+_PROGRESS_LOCK = threading.Lock()
+
+
+@dataclass
+class _BatchResult:
+    task_type: str
+    processed: Dict[str, int] = field(default_factory=dict)
+    failed: Dict[str, int] = field(default_factory=dict)
+    errors: Dict[str, List[str]] = field(default_factory=dict)
+
+
+@dataclass
+class _RunnerContext:
+    api_key: Optional[str]
+    model: Optional[str]
+    include_image: bool
+    max_attempts: int
+    winner_weights_ready: bool = False
+    winner_weights_lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+def register_progress_callback(import_task_id: str, callback: Optional[_ProgressCallback]) -> None:
+    """Register or remove a progress callback for an import."""
+
+    key = str(import_task_id or "")
+    with _PROGRESS_LOCK:
+        if callback is None:
+            _PROGRESS_CALLBACKS.pop(key, None)
+        else:
+            _PROGRESS_CALLBACKS[key] = callback
+
+
+def unregister_progress_callback(import_task_id: str) -> None:
+    register_progress_callback(import_task_id, None)
+
+
+def _notify_progress(import_task_id: str, task_type: str, payload: Mapping[str, int]) -> None:
+    with _PROGRESS_LOCK:
+        callback = _PROGRESS_CALLBACKS.get(str(import_task_id or ""))
+    if callback is None:
+        return
+    try:
+        callback(str(import_task_id or ""), task_type, dict(payload))
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Progress callback failed: import=%s", import_task_id)
+
+
+def run_auto(tasks: set[str], *, batch_size: int = 200, max_parallel: int = 3) -> Dict[str, Dict[str, object]]:
+    """Drain ``ai_task_queue`` executing the requested task types."""
+
+    ordered_tasks = [name for name in _TASK_ORDER if name in tasks]
+    if not ordered_tasks:
+        return {}
+
+    try:
+        batch_size = int(batch_size)
+    except Exception:
+        batch_size = 200
+    batch_size = max(1, min(batch_size, 200))
+
+    try:
+        max_parallel = int(max_parallel)
+    except Exception:
+        max_parallel = 3
+    max_parallel = max(1, min(max_parallel, 8))
+
+    api_key = config.get_api_key() or None
+    model = config.get_model() or "gpt-4o-mini"
+    include_image = config.include_image_in_ai()
+
+    context = _RunnerContext(api_key=api_key, model=model, include_image=include_image, max_attempts=_MAX_ATTEMPTS)
+
+    progress: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(lambda: {name: {"requested": 0, "processed": 0, "failed": 0} for name in _TASK_ORDER})
+    errors: Dict[str, List[str]] = defaultdict(list)
+    seen_task_ids: set[int] = set()
+
+    conn = database.get_connection(DB_PATH)
+    database.initialize_database(conn)
+
+    try:
+        for task_type in ordered_tasks:
+            while True:
+                pending = database.fetch_pending_ai_tasks(
+                    conn,
+                    task_types=[task_type],
+                    limit=batch_size * max_parallel,
+                )
+                if not pending:
+                    break
+
+                if task_type in _GPT_TASKS and (not context.api_key or not context.model):
+                    logger.warning("AI runner skipping %s tasks due to missing API configuration", task_type)
+
+                task_ids = [int(row["id"]) for row in pending]
+                database.mark_ai_tasks_in_progress(conn, task_ids)
+
+                batches: List[List[Mapping[str, object]]] = []
+                current: List[Mapping[str, object]] = []
+                for row in pending:
+                    row_dict = dict(row)
+                    import_id = str(row_dict.get("import_task_id") or "")
+                    entry = progress[import_id][task_type]
+                    task_id = int(row_dict["id"])
+                    if task_id not in seen_task_ids:
+                        seen_task_ids.add(task_id)
+                        entry["requested"] += 1
+                    current.append(row_dict)
+                    if len(current) >= batch_size:
+                        batches.append(current)
+                        current = []
+                if current:
+                    batches.append(current)
+
+                if not batches:
+                    continue
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers=max_parallel) as executor:
+                    futures = [executor.submit(_process_batch, task_type, batch, context) for batch in batches]
+                    for future in concurrent.futures.as_completed(futures):
+                        result = future.result()
+                        for import_id, value in result.processed.items():
+                            progress[import_id][task_type]["processed"] += int(value)
+                        for import_id, value in result.failed.items():
+                            progress[import_id][task_type]["failed"] += int(value)
+                        for import_id, msgs in result.errors.items():
+                            if msgs:
+                                errors[import_id].extend(msgs)
+                        touched = set(result.processed.keys()) | set(result.failed.keys())
+                        for import_id in touched:
+                            _notify_progress(import_id, task_type, progress[import_id][task_type])
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    summary: Dict[str, Dict[str, object]] = {}
+    for import_id, task_map in progress.items():
+        has_activity = any(
+            entry["requested"] or entry["processed"] or entry["failed"]
+            for entry in task_map.values()
+        )
+        if not has_activity:
+            continue
+        summary[import_id] = {
+            "tasks": {name: dict(vals) for name, vals in task_map.items()},
+            "errors": list(errors.get(import_id, [])),
+        }
+    return summary
+
+
+def _process_batch(task_type: str, rows: Sequence[Mapping[str, object]], context: _RunnerContext) -> _BatchResult:
+    if task_type in _GPT_TASKS:
+        return _process_columns_batch(task_type, rows, context)
+    if task_type == "winner_score":
+        return _process_winner_batch(rows, context)
+    logger.warning("Unknown AI task type encountered: %s", task_type)
+    return _BatchResult(task_type=task_type)
+
+
+def _process_columns_batch(task_type: str, rows: Sequence[Mapping[str, object]], context: _RunnerContext) -> _BatchResult:
+    result = _BatchResult(task_type=task_type)
+    conn = database.get_connection(DB_PATH)
+    try:
+        product_ids = [int(row["product_id"]) for row in rows if row.get("product_id") is not None]
+        if not product_ids:
+            return _record_batch_failure(
+                conn,
+                rows,
+                result,
+                reason="missing_products",
+                allow_retry=False,
+                context=context,
+            )
+
+        products = database.get_products_by_ids(conn, product_ids)
+        if not products:
+            return _record_batch_failure(
+                conn,
+                rows,
+                result,
+                reason="missing_products",
+                allow_retry=False,
+                context=context,
+            )
+
+        items = _build_product_payloads(products, include_image=context.include_image)
+        if not items:
+            return _record_batch_failure(
+                conn,
+                rows,
+                result,
+                reason="missing_payload",
+                allow_retry=False,
+                context=context,
+            )
+
+        if not context.api_key or not context.model:
+            return _record_batch_failure(
+                conn,
+                rows,
+                result,
+                reason="openai_unavailable",
+                allow_retry=False,
+                context=context,
+            )
+
+        try:
+            with _GPT_CALL_SEMAPHORE:
+                ok_map, _, _, _ = gpt.generate_batch_columns(context.api_key, context.model, items)
+        except gpt.InvalidJSONError:
+            logger.warning("GPT returned invalid JSON for task=%s batch=%s", task_type, [row.get("id") for row in rows])
+            return _record_batch_failure(
+                conn,
+                rows,
+                result,
+                reason="invalid_json",
+                allow_retry=True,
+                context=context,
+            )
+        except Exception as exc:  # pragma: no cover - network guarded
+            message = str(exc) or exc.__class__.__name__
+            logger.error("GPT batch failed task=%s error=%s", task_type, message)
+            return _record_batch_failure(
+                conn,
+                rows,
+                result,
+                reason=message,
+                allow_retry=True,
+                context=context,
+            )
+
+        updated = False
+        missing_rows: List[Mapping[str, object]] = []
+        for row in rows:
+            pid = int(row.get("product_id"))
+            import_id = str(row.get("import_task_id") or "")
+            entry = ok_map.get(str(pid))
+            if entry:
+                updates = {
+                    "desire": entry.get("desire"),
+                    "desire_magnitude": entry.get("desire_magnitude"),
+                    "awareness_level": entry.get("awareness_level"),
+                    "competition_level": entry.get("competition_level"),
+                    "ai_columns_completed_at": datetime.utcnow().isoformat(),
+                }
+                clean_updates = {k: v for k, v in updates.items() if v not in (None, "")}
+                if clean_updates:
+                    database.update_product(conn, pid, **clean_updates)
+                    updated = True
+                result.processed[import_id] = result.processed.get(import_id, 0) + 1
+            else:
+                missing_rows.append(row)
+
+        if updated:
+            conn.commit()
+
+        if missing_rows:
+            result = _record_batch_failure(
+                conn,
+                missing_rows,
+                result,
+                reason="missing_result",
+                allow_retry=True,
+                context=context,
+            )
+
+        missing_ids = {int(r.get("id")) for r in missing_rows}
+        completed_ids = [int(row.get("id")) for row in rows if int(row.get("id")) not in missing_ids]
+        if completed_ids:
+            database.complete_ai_tasks(conn, completed_ids)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    return result
+
+
+def _process_winner_batch(rows: Sequence[Mapping[str, object]], context: _RunnerContext) -> _BatchResult:
+    result = _BatchResult(task_type="winner_score")
+    conn = database.get_connection(DB_PATH)
+    try:
+        product_ids = [int(row["product_id"]) for row in rows if row.get("product_id") is not None]
+        if not product_ids:
+            return _record_batch_failure(
+                conn,
+                rows,
+                result,
+                reason="missing_products",
+                allow_retry=False,
+                context=context,
+            )
+        weights = _ensure_winner_weights(conn, product_ids, context)
+        try:
+            winner_score.generate_winner_scores(conn, product_ids=product_ids, weights=weights)
+            task_ids = [int(row["id"]) for row in rows]
+            database.complete_ai_tasks(conn, task_ids)
+            for row in rows:
+                import_id = str(row.get("import_task_id") or "")
+                result.processed[import_id] = result.processed.get(import_id, 0) + 1
+        except Exception as exc:
+            message = str(exc) or "winner_score_error"
+            result = _record_batch_failure(
+                conn,
+                rows,
+                result,
+                reason=message,
+                allow_retry=True,
+                context=context,
+            )
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    return result
+
+
+def _ensure_winner_weights(
+    conn,
+    product_ids: Sequence[int],
+    context: _RunnerContext,
+) -> Optional[Dict[str, int]]:
+    """Ensure Winner Score weights are ready, optionally auto-adjusting them."""
+
+    with context.winner_weights_lock:
+        if context.winner_weights_ready:
+            return winner_config.get_winner_weights_raw()
+
+        cfg = config.load_config()
+        auto_adjust = bool(cfg.get("auto_adjust_weights", True))
+        existing = cfg.get("winner_weights")
+        has_existing = isinstance(existing, dict) and bool(existing)
+
+        if has_existing and not auto_adjust:
+            context.winner_weights_ready = True
+            return winner_config.get_winner_weights_raw()
+
+        if not product_ids:
+            context.winner_weights_ready = True
+            return winner_config.get_winner_weights_raw()
+
+        if not auto_adjust:
+            context.winner_weights_ready = True
+            return winner_config.get_winner_weights_raw()
+
+        if not context.api_key:
+            logger.info("Skipping winner weight auto-adjust: missing API credentials")
+            context.winner_weights_ready = True
+            return winner_config.get_winner_weights_raw()
+
+        aggregates = aggregates_service.compute_dataset_aggregates(
+            conn, scope_ids=product_ids
+        )
+        if not aggregates.get("total_products"):
+            context.winner_weights_ready = True
+            return winner_config.get_winner_weights_raw()
+
+        try:
+            with _GPT_CALL_SEMAPHORE:
+                suggestion = gpt.recommend_weights_from_aggregates(
+                    context.api_key,
+                    "gpt-4o",
+                    aggregates,
+                )
+        except Exception as exc:  # pragma: no cover - network guarded
+            logger.warning("Winner weight auto-adjust failed: %s", exc)
+            context.winner_weights_ready = True
+            return winner_config.get_winner_weights_raw()
+
+        weights = suggestion.get("weights") if isinstance(suggestion, dict) else None
+        order = suggestion.get("order") if isinstance(suggestion, dict) else None
+        if not isinstance(weights, dict) or not weights:
+            logger.info("Winner weight suggestion missing payload; keeping existing weights")
+            context.winner_weights_ready = True
+            return winner_config.get_winner_weights_raw()
+
+        try:
+            weights_final, _, _ = winner_config.update_winner_settings(
+                weights_in=weights,
+                order_in=order,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Persisting winner weight suggestion failed: %s", exc)
+            context.winner_weights_ready = True
+            return winner_config.get_winner_weights_raw()
+
+        context.winner_weights_ready = True
+        return weights_final
+
+
+def _record_batch_failure(
+    conn,
+    rows: Sequence[Mapping[str, object]],
+    result: _BatchResult,
+    *,
+    reason: str,
+    allow_retry: bool,
+    context: _RunnerContext,
+) -> _BatchResult:
+    task_ids_requeue: List[int] = []
+    task_ids_fail: List[int] = []
+    for row in rows:
+        task_id = int(row.get("id"))
+        import_id = str(row.get("import_task_id") or "")
+        result.failed[import_id] = result.failed.get(import_id, 0) + 1
+        if allow_retry and _should_retry(row, context.max_attempts):
+            task_ids_requeue.append(task_id)
+        else:
+            task_ids_fail.append(task_id)
+            result.errors.setdefault(import_id, []).append(reason)
+    if task_ids_requeue:
+        database.requeue_ai_tasks(conn, task_ids_requeue)
+    if task_ids_fail:
+        database.fail_ai_tasks(conn, task_ids_fail, reason[:512])
+    return result
+
+
+def _should_retry(row: Mapping[str, object], max_attempts: int) -> bool:
+    try:
+        attempts = int(row.get("attempts") or 0)
+    except Exception:
+        attempts = 0
+    return (attempts + 1) < max_attempts
+
+
+def _build_product_payloads(products: Sequence[Mapping[str, object]], *, include_image: bool) -> List[Dict[str, object]]:
+    items: List[Dict[str, object]] = []
+    for prod in products:
+        product = row_to_dict(prod)
+        try:
+            extra = json.loads(rget(product, "extra") or "{}")
+        except Exception:
+            extra = {}
+        item = {
+            "id": rget(product, "id"),
+            "name": rget(product, "name"),
+            "category": rget(product, "category"),
+            "price": rget(product, "price"),
+            "rating": extra.get("rating"),
+            "units_sold": extra.get("units_sold"),
+            "revenue": extra.get("revenue"),
+            "conversion_rate": extra.get("conversion_rate"),
+            "launch_date": extra.get("launch_date"),
+            "date_range": rget(product, "date_range") or extra.get("date_range"),
+            "image_url": rget(product, "image_url") or extra.get("image_url"),
+        }
+        if not include_image:
+            item.pop("image_url", None)
+        items.append(item)
+    return items

--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 
 DEFAULT_CONFIG: Dict[str, Any] = {
     "autoFillIAOnImport": True,
+    "auto_adjust_weights": True,
     "aiBatch": {
         "BATCH_SIZE": 10,
         "MAX_CONCURRENCY": 2,
@@ -242,7 +243,11 @@ def update_weight(key: str, value: float) -> None:
 
 def get_weights_version() -> int:
     cfg = load_config()
-    try:
-        return int(cfg.get("weightsUpdatedAt", 0))
-    except Exception:
-        return 0
+    for key in ("weightsVersion", "weightsUpdatedAt"):
+        try:
+            value = int(cfg.get(key, 0))
+            if value:
+                return value
+        except Exception:
+            continue
+    return 0

--- a/product_research_app/services/aggregates.py
+++ b/product_research_app/services/aggregates.py
@@ -1,0 +1,184 @@
+"""Utilities to compute aggregate statistics for imported products.
+
+This module exposes helpers that summarise the current dataset (or a
+restricted subset of products) so higher level services can build prompts
+for the AI orchestrator without iterating over every product on the Python
+side.  The output focuses on the metrics relevant for the automatic Winner
+Score calibration pipeline: price, rating, sales proxies, desire and
+competition labels as well as product "oldness" and awareness levels.
+
+All functions operate on a SQLite connection and avoid mutating the
+database.  Returned structures are plain dictionaries ready to be serialised
+as JSON.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from statistics import mean
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from .. import database
+from ..utils.db import row_to_dict
+from . import winner_score
+
+
+NumericMetric = Mapping[str, Any]
+
+
+def _load_extra(payload: Mapping[str, Any]) -> MutableMapping[str, Any]:
+    raw = payload.get("extra")
+    if isinstance(raw, dict):
+        return dict(raw)
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except Exception:
+        return {}
+
+
+def _to_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        if isinstance(value, str) and not value.strip():
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _normalise_label(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    return str(value).strip().lower() or "unknown"
+
+
+def _percentiles(values: Sequence[float]) -> Dict[str, float]:
+    if not values:
+        return {}
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        v = ordered[0]
+        return {"p05": v, "p25": v, "p50": v, "p75": v, "p95": v}
+
+    def pick(q: float) -> float:
+        idx = int(round((len(ordered) - 1) * q))
+        idx = max(0, min(len(ordered) - 1, idx))
+        return ordered[idx]
+
+    return {
+        "p05": pick(0.05),
+        "p25": pick(0.25),
+        "p50": pick(0.50),
+        "p75": pick(0.75),
+        "p95": pick(0.95),
+    }
+
+
+def _numeric_summary(values: Iterable[Optional[float]]) -> Dict[str, Any]:
+    cleaned = [float(v) for v in values if v is not None]
+    if not cleaned:
+        return {"count": 0}
+    stats = {
+        "count": len(cleaned),
+        "min": min(cleaned),
+        "max": max(cleaned),
+        "mean": mean(cleaned),
+    }
+    stats.update(_percentiles(cleaned))
+    return stats
+
+
+def _categorical_summary(values: Iterable[str]) -> Dict[str, Any]:
+    counter = Counter(_normalise_label(v) for v in values if v is not None)
+    total = sum(counter.values())
+    data = dict(counter)
+    data["count"] = total
+    return data
+
+
+def _extract_metrics(product: Mapping[str, Any]) -> Dict[str, Any]:
+    data = row_to_dict(product)
+    extra = _load_extra(data)
+    metrics: Dict[str, Any] = {}
+    metrics["price"] = _to_float(data.get("price") or extra.get("price"))
+    metrics["rating"] = _to_float(data.get("rating") or extra.get("rating"))
+    metrics["units_sold"] = _to_float(
+        extra.get("units_sold")
+        or extra.get("orders")
+        or extra.get("sales")
+    )
+    metrics["revenue"] = _to_float(extra.get("revenue") or extra.get("gmv"))
+
+    desire = data.get("desire") or data.get("desire_magnitude") or extra.get("desire")
+    if desire is None:
+        desire = extra.get("magnitud_deseo")
+    metrics["desire"] = _normalise_label(desire)
+
+    competition = data.get("competition_level") or extra.get("competition_level")
+    if competition is None:
+        competition = extra.get("saturacion_mercado")
+    metrics["competition"] = _normalise_label(competition)
+
+    awareness = (
+        data.get("awareness_level")
+        or extra.get("awareness_level")
+        or extra.get("nivel_consciencia")
+    )
+    metrics["awareness"] = _normalise_label(awareness)
+
+    merged = dict(data)
+    merged.update(extra)
+    metrics["oldness_days"] = winner_score._oldness_days(merged)  # type: ignore[attr-defined]
+    metrics["winner_score"] = _to_float(data.get("winner_score"))
+    metrics["conversion_rate"] = _to_float(extra.get("conversion_rate"))
+    metrics["profit_margin"] = _to_float(extra.get("profit_margin"))
+    return metrics
+
+
+def compute_dataset_aggregates(
+    conn,
+    *,
+    scope_ids: Optional[Iterable[Any]] = None,
+) -> Dict[str, Any]:
+    """Return aggregated statistics for the given set of products."""
+
+    rows: List[Mapping[str, Any]]
+    if scope_ids:
+        unique_ids = [int(r) for r in dict.fromkeys(scope_ids) if str(r).strip()]
+        if not unique_ids:
+            rows = []
+        else:
+            rows = database.get_products_by_ids(conn, unique_ids)
+    else:
+        rows = database.list_products(conn)
+
+    metrics = [_extract_metrics(row) for row in rows]
+    summary = {
+        "total_products": len(metrics),
+        "numeric": {
+            "price": _numeric_summary(m.get("price") for m in metrics),
+            "rating": _numeric_summary(m.get("rating") for m in metrics),
+            "units_sold": _numeric_summary(m.get("units_sold") for m in metrics),
+            "revenue": _numeric_summary(m.get("revenue") for m in metrics),
+            "oldness_days": _numeric_summary(m.get("oldness_days") for m in metrics),
+            "winner_score": _numeric_summary(m.get("winner_score") for m in metrics),
+            "conversion_rate": _numeric_summary(m.get("conversion_rate") for m in metrics),
+            "profit_margin": _numeric_summary(m.get("profit_margin") for m in metrics),
+        },
+        "categorical": {
+            "desire": _categorical_summary(m.get("desire") for m in metrics),
+            "competition": _categorical_summary(m.get("competition") for m in metrics),
+            "awareness": _categorical_summary(m.get("awareness") for m in metrics),
+        },
+    }
+    if scope_ids:
+        summary["scope_ids"] = list(dict.fromkeys(scope_ids))
+    return summary
+
+
+__all__ = ["compute_dataset_aggregates"]
+

--- a/product_research_app/services/config.py
+++ b/product_research_app/services/config.py
@@ -78,6 +78,9 @@ def init_app_config() -> None:
     if "weightsUpdatedAt" not in cfg:
         cfg["weightsUpdatedAt"] = int(time.time())
         changed = True
+    if "weightsVersion" not in cfg:
+        cfg["weightsVersion"] = 0
+        changed = True
     if changed:
         save_config(cfg)
 
@@ -134,6 +137,7 @@ def update_winner_settings(
     cfg["weights_order"] = order
     cfg["weights_enabled"] = enabled
     cfg["weightsUpdatedAt"] = int(time.time())
+    cfg["weightsVersion"] = int(cfg.get("weightsVersion", 0)) + 1
     save_config(cfg)
     return weights, order, enabled
 

--- a/product_research_app/services/importer_unified.py
+++ b/product_research_app/services/importer_unified.py
@@ -5,7 +5,10 @@ import io
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-import pandas as pd
+try:  # pragma: no cover - optional dependency
+    import pandas as pd
+except Exception:  # pragma: no cover - gracefully handle missing pandas
+    pd = None  # type: ignore[assignment]
 
 from . import importer_fast
 
@@ -37,6 +40,9 @@ def import_csv(bytes_data: bytes, *, source: str, status_cb: StatusCallback) -> 
 
 def import_xlsx(bytes_data: bytes, *, source: str, status_cb: StatusCallback) -> List[Dict[str, Any]]:
     """Parse XLSX bytes into a list of dictionaries using pandas."""
+    if pd is None:
+        _safe_emit(status_cb, stage="parse_xlsx", done=0, total=0)
+        raise RuntimeError("pandas is required for XLSX imports")
     _safe_emit(status_cb, stage="parse_xlsx", done=0, total=0)
     df = pd.read_excel(io.BytesIO(bytes_data), dtype=str)
     if df.empty:


### PR DESCRIPTION
## Summary
- add a dataset aggregates service plus a GPT helper to request winner-score weight profiles based on the current import scope
- update the AI runner to auto-adjust winner weights once per run, persist the version/timestamp in config, and reuse the calibrated weights during batch scoring
- extend configuration defaults and tests to cover the new winner-score pipeline and progress reporting

## Testing
- pytest product_research_app/tests/test_app_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e161ce6083289697c037506e277e