### PR TITLE
Summarize weight payloads before hitting GPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Product Research App
+
+Esta aplicación permite analizar catálogos de productos y coordinar tareas con modelos de OpenAI.
+
+## Variables de entorno
+
+Configura estas variables para ajustar el comportamiento del orquestador de GPT:
+
+- `OPENAI_API_KEY`: clave de OpenAI utilizada por defecto para todas las llamadas.
+- `MAX_ITEMS` (por defecto `300`): tamaño máximo de lote al enviar productos al modelo en tareas de consulta y tendencias. Para imputación y desire se limita automáticamente a bloques de 100 elementos.
+- `GPT_TIMEOUT` (por defecto `60` segundos): tiempo máximo de espera para las llamadas a la API de OpenAI.
+- `GPT_MODEL_A` a `GPT_MODEL_E`: permiten sobreescribir los modelos por defecto utilizados en las tareas `consulta`, `pesos`, `tendencias`, `imputacion` y `desire` respectivamente.
+
+Coloca estas variables en tu entorno o en el archivo de configuración según tus necesidades.

--- a/product_research_app/ai/__init__.py
+++ b/product_research_app/ai/__init__.py
@@ -1,0 +1,5 @@
+"""AI orchestration helpers."""
+
+from .gpt_orchestrator import run_task
+
+__all__ = ["run_task"]

--- a/product_research_app/ai/gpt_orchestrator.py
+++ b/product_research_app/ai/gpt_orchestrator.py
@@ -1,0 +1,628 @@
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import re
+from typing import Any, Dict, Iterable, List, Literal, Optional, Sequence, Tuple
+
+import requests
+
+try:  # pragma: no cover - defensive when services package is unavailable
+    from product_research_app.services.aggregates import (
+        build_weighting_aggregates,
+        sample_product_titles,
+    )
+except Exception:  # pragma: no cover
+    build_weighting_aggregates = None
+    sample_product_titles = None
+
+logger = logging.getLogger(__name__)
+
+CHAT_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"
+SYSTEM_PROMPT = (
+    "Eres un analista experto que trabaja con grandes listados de productos. "
+    "Debes entregar conclusiones claras y siempre terminar con un bloque JSON "
+    "dentro de triple acento grave que incluya la clave obligatoria 'prompt_version'."
+)
+JSON_BLOCK_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+
+_TaskName = Literal["consulta", "pesos", "tendencias", "imputacion", "desire"]
+
+_TASK_MODEL_MAP: Dict[_TaskName, Tuple[str, str]] = {
+    "consulta": ("A", "gpt-4o-mini"),
+    "pesos": ("B", "gpt-4o"),
+    "tendencias": ("C", "gpt-4o-mini"),
+    "imputacion": ("D", "gpt-4o-mini"),
+    "desire": ("E", "gpt-4o-mini"),
+}
+
+
+def run_task(
+    task: _TaskName,
+    *,
+    prompt_text: str,
+    json_payload: Optional[Dict[str, Any]],
+    model_hint: Optional[str] = None,
+    system_prompt: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Execute an AI task orchestrating chunking and response parsing."""
+
+    if task not in _TASK_MODEL_MAP:
+        raise ValueError(f"Unknown task '{task}'")
+
+    model = _resolve_model(task, model_hint)
+    api_key = _resolve_api_key()
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is not configured")
+
+    max_items = _get_max_items()
+    timeout = _get_timeout()
+
+    payload = dict(json_payload) if isinstance(json_payload, dict) else {}
+    products = payload.get("products") if isinstance(payload.get("products"), list) else None
+
+    warnings: List[str] = []
+    text_parts: List[str] = []
+    combined_json: Dict[str, Any] = {}
+    result_map: Dict[str, Any] = {}
+    prompt_versions: List[str] = []
+
+    call_count = 0
+    chunk_sizes: List[int] = []
+    estimated_tokens = 0.0
+
+    chosen_system_prompt = system_prompt.strip() if isinstance(system_prompt, str) and system_prompt.strip() else SYSTEM_PROMPT
+
+    if task == "pesos":
+        context, original_count = _prepare_weights_context(payload)
+        prompt = _build_prompt(prompt_text, context)
+        response = _call_openai(model, prompt, api_key, timeout, chosen_system_prompt)
+        call_count += 1
+        chunk_sizes.append(original_count)
+        content = response["content"]
+        estimated_tokens += _estimate_tokens(prompt, content, response.get("usage"))
+        text, data, chunk_warnings = _parse_model_response(content)
+        warnings.extend(chunk_warnings)
+        if text:
+            text_parts.append(text)
+        if data:
+            combined_json = data
+            pv = data.get("prompt_version")
+            if isinstance(pv, str):
+                prompt_versions.append(pv)
+        ok = bool(data) and not chunk_warnings
+    else:
+        if not products:
+            chunks = [None]
+        else:
+            if task in {"imputacion", "desire"}:
+                chunk_size = max(1, min(max_items, 100))
+            else:
+                chunk_size = max(1, max_items)
+            chunks = list(_chunk_sequence(products, chunk_size))
+        if not chunks:
+            chunks = [None]
+
+        ok = True
+        for chunk in chunks:
+            context = dict(payload)
+            if chunk is not None:
+                context["products"] = chunk
+                chunk_sizes.append(len(chunk))
+            elif products:
+                # this happens when we have products but chunking returned nothing
+                chunk_sizes.append(0)
+            else:
+                chunk_sizes.append(0)
+            prompt = _build_prompt(prompt_text, context)
+            response = _call_openai(model, prompt, api_key, timeout, chosen_system_prompt)
+            call_count += 1
+            content = response["content"]
+            estimated_tokens += _estimate_tokens(prompt, content, response.get("usage"))
+            text, data, chunk_warnings = _parse_model_response(content)
+            warnings.extend(chunk_warnings)
+            if text:
+                text_parts.append(text)
+            if not data:
+                ok = False
+                continue
+            pv = data.get("prompt_version")
+            if isinstance(pv, str):
+                prompt_versions.append(pv)
+
+            if task in {"consulta", "tendencias"}:
+                combined_json = _merge_chunk_data(combined_json, data)
+            elif task in {"imputacion", "desire"}:
+                mapping = _extract_mapping(data)
+                if mapping:
+                    result_map.update(mapping)
+                else:
+                    ok = False
+                combined_json = {"prompt_version": pv} if pv else {}
+            else:
+                combined_json = data
+
+            if chunk_warnings:
+                ok = False
+
+    if task in {"imputacion", "desire"}:
+        if prompt_versions:
+            combined_json["prompt_version"] = prompt_versions[-1]
+        combined_json["results"] = result_map
+        ok = ok and bool(result_map)
+
+    if task in {"consulta", "tendencias"} and prompt_versions:
+        combined_json["prompt_version"] = prompt_versions[-1]
+
+    meta = {
+        "calls": call_count or len(chunk_sizes),
+        "chunks": len(chunk_sizes),
+        "chunk_sizes": chunk_sizes,
+        "estimated_tokens": int(round(estimated_tokens)),
+        "model": model,
+    }
+
+    logger.info(
+        "gpt_orchestrator %s",
+        json.dumps(
+            {
+                "task": task,
+                "model": model,
+                "calls": meta["calls"],
+                "chunks": meta["chunks"],
+                "tokens": meta["estimated_tokens"],
+            },
+            ensure_ascii=False,
+        ),
+    )
+
+    return {
+        "ok": ok,
+        "task": task,
+        "model": model,
+        "text": "\n\n".join(p for p in text_parts if p).strip() or None,
+        "data": combined_json or None,
+        "warnings": warnings,
+        "meta": meta,
+    }
+
+
+def _resolve_model(task: _TaskName, model_hint: Optional[str]) -> str:
+    letter, default_model = _TASK_MODEL_MAP[task]
+    if model_hint:
+        return model_hint
+    env_model = os.environ.get(f"GPT_MODEL_{letter}")
+    return env_model or default_model
+
+
+def _resolve_api_key() -> Optional[str]:
+    key = os.environ.get("OPENAI_API_KEY")
+    if key:
+        return key
+    try:
+        from product_research_app import config
+    except Exception:  # pragma: no cover - fallback when config is unavailable
+        return None
+    return config.get_api_key()
+
+
+def _get_max_items() -> int:
+    try:
+        from product_research_app import config
+    except Exception:  # pragma: no cover - fallback when config import fails
+        return _DEFAULT_MAX_ITEMS
+    return config.get_env_max_items(_DEFAULT_MAX_ITEMS)
+
+
+def _get_timeout() -> float:
+    try:
+        from product_research_app import config
+    except Exception:  # pragma: no cover - fallback when config import fails
+        return _DEFAULT_TIMEOUT
+    return config.get_gpt_timeout_seconds(_DEFAULT_TIMEOUT)
+
+
+_DEFAULT_MAX_ITEMS = 300
+_DEFAULT_TIMEOUT = 60.0
+
+
+def _prepare_weights_context(payload: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
+    context = dict(payload)
+    raw_products = payload.get("products")
+    product_list: List[Dict[str, Any]]
+    if isinstance(raw_products, list):
+        product_list = [item for item in raw_products if isinstance(item, dict)]
+    else:
+        product_list = []
+    product_count = len(product_list)
+
+    aggregates_payload = None
+    sample_titles: List[str] = []
+
+    if isinstance(raw_products, dict):
+        aggregates_payload = _normalise_aggregates(raw_products)
+        sample_titles = _normalise_titles(raw_products.get("sample_titles"))
+    elif product_list:
+        aggregates_payload = _build_weighting_aggregates_from_list(product_list)
+        sample_titles = _derive_sample_titles(product_list)
+
+    context.pop("products", None)
+
+    if aggregates_payload is None:
+        candidate = context.pop("aggregates", None)
+        aggregates_payload = _normalise_aggregates(candidate)
+
+    if aggregates_payload is None and product_list:
+        aggregates_payload = _build_weighting_aggregates_from_list(product_list)
+    if aggregates_payload is None:
+        aggregates_payload = {"metrics": {}, "total_products": product_count}
+
+    if not sample_titles:
+        sample_titles = _normalise_titles(context.get("sample_titles"))
+        if not sample_titles:
+            sample_titles = _derive_sample_titles(product_list)
+
+    if sample_titles:
+        context["sample_titles"] = sample_titles
+    else:
+        context.pop("sample_titles", None)
+
+    context["aggregates"] = aggregates_payload
+
+    if not product_count and isinstance(aggregates_payload, dict):
+        total_hint = aggregates_payload.get("total_products") or aggregates_payload.get("total_items")
+        if isinstance(total_hint, (int, float)):
+            product_count = int(total_hint)
+
+    return context, product_count
+
+
+def _normalise_aggregates(candidate: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(candidate, dict):
+        return None
+    if isinstance(candidate.get("aggregates"), dict):
+        return dict(candidate["aggregates"])
+    if isinstance(candidate.get("summary_stats"), dict):
+        return dict(candidate["summary_stats"])
+    metrics = candidate.get("metrics")
+    if isinstance(metrics, dict):
+        result = dict(candidate)
+        result["metrics"] = dict(metrics)
+        return result
+    return None
+
+
+def _normalise_titles(raw_titles: Any, limit: int = 20) -> List[str]:
+    if not isinstance(raw_titles, Iterable) or isinstance(raw_titles, (str, bytes)):
+        return []
+    cleaned: List[str] = []
+    seen = set()
+    for title in raw_titles:
+        if not isinstance(title, str):
+            continue
+        trimmed = title.strip()
+        if not trimmed or trimmed in seen:
+            continue
+        cleaned.append(trimmed)
+        seen.add(trimmed)
+        if len(cleaned) >= limit:
+            break
+    return cleaned
+
+
+def _derive_sample_titles(products: Sequence[Dict[str, Any]], limit: int = 20) -> List[str]:
+    if not products:
+        return []
+    if sample_product_titles is not None:
+        return sample_product_titles(list(products), limit=limit)
+    return _legacy_sample_titles(products, limit=limit)
+
+
+def _legacy_sample_titles(products: Sequence[Dict[str, Any]], limit: int = 20) -> List[str]:
+    if limit <= 0:
+        return []
+    titles: List[str] = []
+    seen = set()
+    for product in products:
+        if not isinstance(product, dict):
+            continue
+        title = product.get("title")
+        if not isinstance(title, str):
+            continue
+        trimmed = title.strip()
+        if not trimmed or trimmed in seen:
+            continue
+        titles.append(trimmed)
+        seen.add(trimmed)
+
+    if len(titles) <= limit:
+        return titles
+
+    if limit == 1:
+        return titles[:1]
+
+    span = len(titles) - 1
+    indices = []
+    for i in range(limit):
+        idx = round(i * span / (limit - 1))
+        if idx not in indices:
+            indices.append(idx)
+    selected = [titles[idx] for idx in indices]
+    for title in titles:
+        if len(selected) >= limit:
+            break
+        if title not in selected:
+            selected.append(title)
+    return selected[:limit]
+
+
+def _build_weighting_aggregates_from_list(products: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    if build_weighting_aggregates is not None:
+        return build_weighting_aggregates(list(products))
+    return _summarise_products_for_weights(products)
+
+
+def _chunk_sequence(seq: Sequence[Any], chunk_size: int) -> Iterable[List[Any]]:
+    for idx in range(0, len(seq), chunk_size):
+        yield list(seq[idx : idx + chunk_size])
+
+
+def _build_prompt(prompt_text: str, context: Optional[Dict[str, Any]]) -> str:
+    prompt = prompt_text.strip()
+    if context:
+        prompt += "\n\n### CONTEXTO JSON\n"
+        prompt += json.dumps(context, ensure_ascii=False)
+    prompt += (
+        "\n\n### INSTRUCCIONES DE FORMATO\n"
+        "Responde en español y finaliza siempre con un bloque ```json"  # noqa: B950
+        "\n{...}\n``` que incluya la clave 'prompt_version'."
+    )
+    return prompt
+
+
+def _call_openai(
+    model: str,
+    prompt: str,
+    api_key: str,
+    timeout: float,
+    system_prompt: str,
+) -> Dict[str, Any]:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt or SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0.2,
+    }
+    try:
+        response = requests.post(
+            CHAT_COMPLETIONS_URL,
+            headers=headers,
+            json=body,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        raise RuntimeError(f"OpenAI request failed: {exc}") from exc
+
+    choices = payload.get("choices")
+    if not choices:  # pragma: no cover - defensive
+        raise RuntimeError("OpenAI response missing choices")
+    message = choices[0].get("message") or {}
+    content = message.get("content")
+    if not isinstance(content, str):  # pragma: no cover - defensive
+        raise RuntimeError("OpenAI response missing content")
+
+    usage = None
+    usage_payload = payload.get("usage")
+    if isinstance(usage_payload, dict):
+        usage_val = usage_payload.get("total_tokens")
+        if isinstance(usage_val, (int, float)):
+            usage = float(usage_val)
+
+    return {"content": content, "usage": usage}
+
+
+def _parse_model_response(content: str) -> Tuple[str, Optional[Dict[str, Any]], List[str]]:
+    warnings: List[str] = []
+    match = JSON_BLOCK_RE.search(content)
+    data: Optional[Dict[str, Any]] = None
+    if not match:
+        warnings.append("Respuesta sin bloque JSON")
+        text = content.strip()
+        return text, None, warnings
+
+    json_text = match.group(1)
+    try:
+        parsed = json.loads(json_text)
+        if not isinstance(parsed, dict):
+            warnings.append("Bloque JSON no es un objeto")
+        else:
+            if "prompt_version" not in parsed:
+                warnings.append("JSON sin prompt_version")
+            data = parsed
+    except json.JSONDecodeError as exc:
+        warnings.append(f"JSON inválido: {exc}")
+
+    text = JSON_BLOCK_RE.sub("", content).strip()
+    return text, data, warnings
+
+
+def _merge_chunk_data(base: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[str, Any]:
+    if not base:
+        base = {}
+    if not isinstance(incoming, dict):
+        return base
+    refs = incoming.get("refs")
+    if isinstance(refs, list):
+        base_refs = base.get("refs")
+        if not isinstance(base_refs, list):
+            base_refs = []
+        base_refs = _merge_refs(base_refs, refs)
+        base["refs"] = base_refs
+    for key, value in incoming.items():
+        if key == "refs":
+            continue
+        base[key] = value
+    return base
+
+
+def _merge_refs(existing: List[Dict[str, Any]], new_refs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    seen = set()
+    merged: List[Dict[str, Any]] = []
+    for ref in existing + new_refs:
+        if not isinstance(ref, dict):
+            continue
+        ref_id = ref.get("id")
+        ref_cat = ref.get("category") or ref.get("categoria")
+        key = (str(ref_id) if ref_id is not None else None, str(ref_cat) if ref_cat is not None else None)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(ref)
+    return merged
+
+
+def _extract_mapping(data: Dict[str, Any]) -> Dict[str, Any]:
+    mapping: Dict[str, Any] = {}
+    if not isinstance(data, dict):
+        return mapping
+    if isinstance(data.get("results"), dict):
+        for key, value in data["results"].items():
+            mapping[str(key)] = value
+        return mapping
+    if isinstance(data.get("items"), list):
+        for entry in data["items"]:
+            if not isinstance(entry, dict):
+                continue
+            pid = entry.get("id") or entry.get("product_id") or entry.get("asin")
+            if pid is None:
+                continue
+            copy_entry = dict(entry)
+            copy_entry.pop("id", None)
+            copy_entry.pop("product_id", None)
+            mapping[str(pid)] = copy_entry
+        return mapping
+    for key, value in data.items():
+        if key == "prompt_version":
+            continue
+        mapping[str(key)] = value
+    return mapping
+
+
+def _summarise_products_for_weights(products: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    metric_values: Dict[str, List[Tuple[str, float]]] = {}
+    for item in products:
+        if not isinstance(item, dict):
+            continue
+        pid = _extract_product_id(item)
+        for metric, value in _gather_numeric_metrics(item).items():
+            metric_values.setdefault(metric, [])
+            metric_values[metric].append((pid, value))
+
+    summary: Dict[str, Any] = {"metrics": {}}
+    for metric, entries in metric_values.items():
+        values = [val for _, val in entries]
+        if not values:
+            continue
+        stats = _metric_summary(entries, values)
+        summary["metrics"][metric] = stats
+    summary["total_products"] = len(products)
+    return summary
+
+
+def _extract_product_id(item: Dict[str, Any]) -> str:
+    for key in ("id", "product_id", "asin", "sku", "code", "name"):
+        val = item.get(key)
+        if val not in (None, ""):
+            return str(val)
+    return ""
+
+
+def _gather_numeric_metrics(item: Dict[str, Any]) -> Dict[str, float]:
+    metrics: Dict[str, float] = {}
+    for key, value in item.items():
+        if isinstance(value, (int, float)):
+            metrics[key] = float(value)
+    nested = item.get("metrics")
+    if isinstance(nested, dict):
+        for key, value in nested.items():
+            if isinstance(value, (int, float)):
+                metrics[key] = float(value)
+    return metrics
+
+
+def _metric_summary(entries: List[Tuple[str, float]], values: List[float]) -> Dict[str, Any]:
+    values_sorted = sorted(values)
+    min_val = float(values_sorted[0])
+    max_val = float(values_sorted[-1])
+    mean_val = float(sum(values_sorted) / len(values_sorted))
+    p25 = float(_percentile(values_sorted, 0.25))
+    p50 = float(_percentile(values_sorted, 0.50))
+    p75 = float(_percentile(values_sorted, 0.75))
+    std_val = float(_stddev(values_sorted))
+
+    top_entries = [
+        {"id": str(pid), "value": val}
+        for pid, val in sorted(entries, key=lambda x: x[1], reverse=True)
+        if pid
+    ][:10]
+    bottom_entries = [
+        {"id": str(pid), "value": val}
+        for pid, val in sorted(entries, key=lambda x: x[1])
+        if pid
+    ][:10]
+
+    return {
+        "count": len(values_sorted),
+        "min": min_val,
+        "max": max_val,
+        "mean": mean_val,
+        "p25": p25,
+        "p50": p50,
+        "p75": p75,
+        "std": std_val,
+        "top": top_entries,
+        "bottom": bottom_entries,
+        "top_ids": [entry["id"] for entry in top_entries],
+        "bottom_ids": [entry["id"] for entry in bottom_entries],
+    }
+
+
+def _percentile(values: Sequence[float], pct: float) -> float:
+    if not values:
+        return math.nan
+    if len(values) == 1:
+        return float(values[0])
+    idx = (len(values) - 1) * pct
+    lower = math.floor(idx)
+    upper = math.ceil(idx)
+    if lower == upper:
+        return float(values[int(idx)])
+    lower_val = values[lower]
+    upper_val = values[upper]
+    return float(lower_val + (upper_val - lower_val) * (idx - lower))
+
+
+def _stddev(values: Sequence[float]) -> float:
+    n = len(values)
+    if n < 2:
+        return 0.0
+    mean_val = sum(values) / n
+    variance = sum((val - mean_val) ** 2 for val in values) / (n - 1)
+    return variance ** 0.5
+
+
+def _estimate_tokens(prompt: str, content: str, usage: Optional[float]) -> float:
+    if usage is not None:
+        return float(usage)
+    approx = (len(prompt) + len(content)) / 4.0
+    return max(1.0, approx)

--- a/product_research_app/ai/prompts/consulta.md
+++ b/product_research_app/ai/prompts/consulta.md
@@ -1,0 +1,8 @@
+Eres un analista senior de investigación de productos. Tienes acceso a listados extensos de productos publicitarios con métricas de rendimiento, descripciones y metadatos de campaña. Debes:
+
+1. Identificar los patrones más relevantes del conjunto recibido, comparando productos destacados y rezagados.
+2. Extraer aprendizajes accionables para marketing y crecimiento usando un tono profesional en español.
+3. Mantener siempre referencias claras a los productos que cites (id y categoría cuando exista).
+4. Finalizar la respuesta con una sección de conclusiones resumidas y preparar un bloque JSON con claves útiles para la aplicación cliente, obligatoriamente incluyendo `"prompt_version"`.
+
+Si la entrada contiene filtros o subconjuntos, respétalos sin inventar datos externos. Prioriza la precisión sobre la creatividad.

--- a/product_research_app/ai/prompts/desire.md
+++ b/product_research_app/ai/prompts/desire.md
@@ -1,0 +1,8 @@
+Eres un estratega de producto enfocado en estimar el nivel de deseo y atractivo comercial de anuncios. Tu análisis debe:
+
+- Evaluar cada producto a partir de sus métricas de performance, copy y señales competitivas.
+- Resumir por qué un producto resulta más o menos deseable para la audiencia objetivo.
+- Entregar recomendaciones prácticas para capitalizar los productos con mayor potencial.
+- Finalizar con un bloque JSON que represente `{id -> evaluacion}` e incluya siempre `"prompt_version"`.
+
+Trabaja únicamente con el conjunto proporcionado y evita introducir información externa.

--- a/product_research_app/ai/prompts/imputacion.md
+++ b/product_research_app/ai/prompts/imputacion.md
@@ -1,0 +1,8 @@
+Eres un asistente de datos responsable de imputar valores faltantes o inconsistentes para productos digitales. La información de entrada puede traer huecos; debes:
+
+- Revisar métricas clave por producto y proponer imputaciones plausibles basadas en señales similares del dataset.
+- Indicar para cada producto el razonamiento resumido detrás de la imputación.
+- Mantener el tono técnico y conciso en español.
+- Finalizar con un bloque JSON que contenga un mapeo `{id -> campos_imputados}` e incluya siempre `"prompt_version"`.
+
+Nunca inventes productos nuevos ni modifiques valores confiables presentes en el contexto.

--- a/product_research_app/ai/prompts/pesos.md
+++ b/product_research_app/ai/prompts/pesos.md
@@ -1,0 +1,9 @@
+Eres un consultor de analítica encargado de calibrar pesos de scoring para priorizar productos. Recibirás estadísticas agregadas (percentiles, top/bottom ids) de diversas métricas.
+
+Tu misión es:
+- Detectar sesgos o métricas dominantes y proponer ajustes equilibrados.
+- Justificar cada recomendación con base en los datos agregados disponibles.
+- Entregar pasos accionables para operadores que aplicarán los nuevos pesos.
+- Finalizar con un bloque JSON que detalle las recomendaciones numéricas y meta-información, incluyendo obligatoriamente `"prompt_version"`.
+
+No inventes datos adicionales; usa únicamente los agregados proporcionados.

--- a/product_research_app/ai/prompts/tendencias.md
+++ b/product_research_app/ai/prompts/tendencias.md
@@ -1,0 +1,8 @@
+Eres un especialista en inteligencia de mercado encargado de detectar tendencias en catálogos de productos publicitarios. Analiza la información proporcionada para:
+
+1. Reconocer señales crecientes o decrecientes (segmentos, creatividades, precios, formatos) dentro del rango temporal indicado.
+2. Identificar oportunidades accionables para marketing, diferenciando hallazgos rápidos vs. estratégicos.
+3. Referenciar explícitamente los productos y categorías que respalden cada observación.
+4. Terminar con un resumen ejecutivo y con un bloque JSON estructurado que incluya métricas clave y `"prompt_version"`.
+
+No generes datos externos ni extrapoles más allá del contexto entregado.

--- a/product_research_app/api/__init__.py
+++ b/product_research_app/api/__init__.py
@@ -4,6 +4,7 @@ app = Flask(__name__)
 
 # Import API modules which attach routes to ``app``.
 from . import config  # noqa: E402,F401
+from . import gpt_endpoints  # noqa: E402,F401
 
 # Log registered routes for easier debugging in start-up logs.
 for r in app.url_map.iter_rules():

--- a/product_research_app/api/gpt_endpoints.py
+++ b/product_research_app/api/gpt_endpoints.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+from flask import Blueprint, current_app, jsonify, request
+
+from . import app
+from product_research_app.ai import gpt_orchestrator
+from product_research_app.services.aggregates import (
+    build_weighting_aggregates,
+    sample_product_titles,
+)
+
+_GPT_API = Blueprint("gpt_api", __name__)
+
+_ALLOWED_PRODUCT_FIELDS = {
+    "price",
+    "rating",
+    "units_sold",
+    "revenue",
+    "desire",
+    "competition",
+    "oldness",
+    "awareness",
+    "category",
+    "title",
+    "description",
+    "id",
+    "dateAdded",
+    "store",
+}
+
+_DEFAULT_PROMPTS: Mapping[str, str] = {
+    "consulta": "Analiza el conjunto de productos y entrega hallazgos accionables.",
+    "pesos": "Revisa los agregados y sugiere cómo ajustar los pesos del scoring.",
+    "tendencias": "Identifica tendencias clave y oportunidades dentro del contexto.",
+    "imputacion": "Propón imputaciones plausibles para los campos faltantes.",
+    "desire": "Evalúa el nivel de deseo comercial de cada producto.",
+}
+
+_PROMPT_DIR = Path(__file__).resolve().parent.parent / "ai" / "prompts"
+_PROMPT_FILENAMES: Mapping[str, str] = {
+    "consulta": "consulta.md",
+    "pesos": "pesos.md",
+    "tendencias": "tendencias.md",
+    "imputacion": "imputacion.md",
+    "desire": "desire.md",
+}
+
+
+def _register_routes() -> None:
+    app.register_blueprint(_GPT_API, url_prefix="/api/gpt")
+
+
+def _handle_task(task: str) -> tuple[dict, int]:
+    body = request.get_json(force=True, silent=True)
+    if not isinstance(body, dict):
+        return {"ok": False, "error": "JSON inválido"}, 400
+
+    prompt_text = body.get("prompt_text")
+    if not isinstance(prompt_text, str) or not prompt_text.strip():
+        prompt_text = _DEFAULT_PROMPTS.get(task, "")
+    prompt_text = prompt_text.strip()
+
+    context_raw = body.get("context")
+    if not isinstance(context_raw, MutableMapping):
+        context_raw = {}
+
+    params_raw = body.get("params")
+    params: Dict[str, Any]
+    if isinstance(params_raw, MutableMapping):
+        params = dict(params_raw)
+    else:
+        params = {}
+
+    sanitized_context = _sanitize_context(context_raw)
+    payload = dict(sanitized_context)
+    if task == "pesos":
+        payload = _inject_weighting_summary(payload)
+    if params:
+        payload["params"] = params
+
+    result = gpt_orchestrator.run_task(
+        task, prompt_text=prompt_text, json_payload=payload, system_prompt=_get_system_prompt(task)
+    )
+
+    meta = result.get("meta") or {}
+    info = {
+        "task": task,
+        "items": len(sanitized_context.get("products") or []),
+        "group_id": sanitized_context.get("group_id"),
+        "time_window": sanitized_context.get("time_window"),
+        "chunks": meta.get("chunks"),
+        "model": result.get("model"),
+    }
+    current_app.logger.info("gpt_endpoint %s", json.dumps(info, ensure_ascii=False))
+
+    response = {
+        "ok": bool(result.get("ok")),
+        "text": result.get("text"),
+        "data": result.get("data"),
+        "warnings": result.get("warnings") or [],
+        "meta": meta,
+        "model": result.get("model"),
+    }
+    return response, 200
+
+
+def _normalize_group_id(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return cleaned or None
+    return str(value)
+
+
+def _sanitize_context(context: Mapping[str, Any]) -> Dict[str, Any]:
+    group_id_raw = context.get("group_id", context.get("groupId"))
+    group_id = _normalize_group_id(group_id_raw)
+    time_window = context.get("time_window")
+    if isinstance(time_window, str):
+        time_window = time_window.strip() or None
+    else:
+        time_window = None
+
+    visible_ids_raw = context.get("visible_ids", context.get("visibleIds"))
+    visible_ids: Optional[List[str]] = None
+    if isinstance(visible_ids_raw, Iterable) and not isinstance(visible_ids_raw, (str, bytes)):
+        tmp: List[str] = []
+        for item in visible_ids_raw:
+            if item in (None, ""):
+                continue
+            tmp.append(str(item))
+        visible_ids = tmp
+
+    products_raw = context.get("products")
+    sanitized_products: List[Dict[str, Any]] = []
+    if isinstance(products_raw, list):
+        for entry in products_raw:
+            if not isinstance(entry, MutableMapping):
+                continue
+            if group_id is not None:
+                entry_group = entry.get("group_id") or entry.get("groupId") or entry.get("group")
+                if _normalize_group_id(entry_group) != group_id:
+                    continue
+            sanitized = {}
+            for key in _ALLOWED_PRODUCT_FIELDS:
+                if key in entry:
+                    value = entry[key]
+                    if key == "id" and value not in (None, ""):
+                        sanitized[key] = str(value)
+                    else:
+                        sanitized[key] = value
+            if sanitized:
+                sanitized_products.append(sanitized)
+
+    sanitized_context: Dict[str, Any] = {
+        "group_id": group_id,
+        "time_window": time_window,
+        "products": sanitized_products,
+    }
+    if visible_ids is not None:
+        sanitized_context["visible_ids"] = visible_ids
+
+    return sanitized_context
+
+
+def _inject_weighting_summary(context: Dict[str, Any]) -> Dict[str, Any]:
+    products = context.get("products")
+    if not isinstance(products, list):
+        context["products"] = {"aggregates": {"metrics": {}, "total_products": 0}, "sample_titles": []}
+        return context
+
+    aggregates = build_weighting_aggregates(products)
+    titles = sample_product_titles(products, limit=20)
+    context["products"] = {"aggregates": aggregates, "sample_titles": titles}
+    return context
+
+
+@lru_cache(maxsize=None)
+def _get_system_prompt(task: str) -> str:
+    filename = _PROMPT_FILENAMES.get(task)
+    if not filename:
+        return gpt_orchestrator.SYSTEM_PROMPT
+    path = _PROMPT_DIR / filename
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        current_app.logger.warning("prompt_template_missing task=%s path=%s", task, path)
+        return gpt_orchestrator.SYSTEM_PROMPT
+    cleaned = text.strip()
+    return cleaned or gpt_orchestrator.SYSTEM_PROMPT
+
+
+@_GPT_API.route("/consulta", methods=["POST"])
+def consulta_endpoint():
+    payload, status = _handle_task("consulta")
+    return jsonify(payload), status
+
+
+@_GPT_API.route("/pesos", methods=["POST"])
+def pesos_endpoint():
+    payload, status = _handle_task("pesos")
+    return jsonify(payload), status
+
+
+@_GPT_API.route("/tendencias", methods=["POST"])
+def tendencias_endpoint():
+    payload, status = _handle_task("tendencias")
+    return jsonify(payload), status
+
+
+@_GPT_API.route("/imputacion", methods=["POST"])
+def imputacion_endpoint():
+    payload, status = _handle_task("imputacion")
+    return jsonify(payload), status
+
+
+@_GPT_API.route("/desire", methods=["POST"])
+def desire_endpoint():
+    payload, status = _handle_task("desire")
+    return jsonify(payload), status
+
+
+_register_routes()

--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -7,6 +7,7 @@ file. If the file does not exist, default values are returned.
 """
 
 import json
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -122,6 +123,9 @@ def _merge_defaults(dst: Dict[str, Any], src: Dict[str, Any]) -> bool:
 def get_api_key() -> Optional[str]:
     """Return the stored OpenAI API key if present."""
 
+    env_key = os.environ.get("OPENAI_API_KEY")
+    if env_key:
+        return env_key
     config = load_config()
     return config.get("api_key")
 
@@ -193,6 +197,32 @@ def get_ai_image_cost_max_usd() -> float:
         return float(cfg.get("aiImageCostMaxUSD", 0.02))
     except Exception:
         return 0.02
+
+
+def get_env_max_items(default: int = 300) -> int:
+    """Return MAX_ITEMS override from environment or a default."""
+
+    value = os.environ.get("MAX_ITEMS")
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def get_gpt_timeout_seconds(default: float = 60.0) -> float:
+    """Return GPT timeout (seconds) from environment or default."""
+
+    value = os.environ.get("GPT_TIMEOUT")
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
 
 
 SCORING_DEFAULT_WEIGHTS: Dict[str, float] = {

--- a/product_research_app/services/aggregates.py
+++ b/product_research_app/services/aggregates.py
@@ -1,0 +1,170 @@
+"""Utilities for building aggregate statistics over product datasets."""
+from __future__ import annotations
+
+import math
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+
+MetricEntry = Tuple[str, float]
+
+
+def build_weighting_aggregates(products: List[dict]) -> Dict[str, dict]:
+    """Return aggregate statistics for each numeric metric in ``products``.
+
+    The result maps every metric name to a dictionary containing descriptive
+    statistics plus identifiers of the top and bottom performers. Only numeric
+    values (``int`` or ``float``) are considered for aggregation and coverage
+    ratios are expressed as values between 0.0 and 1.0.
+    """
+
+    metrics: Dict[str, List[MetricEntry]] = {}
+    total_products = len(products)
+
+    for product in products:
+        if not isinstance(product, dict):
+            continue
+        product_id = _coerce_id(product.get("id"))
+        for key, value in product.items():
+            if _is_numeric(value):
+                metrics.setdefault(key, []).append((product_id, float(value)))
+        nested = product.get("metrics")
+        if isinstance(nested, dict):
+            for key, value in nested.items():
+                if _is_numeric(value):
+                    metrics.setdefault(key, []).append((product_id, float(value)))
+
+    aggregates: Dict[str, dict] = {}
+    for metric, entries in metrics.items():
+        values = [value for _, value in entries]
+        if not values:
+            continue
+        aggregates[metric] = _summarise_metric(entries, values, total_products)
+
+    return {"metrics": aggregates, "total_products": total_products}
+
+
+def sample_product_titles(products: List[dict], limit: int = 20) -> List[str]:
+    """Return up to ``limit`` unique product titles distributed across the list."""
+
+    if limit <= 0:
+        return []
+
+    unique_titles: List[str] = []
+    seen = set()
+    for product in products:
+        if not isinstance(product, dict):
+            continue
+        title = product.get("title")
+        if not isinstance(title, str):
+            continue
+        cleaned = title.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        unique_titles.append(cleaned)
+        seen.add(cleaned)
+
+    if len(unique_titles) <= limit:
+        return unique_titles
+
+    if limit == 1:
+        return unique_titles[:1]
+
+    span = len(unique_titles) - 1
+    step_positions = [round(i * span / (limit - 1)) for i in range(limit)]
+
+    selected: List[str] = []
+    used_positions = set()
+    for pos in step_positions:
+        if pos in used_positions:
+            continue
+        selected.append(unique_titles[pos])
+        used_positions.add(pos)
+
+    if len(selected) < limit:
+        for title in unique_titles:
+            if title in selected:
+                continue
+            selected.append(title)
+            if len(selected) >= limit:
+                break
+
+    return selected[:limit]
+
+
+def _coerce_id(value: object) -> str:
+    if value in (None, ""):
+        return ""
+    return str(value)
+
+
+def _is_numeric(value: object) -> bool:
+    return isinstance(value, (int, float)) and math.isfinite(value)
+
+
+def _summarise_metric(entries: Sequence[MetricEntry], values: Sequence[float], total: int) -> dict:
+    values_sorted = sorted(values)
+    count = len(values_sorted)
+    coverage = (count / total) if total else 0.0
+
+    min_val = float(values_sorted[0])
+    max_val = float(values_sorted[-1])
+    mean_val = float(sum(values_sorted) / count)
+    p25 = float(_percentile(values_sorted, 0.25))
+    median = float(_percentile(values_sorted, 0.50))
+    p75 = float(_percentile(values_sorted, 0.75))
+    std_val = float(_stddev(values_sorted))
+
+    top_ids = _rank_ids(entries, reverse=True)
+    bottom_ids = _rank_ids(entries, reverse=False)
+
+    return {
+        "min": min_val,
+        "p25": p25,
+        "median": median,
+        "p75": p75,
+        "max": max_val,
+        "mean": mean_val,
+        "std": std_val,
+        "top_ids": top_ids,
+        "bottom_ids": bottom_ids,
+        "coverage": coverage,
+    }
+
+
+def _percentile(values: Sequence[float], pct: float) -> float:
+    if not values:
+        return math.nan
+    if len(values) == 1:
+        return float(values[0])
+    idx = (len(values) - 1) * pct
+    lower = math.floor(idx)
+    upper = math.ceil(idx)
+    if lower == upper:
+        return float(values[int(idx)])
+    lower_val = values[lower]
+    upper_val = values[upper]
+    return float(lower_val + (upper_val - lower_val) * (idx - lower))
+
+
+def _stddev(values: Sequence[float]) -> float:
+    n = len(values)
+    if n < 2:
+        return 0.0
+    mean_val = sum(values) / n
+    variance = sum((val - mean_val) ** 2 for val in values) / (n - 1)
+    return float(math.sqrt(variance))
+
+
+def _rank_ids(entries: Iterable[MetricEntry], *, reverse: bool) -> List[str]:
+    ranked: List[str] = []
+    seen = set()
+    for product_id, _ in sorted(entries, key=lambda item: item[1], reverse=reverse):
+        if not product_id:
+            continue
+        if product_id in seen:
+            continue
+        ranked.append(product_id)
+        seen.add(product_id)
+        if len(ranked) >= 10:
+            break
+    return ranked

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -33,6 +33,267 @@ body.dark {
   --bar-btn-focus: #3A6FD8;
 }
 
+#gptActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-top: 8px;
+}
+
+#gptActions button {
+  flex-shrink: 0;
+}
+
+.gpt-panel {
+  margin-top: 10px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 10px;
+  padding: 12px;
+  color: #1a1b2e;
+}
+
+body.dark .gpt-panel {
+  background: #0f1224;
+  border-color: #2f355c;
+  color: #f4f6ff;
+}
+
+.gpt-panel.hidden {
+  display: none;
+}
+
+.gpt-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.gpt-panel-header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.gpt-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  border-radius: 999px;
+  background: #f7c655;
+  color: #1a1b2e;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-weight: 600;
+}
+
+body.dark .gpt-chip {
+  background: #f0b429;
+  color: #1a1b2e;
+}
+
+.gpt-chip.hidden {
+  display: none;
+}
+
+.gpt-markdown {
+  line-height: 1.45;
+  color: #1a1b2e;
+}
+
+body.dark .gpt-markdown {
+  color: #f4f6ff;
+}
+
+.gpt-markdown p {
+  margin: 0 0 0.6em;
+}
+
+.gpt-markdown ul {
+  margin: 0.4em 0 0.6em 1.4em;
+  padding: 0;
+}
+
+.gpt-markdown a {
+  color: #80b3ff;
+  text-decoration: underline;
+}
+
+.gpt-markdown code {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-family: "Fira Code", monospace;
+  font-size: 0.85em;
+}
+
+.gpt-risks {
+  margin-top: 12px;
+  border-left: 3px solid #f39c12;
+  background: rgba(243, 156, 18, 0.12);
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+
+body.dark .gpt-risks {
+  background: rgba(243, 156, 18, 0.18);
+}
+
+.gpt-risks h4 {
+  margin: 0 0 4px;
+  font-size: 0.95rem;
+}
+
+.gpt-risks ul {
+  margin: 0;
+  padding-left: 1.2em;
+  font-size: 0.88rem;
+}
+
+.gpt-data {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.gpt-block {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  padding: 10px;
+  color: #1a1b2e;
+}
+
+body.dark .gpt-block {
+  background: rgba(21, 26, 48, 0.9);
+  border-color: rgba(96, 110, 154, 0.4);
+  color: #f4f6ff;
+}
+
+.gpt-block h4 {
+  margin: 0 0 6px;
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.gpt-block ul {
+  margin: 0;
+  padding-left: 1.2em;
+  font-size: 0.9rem;
+}
+
+.gpt-block ul li {
+  margin-bottom: 4px;
+}
+
+.gpt-block .gpt-order {
+  margin-top: 6px;
+  font-size: 0.85rem;
+  color: #c5ceff;
+}
+
+.gpt-metric {
+  font-weight: 600;
+  margin-right: 8px;
+}
+
+.gpt-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.gpt-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+}
+
+.gpt-item {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  padding: 10px;
+  color: #1a1b2e;
+}
+
+body.dark .gpt-item {
+  background: rgba(21, 26, 48, 0.9);
+  border-color: rgba(96, 110, 154, 0.4);
+  color: #f4f6ff;
+}
+
+.gpt-item header {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.gpt-item ul {
+  margin: 4px 0 0 1.2em;
+  padding: 0;
+  font-size: 0.85rem;
+}
+
+.gpt-tag {
+  display: inline-flex;
+  padding: 2px 8px;
+  background: #1f8b4c;
+  color: #fff;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  margin-top: 6px;
+}
+
+.gpt-warnings {
+  margin-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 8px;
+}
+
+.gpt-warnings.hidden {
+  display: none;
+}
+
+.gpt-warnings h4 {
+  margin: 0 0 4px;
+  font-size: 0.9rem;
+}
+
+.gpt-warnings ul {
+  margin: 0;
+  padding-left: 1.2em;
+  font-size: 0.85rem;
+}
+
+.gpt-meta {
+  margin-top: 10px;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.gpt-meta.hidden {
+  display: none;
+}
+
+.gpt-apply-btn {
+  margin-top: 10px;
+  padding: 6px 12px;
+  font-size: 0.85rem;
+}
+
+.gpt-highlight {
+  background: rgba(247, 198, 85, 0.18);
+  box-shadow: 0 0 0 2px rgba(247, 198, 85, 0.8);
+}
+
+body.dark .gpt-highlight {
+  background: rgba(247, 198, 85, 0.15);
+  box-shadow: 0 0 0 2px rgba(247, 198, 85, 0.65);
+}
+
 table {
   width: 100%;
   border-collapse: collapse;

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -119,7 +119,28 @@ body.dark .skeleton{background:#333;}
     <textarea id="gptPrompt" rows="1" maxlength="2000" placeholder="Escribe consulta para GPT..." aria-label="Escribe consulta para GPT..."></textarea>
     <div id="gptActions">
       <button id="sendPrompt">Enviar consulta a GPT</button>
+      <button id="btnGptWeights">Ajustar pesos con IA</button>
+      <button id="btnGptTrends">Análisis de tendencias (profundo)</button>
+      <button id="btnGptImpute">Imputar campos</button>
+      <button id="btnGptDesire">Resumir desire</button>
       <button id="btnGenWinner" class="bar-btn" disabled title="Generar Winner Score" aria-label="Generar Winner Score">Generar Winner Score</button>
+    </div>
+    <div id="gptPanel" class="card gpt-panel hidden">
+      <div class="gpt-panel-header">
+        <h3>Asistente IA</h3>
+        <span id="gptChunkChip" class="gpt-chip hidden">Procesado por lotes</span>
+      </div>
+      <div id="gptText" class="gpt-markdown muted">Los resultados de la IA aparecerán aquí.</div>
+      <div id="gptRisks" class="gpt-risks hidden">
+        <h4>Riesgos logísticos</h4>
+        <ul></ul>
+      </div>
+      <div id="gptDataBlocks" class="gpt-data"></div>
+      <div id="gptWarnings" class="gpt-warnings hidden">
+        <h4>Log</h4>
+        <ul></ul>
+      </div>
+      <div id="gptMeta" class="gpt-meta hidden"></div>
     </div>
     <div id="searchRowRight">
       <div id="listMeta">0 resultados</div>
@@ -370,6 +391,7 @@ body.dark .skeleton{background:#333;}
 import { applyFilters, readFilters } from '/static/js/filters-panel.js';
 import * as api from "/static/js/net.js";
 import * as groupsService from "/static/js/groups-service.js";
+import { executeGptTask } from '/static/js/gpt-actions.js';
 const { fetchJson } = api;
 const metricKeys = window.metricKeys;
 const openConfigModal = window.openConfigModal;
@@ -472,6 +494,7 @@ function updateResultsBadge(total) {
 window.updateResultsBadge = updateResultsBadge;
 window.allProducts = allProducts;
 window.products = products;
+window.currentTimeWindow = window.currentTimeWindow || null;
 const gridRoot = document.getElementById('productTable');
 
 document.addEventListener('filters-changed', (e) => {
@@ -1197,33 +1220,90 @@ if(gptField){
 async function sendPromptHandler(){
   const prompt = gptField.value.trim();
   if(!prompt){ toast.info('Escribe una consulta'); return; }
-  sendPromptBtn.disabled = true;
   try {
-    const data = await fetchJson('/custom_gpt', {method:'POST', body: JSON.stringify({prompt})});
+    const response = await executeGptTask('consulta', {
+      promptText: prompt,
+      button: sendPromptBtn,
+      busyText: 'Consultando…'
+    });
     const history = document.getElementById('history');
-    if(history){
+    if(history && response){
       const details = document.createElement('details');
       const summary = document.createElement('summary');
       const shortPrompt = prompt.length > 40 ? prompt.substring(0,37) + '...' : prompt;
       summary.textContent = shortPrompt;
       const pre = document.createElement('pre');
-      pre.textContent = data.response || data.error;
+      pre.textContent = response.text || '[sin texto]';
       details.appendChild(summary);
       details.appendChild(pre);
       history.prepend(details);
     }
-    toast.success('Consulta enviada');
     gptField.value = '';
     localStorage.removeItem('lastGptPrompt');
     autoGrow(gptField);
   } catch(err) {
-    toast.error(err.message || 'Error al enviar');
-  } finally {
-    sendPromptBtn.disabled = false;
+    console.error('Error ejecutando consulta GPT', err);
   }
 }
 
 sendPromptBtn.onclick = sendPromptHandler;
+
+function ensureProductsAvailable(){
+  const list = Array.isArray(window.products) ? window.products : [];
+  if (!list.length) {
+    toast.info('No hay productos visibles para analizar');
+    return false;
+  }
+  return true;
+}
+
+const btnGptWeights = document.getElementById('btnGptWeights');
+if (btnGptWeights) {
+  btnGptWeights.addEventListener('click', async () => {
+    if (!ensureProductsAvailable()) return;
+    try {
+      await executeGptTask('pesos', { button: btnGptWeights, busyText: 'Calculando…' });
+    } catch (err) {
+      console.error('Error en pesos IA', err);
+    }
+  });
+}
+
+const btnGptTrends = document.getElementById('btnGptTrends');
+if (btnGptTrends) {
+  btnGptTrends.addEventListener('click', async () => {
+    if (!ensureProductsAvailable()) return;
+    try {
+      await executeGptTask('tendencias', { button: btnGptTrends, busyText: 'Analizando…' });
+    } catch (err) {
+      console.error('Error en análisis de tendencias', err);
+    }
+  });
+}
+
+const btnGptImpute = document.getElementById('btnGptImpute');
+if (btnGptImpute) {
+  btnGptImpute.addEventListener('click', async () => {
+    if (!ensureProductsAvailable()) return;
+    try {
+      await executeGptTask('imputacion', { button: btnGptImpute, busyText: 'Imputando…' });
+    } catch (err) {
+      console.error('Error en imputación IA', err);
+    }
+  });
+}
+
+const btnGptDesire = document.getElementById('btnGptDesire');
+if (btnGptDesire) {
+  btnGptDesire.addEventListener('click', async () => {
+    if (!ensureProductsAvailable()) return;
+    try {
+      await executeGptTask('desire', { button: btnGptDesire, busyText: 'Resumiendo…' });
+    } catch (err) {
+      console.error('Error en desire IA', err);
+    }
+  });
+}
 document.getElementById('darkToggle').onclick = () => {
   document.body.classList.toggle('dark');
 };
@@ -1449,6 +1529,7 @@ document.getElementById('btnGenWinner').onclick = () => {
 
 // -------- Group management --------
 let currentGroupFilter = -1; // -1 indicates all products
+window.currentGroupFilter = currentGroupFilter;
 
 async function loadLists() {
   try {
@@ -1486,6 +1567,7 @@ async function applyGroupFilter(id){
   if(id === -1){
     // load all products
     currentGroupFilter = -1;
+    window.currentGroupFilter = currentGroupFilter;
     fetchProducts();
     // refresh lists to update active styling
     loadLists();
@@ -1493,6 +1575,7 @@ async function applyGroupFilter(id){
   }
   try{
     currentGroupFilter = id;
+    window.currentGroupFilter = currentGroupFilter;
     const data = await fetchJson('/list/' + id);
     allProducts = data;
     window.allProducts = allProducts;

--- a/product_research_app/static/js/gpt-actions.js
+++ b/product_research_app/static/js/gpt-actions.js
@@ -1,0 +1,570 @@
+import { post } from './net.js';
+
+const ENDPOINTS = {
+  consulta: '/api/gpt/consulta',
+  pesos: '/api/gpt/pesos',
+  tendencias: '/api/gpt/tendencias',
+  imputacion: '/api/gpt/imputacion',
+  desire: '/api/gpt/desire'
+};
+
+const DEFAULT_PROMPTS = {
+  consulta: 'Analiza el conjunto de productos y entrega hallazgos accionables.',
+  pesos: 'Ajusta los pesos del winner score usando los agregados proporcionados.',
+  tendencias: 'Realiza un análisis profundo de tendencias y oportunidades.',
+  imputacion: 'Imputa los campos faltantes con valores plausibles.',
+  desire: 'Resume el nivel de desire/comprabilidad de los productos.'
+};
+
+let lastHighlightedIds = new Set();
+let lastWarnings = [];
+let lastResponse = null;
+let pendingImputations = null;
+
+function safeCloneProducts(list) {
+  if (!Array.isArray(list)) return [];
+  if (typeof structuredClone === 'function') {
+    try { return structuredClone(list); } catch (err) { /* continue */ }
+  }
+  try {
+    return JSON.parse(JSON.stringify(list));
+  } catch (err) {
+    return list.map(item => {
+      const copy = {};
+      for (const key in item) copy[key] = item[key];
+      return copy;
+    });
+  }
+}
+
+function getVisibleRowIds() {
+  const rows = Array.from(document.querySelectorAll('#productTable tbody tr'));
+  const ids = [];
+  for (const row of rows) {
+    if (!row || row.offsetParent === null || row.style.display === 'none') continue;
+    const cb = row.querySelector('input.rowCheck');
+    if (!cb || !cb.dataset.id) continue;
+    ids.push(cb.dataset.id);
+  }
+  return ids;
+}
+
+function resolveGroupId(value) {
+  if (value === undefined || value === null || value === '' || value === -1) return null;
+  return String(value);
+}
+
+function resolveTimeWindow(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function collectContext({ includeProducts = true } = {}) {
+  const products = includeProducts && Array.isArray(window.products) ? window.products : [];
+  const context = {
+    group_id: resolveGroupId(window.currentGroupFilter),
+    time_window: resolveTimeWindow(window.currentTimeWindow),
+    products: includeProducts ? safeCloneProducts(products) : []
+  };
+  const visible = getVisibleRowIds();
+  if (visible.length) context.visible_ids = visible;
+  return context;
+}
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function formatInline(text) {
+  if (!text) return '';
+  let out = escapeHtml(text);
+  out = out.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+  out = out.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  out = out.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+  out = out.replace(/`([^`]+)`/g, '<code>$1</code>');
+  return out;
+}
+
+function renderMarkdown(text) {
+  if (!text) return '';
+  const lines = String(text).split(/\r?\n/);
+  const parts = [];
+  let inList = false;
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (!line) {
+      if (inList) {
+        parts.push('</ul>');
+        inList = false;
+      }
+      continue;
+    }
+    if (/^[-*]\s+/.test(line)) {
+      if (!inList) {
+        parts.push('<ul>');
+        inList = true;
+      }
+      parts.push(`<li>${formatInline(line.replace(/^[-*]\s+/, ''))}</li>`);
+      continue;
+    }
+    if (inList) {
+      parts.push('</ul>');
+      inList = false;
+    }
+    if (/^#{1,6}\s+/.test(line)) {
+      const level = Math.min(6, line.match(/^#+/)[0].length);
+      parts.push(`<h${level}>${formatInline(line.replace(/^#{1,6}\s+/, ''))}</h${level}>`);
+    } else {
+      parts.push(`<p>${formatInline(line)}</p>`);
+    }
+  }
+  if (inList) parts.push('</ul>');
+  return parts.join('\n');
+}
+
+function extractHighlightIds(data) {
+  if (!data) return [];
+  const ids = new Set();
+  const refs = data.refs;
+  if (Array.isArray(refs)) {
+    for (const entry of refs) {
+      const id = entry && (entry.id || entry.product_id || entry.productId);
+      if (id !== undefined && id !== null && id !== '') ids.add(String(id));
+    }
+  } else if (refs && typeof refs === 'object') {
+    if (Array.isArray(refs.product_ids)) {
+      refs.product_ids.forEach(id => {
+        if (id !== undefined && id !== null && id !== '') ids.add(String(id));
+      });
+    }
+    if (Array.isArray(refs.ids)) {
+      refs.ids.forEach(id => {
+        if (id !== undefined && id !== null && id !== '') ids.add(String(id));
+      });
+    }
+  }
+  return Array.from(ids);
+}
+
+function highlightRows(ids) {
+  const table = document.getElementById('productTable');
+  if (!table) return;
+  for (const prev of lastHighlightedIds) {
+    const row = table.querySelector(`input.rowCheck[data-id="${CSS.escape(prev)}"]`);
+    const tr = row ? row.closest('tr') : null;
+    if (tr) tr.classList.remove('gpt-highlight');
+  }
+  lastHighlightedIds = new Set();
+  ids.forEach(id => {
+    const row = table.querySelector(`input.rowCheck[data-id="${CSS.escape(id)}"]`);
+    const tr = row ? row.closest('tr') : null;
+    if (tr) {
+      tr.classList.add('gpt-highlight');
+      lastHighlightedIds.add(id);
+    }
+  });
+}
+
+function ensurePanel() {
+  const panel = document.getElementById('gptPanel');
+  if (panel) panel.classList.remove('hidden');
+  return panel;
+}
+
+function updateWarnings(panel, response) {
+  const wrap = panel?.querySelector('#gptWarnings');
+  if (!wrap) return;
+  const list = wrap.querySelector('ul');
+  if (!list) return;
+  list.innerHTML = '';
+  const warnings = [];
+  if (response && response.ok === false) {
+    warnings.push('El modelo no devolvió un resultado completo.');
+  }
+  const arr = Array.isArray(response?.warnings) ? response.warnings : [];
+  for (const item of arr) {
+    if (!item) continue;
+    warnings.push(String(item));
+  }
+  lastWarnings = warnings;
+  if (!warnings.length) {
+    wrap.classList.add('hidden');
+    return;
+  }
+  warnings.forEach(text => {
+    const li = document.createElement('li');
+    li.textContent = text;
+    list.appendChild(li);
+  });
+  wrap.classList.remove('hidden');
+}
+
+function updateRisks(panel, data) {
+  const container = panel?.querySelector('#gptRisks');
+  if (!container) return;
+  const list = container.querySelector('ul');
+  if (!list) return;
+  list.innerHTML = '';
+  const riesgosRaw = data?.riesgos;
+  let riesgos = [];
+  if (Array.isArray(riesgosRaw)) riesgos = riesgosRaw;
+  else if (typeof riesgosRaw === 'string' && riesgosRaw.trim()) riesgos = [riesgosRaw.trim()];
+  if (!riesgos.length) {
+    container.classList.add('hidden');
+    return;
+  }
+  riesgos.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = String(item);
+    list.appendChild(li);
+  });
+  container.classList.remove('hidden');
+}
+
+function renderWeightsBlock(container, data) {
+  if (!data?.weights) return;
+  const block = document.createElement('section');
+  block.className = 'gpt-block gpt-weights';
+  const title = document.createElement('h4');
+  title.textContent = 'Pesos sugeridos';
+  block.appendChild(title);
+  const list = document.createElement('ul');
+  const entries = Object.entries(data.weights).sort((a, b) => (Number(b[1]) || 0) - (Number(a[1]) || 0));
+  entries.forEach(([key, value]) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<span class="gpt-metric">${formatInline(key)}</span><span class="gpt-value">${Number(value).toFixed(2)}</span>`;
+    list.appendChild(li);
+  });
+  block.appendChild(list);
+  if (Array.isArray(data.weights_order) && data.weights_order.length) {
+    const order = document.createElement('p');
+    order.className = 'gpt-order';
+    order.innerHTML = `<strong>Orden sugerido:</strong> ${data.weights_order.join(', ')}`;
+    block.appendChild(order);
+  }
+  container.appendChild(block);
+  document.dispatchEvent(new CustomEvent('gpt-weights-suggestion', { detail: data }));
+}
+
+function renderDesireBlock(container, results) {
+  const entries = Object.entries(results || {});
+  if (!entries.length) return;
+  const block = document.createElement('section');
+  block.className = 'gpt-block gpt-desire';
+  block.innerHTML = '<h4>Resumen de desire</h4>';
+  const list = document.createElement('div');
+  list.className = 'gpt-grid';
+  entries.forEach(([id, info]) => {
+    const card = document.createElement('article');
+    card.className = 'gpt-item';
+    const header = document.createElement('header');
+    header.innerHTML = `<span class="gpt-id">#${formatInline(id)}</span>`;
+    card.appendChild(header);
+    if (info && typeof info === 'object') {
+      if (info.summary || info.text) {
+        const p = document.createElement('p');
+        p.innerHTML = formatInline(info.summary || info.text);
+        card.appendChild(p);
+      }
+      if (Array.isArray(info.bullets) && info.bullets.length) {
+        const ul = document.createElement('ul');
+        info.bullets.forEach(line => {
+          const li = document.createElement('li');
+          li.textContent = String(line);
+          ul.appendChild(li);
+        });
+        card.appendChild(ul);
+      }
+      if (info.desire) {
+        const desireTag = document.createElement('div');
+        desireTag.className = 'gpt-tag';
+        desireTag.textContent = String(info.desire);
+        card.appendChild(desireTag);
+      }
+    } else {
+      const p = document.createElement('p');
+      p.textContent = String(info);
+      card.appendChild(p);
+    }
+    list.appendChild(card);
+  });
+  block.appendChild(list);
+  container.appendChild(block);
+}
+
+function renderGenericResults(container, results) {
+  const entries = Object.entries(results || {});
+  if (!entries.length) return;
+  const block = document.createElement('section');
+  block.className = 'gpt-block gpt-results';
+  block.innerHTML = '<h4>Resultados</h4>';
+  const table = document.createElement('table');
+  table.className = 'gpt-table';
+  const tbody = document.createElement('tbody');
+  entries.forEach(([id, detail]) => {
+    const tr = document.createElement('tr');
+    const tdId = document.createElement('td');
+    tdId.innerHTML = formatInline(id);
+    const tdDetail = document.createElement('td');
+    if (detail && typeof detail === 'object') {
+      const lines = [];
+      for (const [k, v] of Object.entries(detail)) {
+        if (v === undefined || v === null || v === '') continue;
+        lines.push(`<strong>${formatInline(k)}:</strong> ${formatInline(String(v))}`);
+      }
+      tdDetail.innerHTML = lines.length ? lines.join('<br>') : '';
+    } else {
+      tdDetail.innerHTML = formatInline(String(detail));
+    }
+    tr.appendChild(tdId);
+    tr.appendChild(tdDetail);
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  block.appendChild(table);
+  container.appendChild(block);
+}
+
+function renderImputationBlock(container, imputed) {
+  const entries = Object.entries(imputed || {});
+  if (!entries.length) return;
+  pendingImputations = imputed;
+  const block = document.createElement('section');
+  block.className = 'gpt-block gpt-imputed';
+  block.innerHTML = '<h4>Imputaciones sugeridas</h4>';
+  const list = document.createElement('div');
+  list.className = 'gpt-table gpt-imputed-list';
+  entries.forEach(([id, fields]) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'gpt-imputed-item';
+    const title = document.createElement('div');
+    title.className = 'gpt-id';
+    title.textContent = `#${id}`;
+    wrapper.appendChild(title);
+    const ul = document.createElement('ul');
+    for (const [k, v] of Object.entries(fields || {})) {
+      const li = document.createElement('li');
+      li.innerHTML = `<strong>${formatInline(k)}:</strong> ${formatInline(String(v))}`;
+      ul.appendChild(li);
+    }
+    wrapper.appendChild(ul);
+    list.appendChild(wrapper);
+  });
+  block.appendChild(list);
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'gpt-apply-btn';
+  btn.textContent = 'Aplicar imputaciones';
+  btn.addEventListener('click', () => applyImputations(btn));
+  block.appendChild(btn);
+  container.appendChild(block);
+}
+
+async function applyImputations(button) {
+  if (!pendingImputations) return;
+  const entries = Object.entries(pendingImputations);
+  if (!entries.length) return;
+  let okCount = 0;
+  const failures = [];
+  const prev = button ? button.textContent : null;
+  if (button) {
+    button.disabled = true;
+    button.textContent = 'Aplicando…';
+  }
+  for (const [id, fields] of entries) {
+    const numId = Number(id);
+    if (!Number.isFinite(numId)) {
+      failures.push(`ID ${id} inválido`);
+      continue;
+    }
+    try {
+      const payload = Object.assign({}, fields, { source: 'gpt-imputacion' });
+      const res = await fetch(`/products/${numId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || res.statusText || 'Error desconocido');
+      }
+      okCount += 1;
+    } catch (err) {
+      console.error('applyImputations', err);
+      failures.push(`ID ${id}: ${err.message}`);
+    }
+  }
+  if (button) {
+    button.disabled = failures.length === 0;
+    button.textContent = failures.length === 0 ? 'Imputaciones aplicadas' : prev || 'Aplicar imputaciones';
+  }
+  if (okCount) {
+    if (typeof toast !== 'undefined') toast.success(`Imputaciones aplicadas: ${okCount}`);
+    if (typeof window.fetchProducts === 'function') {
+      try { window.fetchProducts(); } catch (err) { /* ignore */ }
+    }
+  }
+  if (failures.length) {
+    if (typeof toast !== 'undefined') toast.error(`Fallos en ${failures.length} imputaciones`);
+    lastWarnings = lastWarnings.concat(failures);
+    showGptLog();
+    const wrap = document.getElementById('gptWarnings');
+    if (wrap) {
+      const list = wrap.querySelector('ul');
+      if (list) {
+        failures.forEach(f => {
+          const li = document.createElement('li');
+          li.textContent = f;
+          list.appendChild(li);
+        });
+      }
+      wrap.classList.remove('hidden');
+    }
+  } else {
+    pendingImputations = null;
+  }
+}
+
+function renderDataBlocks(task, data, container) {
+  container.innerHTML = '';
+  pendingImputations = null;
+  if (!data) return;
+  const cleanData = Object.assign({}, data);
+  delete cleanData.prompt_version;
+  const weights = cleanData.weights;
+  if (weights) {
+    renderWeightsBlock(container, cleanData);
+  }
+  const imputed = cleanData.imputed || (task === 'imputacion' ? cleanData.results : null);
+  if (imputed) {
+    renderImputationBlock(container, imputed);
+  }
+  if (task === 'desire' && cleanData.results) {
+    renderDesireBlock(container, cleanData.results);
+  } else if (cleanData.results && !imputed) {
+    renderGenericResults(container, cleanData.results);
+  }
+}
+
+function updateMeta(panel, response) {
+  const chip = panel?.querySelector('#gptChunkChip');
+  const meta = response?.meta;
+  if (chip) {
+    if (meta?.chunks > 1) {
+      chip.textContent = 'Procesado por lotes';
+      chip.classList.remove('hidden');
+    } else {
+      chip.classList.add('hidden');
+    }
+  }
+  const metaBox = panel?.querySelector('#gptMeta');
+  if (!metaBox) return;
+  const model = response?.model || meta?.model;
+  const tokens = meta?.estimated_tokens;
+  const calls = meta?.calls;
+  const lines = [];
+  if (model) lines.push(`<strong>Modelo:</strong> ${formatInline(model)}`);
+  if (calls) lines.push(`<strong>Llamadas:</strong> ${calls}`);
+  if (tokens) lines.push(`<strong>Tokens aprox.:</strong> ${tokens}`);
+  if (!lines.length) {
+    metaBox.classList.add('hidden');
+  } else {
+    metaBox.innerHTML = lines.join(' · ');
+    metaBox.classList.remove('hidden');
+  }
+}
+
+export function displayGptResponse(task, response) {
+  const panel = ensurePanel();
+  if (!panel) return;
+  const textEl = panel.querySelector('#gptText');
+  if (textEl) {
+    if (response?.text) {
+      textEl.classList.remove('muted');
+      textEl.innerHTML = renderMarkdown(response.text);
+    } else {
+      textEl.classList.add('muted');
+      textEl.innerHTML = '<p>Sin texto recibido.</p>';
+    }
+  }
+  const highlightIds = extractHighlightIds(response?.data);
+  highlightRows(highlightIds);
+  updateWarnings(panel, response);
+  updateRisks(panel, response?.data || null);
+  const dataContainer = panel.querySelector('#gptDataBlocks');
+  if (dataContainer) {
+    renderDataBlocks(task, response?.data || null, dataContainer);
+  }
+  updateMeta(panel, response);
+}
+
+export function notifyOutcome(response) {
+  const warnings = Array.isArray(response?.warnings) ? response.warnings : [];
+  if (response?.ok === false) {
+    if (typeof toast !== 'undefined') {
+      toast.info('La IA devolvió avisos. Revisa el log.', {
+        actionText: 'Ver log',
+        onAction: () => showGptLog()
+      });
+    }
+  } else if (warnings.length) {
+    if (typeof toast !== 'undefined') {
+      toast.info('La respuesta incluye advertencias.', {
+        actionText: 'Ver log',
+        onAction: () => showGptLog()
+      });
+    }
+  }
+}
+
+export async function executeGptTask(task, {
+  promptText,
+  params = {},
+  button = null,
+  context = null,
+  busyText = 'Procesando…'
+} = {}) {
+  const endpoint = ENDPOINTS[task];
+  if (!endpoint) throw new Error(`Tarea GPT desconocida: ${task}`);
+  const payload = {
+    prompt_text: typeof promptText === 'string' && promptText.trim() ? promptText : (DEFAULT_PROMPTS[task] || ''),
+    context: context && typeof context === 'object' ? context : collectContext(),
+    params: params && typeof params === 'object' ? params : {}
+  };
+  let prevText = null;
+  if (button) {
+    prevText = button.textContent;
+    button.disabled = true;
+    if (busyText) button.textContent = busyText;
+  }
+  try {
+    const response = await post(endpoint, payload, 60000);
+    lastResponse = { task, response };
+    displayGptResponse(task, response);
+    notifyOutcome(response);
+    return response;
+  } finally {
+    if (button) {
+      button.disabled = false;
+      if (prevText !== null) button.textContent = prevText;
+    }
+  }
+}
+
+export function showGptLog() {
+  const panel = ensurePanel();
+  if (!panel) return;
+  const wrap = panel.querySelector('#gptWarnings');
+  if (wrap) {
+    wrap.classList.remove('hidden');
+    wrap.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+}
+
+export function getLastResponse() {
+  return lastResponse;
+}

--- a/product_research_app/tests/test_api_gpt_endpoints.py
+++ b/product_research_app/tests/test_api_gpt_endpoints.py
@@ -1,0 +1,137 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from product_research_app.api import app
+from product_research_app.api import gpt_endpoints
+
+
+def test_consulta_endpoint_filters_products_and_uses_template(monkeypatch):
+    client = app.test_client()
+    captured = {}
+
+    def fake_run_task(task, *, prompt_text, json_payload, model_hint=None, system_prompt=None):
+        captured["task"] = task
+        captured["prompt_text"] = prompt_text
+        captured["json_payload"] = json_payload
+        captured["system_prompt"] = system_prompt
+        return {
+            "ok": True,
+            "text": "Análisis",
+            "data": {"refs": [{"id": "1"}], "prompt_version": "v1"},
+            "warnings": [],
+            "meta": {"chunks": 1},
+            "model": "gpt-4o-mini",
+        }
+
+    monkeypatch.setattr(gpt_endpoints.gpt_orchestrator, "run_task", fake_run_task)
+
+    body = {
+        "prompt_text": "   Hola ",
+        "context": {
+            "group_id": "g1",
+            "time_window": "ultima_semana",
+            "products": [
+                {
+                    "id": 1,
+                    "price": 10,
+                    "title": "Prod1",
+                    "email": "user@example.com",
+                    "group_id": "g1",
+                },
+                {
+                    "id": 2,
+                    "price": 20,
+                    "title": "Prod2",
+                    "group_id": "g2",
+                },
+                {
+                    "id": "3",
+                    "price": 30,
+                    "title": "Prod3",
+                    "description": "Algo",
+                    "groupId": "g1",
+                },
+            ],
+            "visible_ids": [1, None, "3"],
+        },
+        "params": {"tone": "casual"},
+    }
+
+    response = client.post("/api/gpt/consulta", data=json.dumps(body), content_type="application/json")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["ok"] is True
+    assert payload["text"] == "Análisis"
+    assert payload["data"]["prompt_version"] == "v1"
+
+    assert captured["task"] == "consulta"
+    assert captured["prompt_text"] == "Hola"
+    sanitized = captured["json_payload"]["products"]
+    assert sanitized == [
+        {"id": "1", "price": 10, "title": "Prod1"},
+        {"id": "3", "price": 30, "title": "Prod3", "description": "Algo"},
+    ]
+    assert captured["json_payload"]["group_id"] == "g1"
+    assert captured["json_payload"]["visible_ids"] == ["1", "3"]
+    assert captured["json_payload"]["params"] == {"tone": "casual"}
+    expected_system = gpt_endpoints._get_system_prompt("consulta")
+    assert captured["system_prompt"] == expected_system
+
+
+def test_pesos_endpoint_uses_default_prompt(monkeypatch):
+    client = app.test_client()
+    captured = {}
+
+    def fake_run_task(task, *, prompt_text, json_payload, model_hint=None, system_prompt=None):
+        captured["task"] = task
+        captured["prompt_text"] = prompt_text
+        captured["json_payload"] = json_payload
+        return {
+            "ok": True,
+            "text": "Resumen",
+            "data": {"prompt_version": "v1"},
+            "warnings": [],
+            "meta": {"chunks": 1},
+            "model": "gpt-4o",
+        }
+
+    monkeypatch.setattr(gpt_endpoints.gpt_orchestrator, "run_task", fake_run_task)
+
+    body = {
+        "prompt_text": "",
+        "context": {
+            "group_id": None,
+            "time_window": None,
+            "products": [
+                {"id": "A", "price": 12, "store": "Shop", "title": "Prod 1"},
+                {"id": "B", "price": 22, "store": "Shop", "title": "Prod 2", "extra": "ignore"},
+            ],
+        },
+        "params": {},
+    }
+
+    response = client.post("/api/gpt/pesos", json=body)
+    assert response.status_code == 200
+    assert captured["task"] == "pesos"
+    assert captured["prompt_text"] == gpt_endpoints._DEFAULT_PROMPTS["pesos"]
+    payload_products = captured["json_payload"]["products"]
+    assert set(payload_products.keys()) == {"aggregates", "sample_titles"}
+    aggregates = payload_products["aggregates"]
+    assert aggregates["total_products"] == 2
+    price_stats = aggregates["metrics"]["price"]
+    assert price_stats["min"] == 12.0
+    assert price_stats["max"] == 22.0
+    assert price_stats["coverage"] == 1.0
+    assert payload_products["sample_titles"] == ["Prod 1", "Prod 2"]
+
+
+def test_invalid_body_returns_400():
+    client = app.test_client()
+    response = client.post("/api/gpt/consulta", data="not-json", content_type="application/json")
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["ok"] is False
+    assert "error" in payload

--- a/product_research_app/tests/test_orchestrator_smoke.py
+++ b/product_research_app/tests/test_orchestrator_smoke.py
@@ -1,0 +1,131 @@
+import json
+
+from product_research_app.ai import gpt_orchestrator
+
+
+def _context_from_prompt(prompt: str) -> dict:
+    marker = "### CONTEXTO JSON\n"
+    if marker not in prompt:
+        return {}
+    after = prompt.split(marker, 1)[1]
+    split_marker = "\n\n### INSTRUCCIONES DE FORMATO"
+    if split_marker in after:
+        json_part = after.split(split_marker, 1)[0]
+    else:
+        json_part = after
+    return json.loads(json_part)
+
+
+def test_consulta_chunking_and_refs(monkeypatch):
+    responses = [
+        {
+            "content": "Resumen 1\n```json\n{\"refs\":[{\"id\":\"1\",\"category\":\"A\"}],\"prompt_version\":\"v1\"}\n```",
+            "usage": 120,
+        },
+        {
+            "content": "Resumen 2\n```json\n{\"refs\":[{\"id\":\"2\",\"category\":\"A\"}],\"prompt_version\":\"v2\"}\n```",
+            "usage": 130,
+        },
+    ]
+    captured_contexts = []
+
+    def fake_call(model, prompt, api_key, timeout, system_prompt):
+        context = _context_from_prompt(prompt)
+        captured_contexts.append(context)
+        return responses.pop(0)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("MAX_ITEMS", "2")
+    monkeypatch.setattr(gpt_orchestrator, "_call_openai", fake_call)
+
+    payload = {"products": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}
+    result = gpt_orchestrator.run_task("consulta", prompt_text="Analiza", json_payload=payload)
+
+    assert result["ok"] is True
+    assert result["meta"]["calls"] == 2
+    assert len(captured_contexts) == 2
+    assert len(captured_contexts[0]["products"]) == 2
+    assert len(captured_contexts[1]["products"]) == 1
+    refs = result["data"]["refs"]
+    assert {ref["id"] for ref in refs} == {"1", "2"}
+    assert result["data"]["prompt_version"] == "v2"
+
+
+def test_pesos_uses_aggregated_summary(monkeypatch):
+    captured = {}
+
+    def fake_call(model, prompt, api_key, timeout, system_prompt):
+        context = _context_from_prompt(prompt)
+        captured["context"] = context
+        return {
+            "content": "Hecho\n```json\n{\"weights\":{\"score\":0.7},\"prompt_version\":\"2024-01\"}\n```",
+            "usage": 88,
+        }
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("MAX_ITEMS", "5")
+    monkeypatch.setattr(gpt_orchestrator, "_call_openai", fake_call)
+
+    payload = {
+        "products": [
+            {"id": "p1", "price": 10, "metrics": {"score": 1}, "title": "Alpha"},
+            {"id": "p2", "price": 15, "metrics": {"score": 3}, "title": "Beta"},
+            {"id": "p3", "price": 20, "metrics": {"score": 2}, "title": "Gamma"},
+        ]
+    }
+    result = gpt_orchestrator.run_task("pesos", prompt_text="Calibra", json_payload=payload)
+
+    context = captured["context"]
+    assert "products" not in context
+    aggregates = context["aggregates"]
+    metrics = aggregates["metrics"]
+    assert "score" in metrics and "price" in metrics
+    score_stats = metrics["score"]
+    assert score_stats["min"] == 1.0
+    assert score_stats["max"] == 3.0
+    assert score_stats["top_ids"][0] == "p2"
+    assert score_stats["bottom_ids"][0] == "p1"
+    assert aggregates["total_products"] == 3
+    assert context.get("sample_titles") == ["Alpha", "Beta", "Gamma"]
+
+    assert result["ok"] is True
+    assert result["data"]["weights"]["score"] == 0.7
+    assert result["data"]["prompt_version"] == "2024-01"
+
+
+def test_desire_batches_into_mapping(monkeypatch):
+    responses = [
+        {
+            "content": "Bloque1\n```json\n{\"results\":{\"a\":{\"desire\":\"Alta\"}},\"prompt_version\":\"v1\"}\n```",
+            "usage": None,
+        },
+        {
+            "content": "Bloque2\n```json\n{\"results\":{\"b\":{\"desire\":\"Media\"},\"c\":{\"desire\":\"Baja\"}},\"prompt_version\":\"v2\"}\n```",
+            "usage": None,
+        },
+    ]
+    contexts = []
+
+    def fake_call(model, prompt, api_key, timeout, system_prompt):
+        context = _context_from_prompt(prompt)
+        contexts.append(context)
+        return responses.pop(0)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("MAX_ITEMS", "2")
+    monkeypatch.setattr(gpt_orchestrator, "_call_openai", fake_call)
+
+    payload = {"products": [{"id": "a"}, {"id": "b"}, {"id": "c"}]}
+    result = gpt_orchestrator.run_task("desire", prompt_text="Completa", json_payload=payload)
+
+    assert len(contexts) == 2
+    assert len(contexts[0]["products"]) == 2
+    assert len(contexts[1]["products"]) == 1
+    data = result["data"]
+    assert data["results"] == {
+        "a": {"desire": "Alta"},
+        "b": {"desire": "Media"},
+        "c": {"desire": "Baja"},
+    }
+    assert data["prompt_version"] == "v2"
+    assert result["ok"] is True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
+Flask
 beautifulsoup4
 Pillow
 openpyxl


### PR DESCRIPTION
## Summary
- add a services-level helper that builds coverage-aware aggregates and sampled titles for product weight tuning requests
- wrap the /api/gpt/pesos payload so only aggregates and representative titles reach the orchestrator
- teach the GPT orchestrator and tests to consume the new aggregate structure instead of raw product lists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf0200fd8832893e0f0ca48f343f2