### PR TITLE
UI: remove manual IA buttons; add auto-AI status chip

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -36,13 +36,37 @@ body.dark {
 #gptActions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
   align-items: center;
   margin-top: 8px;
 }
 
 #gptActions button {
   flex-shrink: 0;
+}
+
+.ai-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: rgba(123, 148, 255, 0.18);
+  border: 1px solid rgba(123, 148, 255, 0.28);
+  color: inherit;
+}
+
+.ai-chip.small {
+  font-size: 0.7rem;
+  padding: 3px 8px;
+}
+
+body.dark .ai-chip {
+  background: rgba(103, 132, 255, 0.16);
+  border-color: rgba(103, 132, 255, 0.32);
+  color: #dbe4ff;
 }
 
 .gpt-panel {
@@ -1491,6 +1515,10 @@ th[aria-sort="descending"]::after{ content:" ▼"; opacity:.6; }
 
 .muted {
   opacity: 0.7;
+}
+
+.pending-placeholder {
+  font-style: italic;
 }
 
 /* Cards */

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -120,10 +120,7 @@ body.dark .skeleton{background:#333;}
     <div id="gptActions">
       <button id="sendPrompt">Enviar consulta a GPT</button>
       <button id="btnGptWeights">Ajustar pesos con IA</button>
-      <button id="btnGptTrends">Análisis de tendencias (profundo)</button>
-      <button id="btnGptImpute">Imputar campos</button>
-      <button id="btnGptDesire">Resumir desire</button>
-      <button id="btnGenWinner" class="bar-btn" disabled title="Generar Winner Score" aria-label="Generar Winner Score">Generar Winner Score</button>
+      <div id="auto-ai-status" class="ai-chip muted small hidden" role="status" aria-live="polite"></div>
     </div>
     <div id="gptPanel" class="card gpt-panel hidden">
       <div class="gpt-panel-header">
@@ -432,19 +429,31 @@ async function sha256(str) {
 async function pollImportStatus(id) {
   try {
     const data = await fetchJson(`/_import_status?task_id=${id}`);
-    if (data.status === 'pending') {
+    const status = (data.status || data.state || '').toString().toLowerCase();
+    if (status === 'pending' || status === 'queued' || status === 'running') {
       if (data.ui_cost_message) showImportBanner(data.ui_cost_message);
       importPollTimer = setTimeout(() => pollImportStatus(id), 2000);
-    } else if (data.status === 'ai') {
+    } else if (status === 'ai') {
       if (data.ui_cost_message) showImportBanner(data.ui_cost_message);
+      const aiStatusPayload = {
+        state: 'RUNNING',
+        desire: data.ai_counts?.desire,
+        imputacion: data.ai_counts?.imputacion,
+        winner_score: data.ai_counts?.winner_score,
+        message: data.message
+      };
+      renderAutoAIStatus(aiStatusPayload);
       importPollTimer = setTimeout(() => pollImportStatus(id), 2000);
     } else {
       localStorage.removeItem(IMPORT_TASK_LS_KEY);
-      if (data.status === 'done') {
+      if (status === 'done' || status === 'finished') {
         await reloadTable();
         hideImportBanner();
+        pollAutoAIStatus(id);
       } else {
         toast.error(data.error || 'Error en importación');
+        pollAutoAIStatus(null);
+        hideAutoAIStatus();
       }
     }
   } catch (e) {
@@ -600,6 +609,28 @@ const columns = [
   { key: 'competition_level', label: 'Competition level', type: 'string', headerClass: 'ec-col ec-col-competition', cellClass: 'ec-col ec-col-competition', dataEcCol: 'competition_level' },
   { key: 'winner_score', label: 'Winner Score', type: 'number' },
 ];
+
+const AUTO_PENDING_FIELDS = new Set(['desire_summary', 'review_count', 'image_count', 'winner_score']);
+
+function shouldShowPendingPlaceholder(key, value) {
+  if (!AUTO_PENDING_FIELDS.has(key)) return false;
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'string') {
+    return value.trim() === '';
+  }
+  if (key === 'winner_score') {
+    const num = Number(value);
+    return !Number.isFinite(num);
+  }
+  return false;
+}
+
+function applyPendingPlaceholder(td, key, value) {
+  if (!shouldShowPendingPlaceholder(key, value)) return false;
+  td.textContent = '(pendiente)';
+  td.classList.add('muted', 'pending-placeholder');
+  return true;
+}
 
 let trendingWords = [];
 
@@ -857,15 +888,21 @@ function renderTable() {
       }
       if (col.render) {
         try { td.textContent = col.render(item); } catch (e) { td.textContent = ''; }
+        applyPendingPlaceholder(td, key, value);
       } else if (key === 'winner_score') {
-        const sc = parseFloat(value);
-        if (!isNaN(sc)) {
-          const scInt = Math.round(sc);
-          td.innerHTML = '<span class="' + winnerScoreClass(scInt) + '">' + scInt.toLocaleString(undefined,{maximumFractionDigits:0}) + '</span>';
-          if (item.winner_score_breakdown && item.winner_score_breakdown.justifications) {
-            const j = item.winner_score_breakdown.justifications;
-            const tooltip = Object.entries(j).map(([k,v])=>`${k}: ${v}`).join('\n');
-            td.title = tooltip;
+        if (!applyPendingPlaceholder(td, key, value)) {
+          const sc = parseFloat(value);
+          if (!isNaN(sc)) {
+            const scInt = Math.round(sc);
+            td.innerHTML = '<span class="' + winnerScoreClass(scInt) + '">' + scInt.toLocaleString(undefined,{maximumFractionDigits:0}) + '</span>';
+            if (item.winner_score_breakdown && item.winner_score_breakdown.justifications) {
+              const j = item.winner_score_breakdown.justifications;
+              const tooltip = Object.entries(j).map(([k,v])=>`${k}: ${v}`).join('\n');
+              td.title = tooltip;
+            }
+          } else {
+            td.textContent = value || '';
+            applyPendingPlaceholder(td, key, value);
           }
         }
       } else if (key === 'image_url' && value) {
@@ -1004,6 +1041,7 @@ function renderTable() {
         }
       } else {
         td.textContent = value || '';
+        applyPendingPlaceholder(td, key, value);
       }
       tr.appendChild(td);
     });
@@ -1145,6 +1183,7 @@ fileInputEl.onchange = async (ev) => {
   ev.preventDefault();
   const file = fileInputEl.files[0];
   if(!file) return;
+  pollAutoAIStatus(null);
   const formData = new FormData();
   formData.append('file', file);
   const btn = document.getElementById('uploadBtn');
@@ -1193,6 +1232,9 @@ document.getElementById('searchBtn').onclick = () => {
 };
 const gptField = document.getElementById('gptPrompt');
 const sendPromptBtn = document.getElementById('sendPrompt');
+const autoAIStatusEl = document.getElementById('auto-ai-status');
+let autoAIStatusTimer = null;
+let currentAutoAITaskId = null;
 
 function autoGrow(el){
   el.style.height = 'auto';
@@ -1269,41 +1311,116 @@ if (btnGptWeights) {
   });
 }
 
-const btnGptTrends = document.getElementById('btnGptTrends');
-if (btnGptTrends) {
-  btnGptTrends.addEventListener('click', async () => {
-    if (!ensureProductsAvailable()) return;
-    try {
-      await executeGptTask('tendencias', { button: btnGptTrends, busyText: 'Analizando…' });
-    } catch (err) {
-      console.error('Error en análisis de tendencias', err);
-    }
-  });
+function clearAutoAIStatusTimer() {
+  if (autoAIStatusTimer) {
+    clearTimeout(autoAIStatusTimer);
+    autoAIStatusTimer = null;
+  }
 }
 
-const btnGptImpute = document.getElementById('btnGptImpute');
-if (btnGptImpute) {
-  btnGptImpute.addEventListener('click', async () => {
-    if (!ensureProductsAvailable()) return;
-    try {
-      await executeGptTask('imputacion', { button: btnGptImpute, busyText: 'Imputando…' });
-    } catch (err) {
-      console.error('Error en imputación IA', err);
+function formatAutoAIProgress(label, info) {
+  if (!info) return null;
+  if (typeof info === 'object') {
+    const current = info.current ?? info.done ?? info.completed ?? info.progress ?? info.processed;
+    const total = info.total ?? info.expected ?? info.max ?? info.out_of;
+    if (total !== undefined && total !== null) {
+      return `${label} ${(current ?? 0)}/${total}`;
     }
-  });
+    if (current !== undefined && current !== null) {
+      return `${label} ${current}`;
+    }
+  }
+  if (typeof info === 'number' && !Number.isNaN(info)) {
+    return `${label} ${info}`;
+  }
+  if (typeof info === 'string' && info.trim()) {
+    return `${label} ${info.trim()}`;
+  }
+  return null;
 }
 
-const btnGptDesire = document.getElementById('btnGptDesire');
-if (btnGptDesire) {
-  btnGptDesire.addEventListener('click', async () => {
-    if (!ensureProductsAvailable()) return;
-    try {
-      await executeGptTask('desire', { button: btnGptDesire, busyText: 'Resumiendo…' });
-    } catch (err) {
-      console.error('Error en desire IA', err);
-    }
-  });
+function hideAutoAIStatus() {
+  if (!autoAIStatusEl) return;
+  autoAIStatusEl.textContent = '';
+  autoAIStatusEl.classList.add('hidden');
 }
+
+function renderAutoAIStatus(status) {
+  if (!autoAIStatusEl) return;
+  const state = (status?.state || '').toString().toUpperCase();
+  if (state !== 'RUNNING') {
+    hideAutoAIStatus();
+    return;
+  }
+  const segments = [];
+  const desireInfo = status.desire ?? status.desire_summary;
+  const imputacionInfo = status.imputacion ?? status.imputation;
+  const scoreInfo = status.winner_score ?? status.score;
+  const pushSegment = (label, info) => {
+    const seg = formatAutoAIProgress(label, info);
+    if (seg) segments.push(seg);
+  };
+  pushSegment('Desire', desireInfo);
+  pushSegment('Imputación', imputacionInfo);
+  pushSegment('Score', scoreInfo);
+  if (!segments.length && status?.message) {
+    segments.push(status.message);
+  }
+  autoAIStatusEl.textContent = `Procesamiento automático – ${segments.join(' · ') || 'en curso'}`;
+  autoAIStatusEl.classList.remove('hidden');
+}
+
+async function pollAutoAIStatus(taskId) {
+  if (!autoAIStatusEl) return;
+  if (!taskId) {
+    currentAutoAITaskId = null;
+    clearAutoAIStatusTimer();
+    hideAutoAIStatus();
+    return;
+  }
+  currentAutoAITaskId = taskId;
+  clearAutoAIStatusTimer();
+  try {
+    const resp = await fetch(`/_ai_status?task_id=${encodeURIComponent(taskId)}`, { cache: 'no-store' });
+    if (resp.status === 404) {
+      if (currentAutoAITaskId === taskId) {
+        hideAutoAIStatus();
+        currentAutoAITaskId = null;
+      }
+      return;
+    }
+    if (!resp.ok) {
+      throw new Error(`status ${resp.status}`);
+    }
+    const data = await resp.json().catch(() => ({}));
+    if (currentAutoAITaskId !== taskId) {
+      return;
+    }
+    renderAutoAIStatus(data);
+    const state = (data?.state || '').toString().toUpperCase();
+    if (state === 'RUNNING') {
+      const interval = Number(data?.poll_interval_ms);
+      const delay = Number.isFinite(interval)
+        ? Math.min(Math.max(interval, 2000), 4000)
+        : 2500;
+      autoAIStatusTimer = setTimeout(() => {
+        pollAutoAIStatus(taskId);
+      }, delay);
+    } else {
+      hideAutoAIStatus();
+      currentAutoAITaskId = null;
+    }
+  } catch (err) {
+    console.debug('Auto AI status polling stopped', err);
+    if (currentAutoAITaskId === taskId) {
+      hideAutoAIStatus();
+      currentAutoAITaskId = null;
+    }
+  }
+}
+
+window.renderAutoAIStatus = renderAutoAIStatus;
+window.pollAutoAIStatus = pollAutoAIStatus;
 document.getElementById('darkToggle').onclick = () => {
   document.body.classList.toggle('dark');
 };
@@ -1486,45 +1603,6 @@ document.getElementById('btnExport').onclick = async () => {
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
   } catch(err){ console.error(err); toast.error('Error al exportar'); }
-};
-
-function getSelectedProductIds(){ return Array.from(selection, Number); }
-function setLoading(btn, s){ if(s){ btn.dataset.prev=btn.textContent; btn.textContent='Actualizando…'; } else { btn.textContent=btn.dataset.prev||btn.textContent; } }
-
-// Generate Winner Score for selected or all products
-document.getElementById('btnGenWinner').onclick = () => {
-  const ids = getSelectedProductIds();
-  const rows = ids.length ? allProducts.filter(p=>ids.includes(Number(p.id))) : products;
-  const payloadProducts = rows.map(p=>{
-    const metrics={};
-    metricKeys.forEach(k=>{ if(p[k]!==undefined) metrics[k]=p[k]; });
-    return {id:p.id, metrics};
-  });
-  if(payloadProducts.some(p=>Object.keys(p.metrics).length<metricKeys.length)){
-    toast.info('Algunos productos tienen métricas faltantes');
-  }
-  const body = ids.length ? {product_ids: ids} : {};
-  body.products = payloadProducts;
-  const btn = document.getElementById('btnGenWinner');
-  btn.disabled = true; setLoading(btn, true);
-  fetch('/api/winner-score/generate?debug=1', {
-    method:'POST', headers:{'Content-Type':'application/json'},
-    body: JSON.stringify(body)
-  }).then(r=>r.json()).then(({processed=0, updated=0, diag})=>{
-    if(!processed) toast.info('Nada que recalcular (0 seleccionados)');
-    else if(updated>0) toast.success(`Winner Score recalculado: ${updated}/${processed} cambiaron`);
-    else {
-      if(diag && diag.sum_filtered===0){
-        toast.info(`Recalculado ${processed}. No afectó: los pesos de métricas presentes suman 0 → fallback uniforme.`);
-      } else {
-        toast.info(`Recalculado ${processed}. El entero 0–100 no varió (redondeo).`);
-      }
-    }
-    if(ids.length) reloadRows(ids); else reloadTable();
-  }).catch(err=>{
-    console.error(err);
-    toast.error('No se pudo actualizar el Winner Score');
-  }).finally(()=>{ btn.disabled=false; setLoading(btn,false); });
 };
 
 // -------- Group management --------

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -32,11 +32,9 @@ function updateMasterState(){
   const btnDel = document.getElementById('btnDelete');
   const btnExp = document.getElementById('btnExport');
   const btnAdd = document.getElementById('btnAddToGroup');
-  const btnGen = document.getElementById('btnGenWinner');
   if(btnDel) btnDel.disabled = noneSelected;
   if(btnExp) btnExp.disabled = noneSelected;
   if(btnAdd) btnAdd.disabled = noneSelected;
-  if(btnGen) btnGen.disabled = false;
   if(bottomBar){
     const selEl = document.getElementById('selCount');
     if(selEl) selEl.textContent = `${selection.size} seleccionados`;


### PR DESCRIPTION
## Summary
- remove the manual GPT/winner score triggers from the toolbar and introduce the auto-processing status chip with background polling and graceful fallbacks
- show pending placeholders for AI-populated fields until the background workers complete their updates
- tweak toolbar spacing/styles and drop leftover winner score button wiring from the table selection helpers

## Testing
- pytest *(fails: missing flask dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb23cf5ac48328828ca63005ef30c4