### PR TITLE
Fix desire pipeline: selection/order/budget/update/commit + diagnostics

### DIFF
--- a/FIX_LOG.md
+++ b/FIX_LOG.md
@@ -1,6 +1,11 @@
 # FIX LOG
 
 ## Fase 1 — Hallazgos
+- **Desire missing log:** `product_research_app/web_app.py::_ensure_desire` emite `desire_missing=true` cuando cualquiera de las columnas `ai_desire`, `ai_desire_label` o `desire_magnitude` vienen vacías tras revisar también `product.desire` y `extras.desire`.
+- **Runner actual:** `product_research_app/ai/runner.py::_process_desire` recorre el `rows_by_id` precargado y solo marca como pendientes los que no pasan `_has_compact_ai_desire` (verifica 2–3 líneas <=90 chars). No valida `ai_desire_label`/`desire_magnitude`, no limita por IDs vía SQL ni reserva llamadas antes de Winner Score.
+- **Orquestador desire:** `product_research_app/ai/gpt_orchestrator.py::run_desire_batch` espera que la respuesta sea JSON puro (sin fences), simplemente hace `json.loads(response)` y devuelve un dict `{id: {lines,class,magnitude,keywords}}` con validaciones mínimas.
+- **Selección y UPDATE actuales:** La selección de pendientes se hace en memoria, ignorando columnas parcialmente vacías. El UPDATE escribe `ai_desire`, `ai_desire_label`, `desire_magnitude` y `ai_columns_completed_at` (y `desire_summary` si existe) pero no hay logs de diagnóstico, y el `conn.commit()` está envuelto en `try/except` que ignora errores.
+- **Archivos a tocar:** `product_research_app/ai/runner.py`, `product_research_app/ai/gpt_orchestrator.py`, posiblemente `product_research_app/services/config.py` o similar para defaults, y nuevo `scripts/smoke_desire.py`.
 - **Causa raíz /_ai_status 404:** La ruta existe en `product_research_app/web_app.py`, pero solo se inicializa `AI_STATUS` cuando se invoca `safe_run_post_import_auto`. El flujo de importación XLSX (`_process_import_job`) nunca llama a ese runner y, tras finalizar, no hay estado asociado al `task_id`, por lo que el `GET /_ai_status` devuelve 404.
 - **Columnas IA vacías tras importación:** En la importación XLSX se invoca el legado `ai_columns.fill_ai_columns` (sin seguimiento de estado) en lugar de `run_post_import_auto`. No se ejecuta el runner que debería rellenar `ai_desire`, `ai_desire_label`, `desire_magnitude`, etc., y la UI (`_ensure_desire` en `product_research_app/web_app.py` y `preprocessProducts` en `product_research_app/static/index.html`) termina registrando `desire_missing=true`.
 - **Runner existente:** `product_research_app/ai/runner.py` ya implementa lotes para deseo/imputación/winner score y actualiza las columnas correctas vía `UPDATE products ...`, pero depende de que se le pase la lista de IDs recién importados y de que se inicialice el estado. También carece de helpers `set_error` / trazas extendidas solicitadas.
@@ -33,6 +38,10 @@
 - Migración defensiva en `database.initialize_database` para copiar `desire_summary` a `ai_desire` en bases antiguas.
 - Logs de `_ensure_desire` incluyen razones y timestamp de actualización.
 - Nuevo script `scripts/smoke_ai_auto.py` para smoke test end-to-end.
+- **Actualización Desire 2024-PR401:**
+  - `product_research_app/ai/runner.py` garantiza que Desire se ejecute primero con reserva mínima de llamadas, selecciona pendientes vía SQL filtrando `ai_desire`, `ai_desire_label` y `desire_magnitude`, añade trazas detalladas (pendientes, envíos, respuestas, actualizaciones) y actualiza solo las columnas requeridas con `executemany+commit`. También sincroniza `desire_summary`, maneja respuestas vacías y expone `run_desire_only` para pruebas.
+  - `product_research_app/ai/gpt_orchestrator.py::run_desire_batch` ahora recorta fences, fuerza JSON-only, normaliza texto (≤3 líneas de 90 chars), etiqueta (`alto|medio|bajo`) y magnitud (0–100) devolviendo `{id: {text,label,magnitude}}` más el cuerpo crudo.
+  - Nuevo `scripts/smoke_desire.py` lanza el pipeline sólo de Desire sobre los ids del último import, imprime métricas y muestras.
 
 ## Validación
 - `pytest` (tras `pip install -r requirements.txt`).

--- a/scripts/smoke_desire.py
+++ b/scripts/smoke_desire.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+from product_research_app.ai.ai_status import get_status
+from product_research_app.ai.runner import BatchResult, run_desire_only
+
+DEFAULT_DB_PATH = Path(__file__).resolve().parent.parent / "product_research_app" / "data.sqlite3"
+DEFAULT_LIMIT = 100
+
+
+def _parse_ids(raw: str) -> List[int]:
+    values: List[int] = []
+    for chunk in raw.replace(",", " ").split():
+        try:
+            num = int(chunk.strip())
+        except Exception:
+            continue
+        if num > 0:
+            values.append(num)
+    return values
+
+
+def _fetch_latest_job(conn: sqlite3.Connection) -> sqlite3.Row | None:
+    cur = conn.execute(
+        "SELECT id, created_at, rows_imported, ai_pending FROM import_jobs ORDER BY created_at DESC LIMIT 1"
+    )
+    return cur.fetchone()
+
+
+def _fetch_job(conn: sqlite3.Connection, task_id: int) -> sqlite3.Row | None:
+    cur = conn.execute(
+        "SELECT id, created_at, rows_imported, ai_pending FROM import_jobs WHERE id=?",
+        (task_id,),
+    )
+    return cur.fetchone()
+
+
+def _determine_product_ids(
+    conn: sqlite3.Connection,
+    job_row: sqlite3.Row | None,
+    args_ids: str | None,
+    limit: int,
+) -> List[int]:
+    if args_ids:
+        return _parse_ids(args_ids)
+
+    if job_row is None:
+        raise RuntimeError("No import job information available; provide --ids")
+
+    pending_ids_raw = job_row["ai_pending"] if "ai_pending" in job_row.keys() else None
+    if pending_ids_raw:
+        try:
+            pending = json.loads(pending_ids_raw)
+        except Exception:
+            pending = []
+        else:
+            if isinstance(pending, list):
+                parsed = [int(pid) for pid in pending if isinstance(pid, (int, float, str))]
+                parsed = [pid for pid in parsed if isinstance(pid, int) and pid > 0]
+                if parsed:
+                    return parsed[:limit]
+
+    rows_imported = int(job_row["rows_imported"] or 0)
+    created_at = job_row["created_at"]
+    if rows_imported > 0:
+        base_target = rows_imported
+    else:
+        base_target = DEFAULT_LIMIT
+    if limit and limit > 0:
+        target = min(limit, base_target) if rows_imported > 0 else limit
+    else:
+        target = base_target
+    target = max(1, target)
+
+    ids: List[int] = []
+    if created_at:
+        cur = conn.execute(
+            "SELECT id FROM products WHERE import_date >= ? ORDER BY id ASC LIMIT ?",
+            (created_at, target),
+        )
+        ids = [int(row[0]) for row in cur.fetchall()]
+    if not ids:
+        cur = conn.execute(
+            "SELECT id FROM products ORDER BY id DESC LIMIT ?",
+            (target,),
+        )
+        ids = [int(row[0]) for row in cur.fetchall()][::-1]
+    return ids
+
+
+def _print_samples(conn: sqlite3.Connection, ids: Iterable[int]) -> None:
+    id_list = list(dict.fromkeys(int(pid) for pid in ids if pid is not None))
+    if not id_list:
+        print("No product ids to sample.")
+        return
+    placeholders = ",".join("?" for _ in id_list)
+    cur = conn.execute(
+        f"SELECT COUNT(*) FROM products WHERE id IN ({placeholders}) "
+        "AND ai_desire IS NOT NULL AND desire_magnitude IS NOT NULL",
+        tuple(id_list),
+    )
+    total = cur.fetchone()[0]
+    print(f"Products with desire data: {total}/{len(id_list)}")
+    cur = conn.execute(
+        f"SELECT id, ai_desire, ai_desire_label, desire_magnitude "
+        f"FROM products WHERE id IN ({placeholders}) AND ai_desire IS NOT NULL "
+        "ORDER BY id ASC LIMIT 5",
+        tuple(id_list),
+    )
+    rows = cur.fetchall()
+    if not rows:
+        print("No samples available.")
+        return
+    for row in rows:
+        desire_text = str(row["ai_desire"] or "").replace("\n", " ")
+        snippet = desire_text[:120]
+        print(
+            f"- #{row['id']} label={row['ai_desire_label']} magnitude={row['desire_magnitude']} text={snippet}"
+        )
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description="Smoke test for the desire pipeline")
+    parser.add_argument("--db-path", type=Path, default=DEFAULT_DB_PATH, help="SQLite database path")
+    parser.add_argument("--task-id", help="Import task id to reuse", default=None)
+    parser.add_argument("--ids", help="Comma/space separated product ids", default=None)
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT, help="Maximum number of ids to inspect")
+    args = parser.parse_args(argv)
+
+    db_path = args.db_path
+    if not db_path.exists():
+        raise FileNotFoundError(f"Database not found: {db_path}")
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        job_row: sqlite3.Row | None
+        task_id_value = args.task_id
+        job_row = None
+        if task_id_value:
+            try:
+                job_id = int(task_id_value)
+            except ValueError:
+                job_id = None
+            if job_id is not None:
+                job_row = _fetch_job(conn, job_id)
+            task_id = str(task_id_value)
+        else:
+            job_row = _fetch_latest_job(conn)
+            if not job_row:
+                raise RuntimeError("No import jobs found; provide --ids explicitly")
+            task_id = str(job_row["id"])
+
+        product_ids = _determine_product_ids(conn, job_row, args.ids, args.limit)
+        product_ids = [pid for pid in product_ids if isinstance(pid, int) and pid > 0]
+        product_ids = list(dict.fromkeys(product_ids))
+        if not product_ids:
+            raise RuntimeError("No product ids resolved; use --ids to provide them")
+    finally:
+        conn.close()
+
+    print(f"Running desire pipeline for task_id={task_id} ids={product_ids[:10]}...", flush=True)
+    result: BatchResult = run_desire_only(task_id, product_ids)
+    print(
+        f"Runner result: processed={result.processed} failed={result.failed} calls={result.calls}",
+        flush=True,
+    )
+
+    status_snapshot = get_status(task_id)
+    if status_snapshot:
+        desire_status = status_snapshot.get("desire") or {}
+        print(f"Status desire snapshot: {desire_status}")
+        if status_snapshot.get("notes"):
+            print(f"Status notes: {status_snapshot['notes']}")
+        if status_snapshot.get("last_error"):
+            print(f"Last error: {status_snapshot['last_error']}")
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        _print_samples(conn, product_ids)
+    finally:
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- refactor the AI desire runner to select pending rows via SQL, reserve budgeted calls, and log detailed diagnostics while updating only the desired columns
- harden run_desire_batch to trim JSON fences, normalize lines/labels/magnitudes, and expose the raw response for troubleshooting
- add a smoke_desire.py helper to rerun the desire pipeline against recent imports for quick verification

## Testing
- pytest *(fails: missing optional dependency flask)*

------
https://chatgpt.com/codex/tasks/task_e_68cb36b72f308328974d68e8f4c4947a