### PR TITLE
feat: redesign header progress indicator with stage-aware updates

### DIFF
--- a/product_research_app/static/css/loading.css
+++ b/product_research_app/static/css/loading.css
@@ -1,17 +1,47 @@
-/* Barra de progreso embebida en la cabecera */
+/* ===================== Header Progress ===================== */
 #app-header { position: relative; }
-#header-progress {
-  position: absolute; left: 0; right: 0; bottom: 0;
-  height: 4px; background: rgba(255,255,255,0.12);
-  border-radius: 0; overflow: hidden; opacity: 0; transition: opacity 160ms ease;
-  pointer-events: none; z-index: 10;
+
+/* Contenedor pegado al borde inferior del header */
+#header-progress{
+  position:absolute; left:12px; right:12px; bottom:6px;
+  display:flex; align-items:center; gap:10px;
+  pointer-events:none; z-index:10; opacity:0; transition:opacity 160ms ease;
+  --hp-track: rgba(255,255,255,0.14);
+  --hp-fill: #8b5cf6; /* violeta sólido, cambia si tu tema usa otro primario */
+  --hp-text: rgba(255,255,255,0.85);
 }
-#header-progress .hp-fill {
-  width: 0%; height: 100%;
-  background: linear-gradient(90deg, #6bc1ff, #9be77f);
+
+/* Pista gruesa */
+#header-progress .hp-track{
+  flex:1; height:16px; border-radius:9999px; overflow:hidden;
+  background: var(--hp-track); outline:1px solid rgba(0,0,0,0.15);
+}
+
+/* Relleno con transición de ancho (sin degradados chillones) */
+#header-progress .hp-fill{
+  height:100%; width:0%;
+  background: var(--hp-fill);
   transition: width 140ms ease-out;
+  position:relative;
 }
-#header-progress .hp-label {
-  position: absolute; right: 10px; bottom: 6px; font-size: 11px;
-  color: rgba(255,255,255,0.7); user-select: none;
+
+/* % dentro de la barra, legible */
+#header-progress .hp-percent{
+  position:absolute; right:8px; top:50%; transform:translateY(-50%);
+  font-size:12px; line-height:1; color:white; font-variant-numeric: tabular-nums;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.35);
 }
+
+/* Meta info a la izquierda: título + etapa */
+#header-progress .hp-meta{
+  display:flex; align-items:center; gap:8px; white-space:nowrap;
+  color: var(--hp-text); font-size:12px; text-shadow: 0 1px 2px rgba(0,0,0,0.2);
+}
+#header-progress .hp-title{ font-weight:600; }
+#header-progress .hp-stage{ opacity:.85; }
+
+/* Visible mientras haya progreso > 0 */
+#header-progress.is-active{ opacity:1; }
+
+/* Accesibilidad al foco (por si se navega con teclado/lectores) */
+#header-progress:focus-visible { outline: 2px solid #ffffff55; border-radius: 10px; }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -95,7 +95,7 @@ body.dark .skeleton{background:#333;}
 </head>
 <body class="dark">
 <div id="topBar">
-  <header id="app-header" style="padding:8px 15px; display:flex; align-items:center; justify-content:space-between;">
+  <header id="app-header" style="padding:8px 15px; display:flex; align-items:center; justify-content:space-between; position:relative;">
     <div style="display:flex; align-items:center; gap:8px;">
       <h1 style="margin:0; font-size:1.4rem;">Ecom Testing App</h1>
       <p style="margin:0;font-size:12px; opacity:0.8;">By El Tito 🤙</p>
@@ -108,9 +108,16 @@ body.dark .skeleton{background:#333;}
       <button id="darkToggle" title="Modo oscuro">🌙</button>
       <button id="configBtn" title="Configuración avanzada">⚙️</button>
     </div>
-    <div id="header-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100">
-      <div class="hp-fill"></div>
-      <span class="hp-label" aria-hidden="true"></span>
+    <div id="header-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+      <div class="hp-track">
+        <div class="hp-fill">
+          <span class="hp-percent">0%</span>
+        </div>
+      </div>
+      <div class="hp-meta">
+        <span class="hp-title">Proceso</span>
+        <span class="hp-stage">En espera</span>
+      </div>
     </div>
   </header>
   <!-- Search bar row with controls -->
@@ -386,6 +393,7 @@ window.groupsService = groupsService;
 const IMPORT_TASK_LS_KEY = 'last_import_task';
 const IMPORT_UPLOAD_FRAC = 0.30;
 const IMPORT_POLL_MAX_FRAC = 0.99;
+const IMPORT_SERVER_SPAN = IMPORT_POLL_MAX_FRAC - IMPORT_UPLOAD_FRAC;
 const IMPORT_STATUS_URL = '/_import_status';
 const IMPORT_START_URL = '/upload';
 let savedApiKeyHash = null;
@@ -420,9 +428,9 @@ async function sha256(str) {
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 function mapServerFraction(serverPct) {
-  const span = IMPORT_POLL_MAX_FRAC - IMPORT_UPLOAD_FRAC;
   const clamped = Math.max(0, Math.min(100, Number(serverPct) || 0));
-  return IMPORT_UPLOAD_FRAC + (clamped / 100) * span;
+  const frac = IMPORT_UPLOAD_FRAC + (clamped / 100) * IMPORT_SERVER_SPAN;
+  return Math.min(IMPORT_POLL_MAX_FRAC, frac);
 }
 
 async function followImportTask(taskId, tracker, { statusUrl = IMPORT_STATUS_URL } = {}) {
@@ -442,42 +450,33 @@ async function followImportTask(taskId, tracker, { statusUrl = IMPORT_STATUS_URL
     }
     if (data.ui_cost_message) showImportBanner(data.ui_cost_message);
     const raw = data.pct ?? data.percent ?? data.percentage ?? data.progress ?? (data.done ? 100 : undefined);
-    if (Number.isFinite(Number(raw))) {
-      tracker?.step(mapServerFraction(Number(raw)));
-    }
+    let serverPct = Number(raw);
+    if (!Number.isFinite(serverPct)) serverPct = 0;
+    serverPct = Math.max(0, Math.min(100, serverPct));
+    const stage = (data.message || data.stage || data.state || '').toString() || 'Procesando…';
+    tracker?.step(mapServerFraction(serverPct), stage);
+
     const statusVal = String(data.state || data.status || '').toLowerCase();
-    if (['pending', 'running', 'ai', 'processing'].includes(statusVal)) {
-      await sleep(600);
-      continue;
+    if (statusVal === 'error' || data.error) {
+      throw new Error(data.error || 'Error en importación');
     }
-    if (statusVal === 'done' || statusVal === 'completed' || statusVal === 'finished' || Number(raw) >= 100) {
+    if (statusVal === 'unknown' || !statusVal) {
+      throw new Error('Estado de importación desconocido');
+    }
+    if (serverPct >= 100 || statusVal === 'done' || statusVal === 'completed' || statusVal === 'finished') {
       await reloadTable({ skipProgress: true });
       hideImportBanner();
       return data;
     }
-    if (statusVal === 'error' || data.error) {
-      hideImportBanner();
-      toast.error(data.error || 'Error en importación');
-      return data;
-    }
-    if (statusVal === 'unknown' || !statusVal) {
-      toast.error('Estado de importación desconocido');
-      hideImportBanner();
-      return data;
-    }
-    await sleep(600);
+    await sleep(450);
   }
 }
 
-async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IMPORT_STATUS_URL, btn } = {}) {
+async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IMPORT_STATUS_URL } = {}) {
   if (!file) throw new Error('Archivo no válido');
-  const tracker = LoadingHelpers.start('Importando catálogo', { btn });
-  let trackerFinished = false;
-  const finishTracker = () => {
-    if (trackerFinished) return;
-    trackerFinished = true;
-    tracker.done();
-  };
+  const tracker = LoadingHelpers.start('Importando catálogo');
+  tracker.setStage('Subiendo archivo…');
+  let lastResult = null;
   try {
     const fd = new FormData();
     fd.append('file', file);
@@ -489,42 +488,33 @@ async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IM
       xhr.upload.onprogress = (event) => {
         if (!event.lengthComputable) return;
         const frac = Math.min(IMPORT_UPLOAD_FRAC, (event.loaded / event.total) * IMPORT_UPLOAD_FRAC);
-        tracker.step(frac);
+        tracker.step(frac, 'Subiendo archivo…');
       };
-      xhr.onerror = () => reject(new Error('Error de red subiendo el archivo'));
+      xhr.onerror = () => reject(new Error('Error de red subiendo archivo'));
       xhr.onload = () => {
         let payload = xhr.response;
         if (!payload && xhr.responseText) {
           try { payload = JSON.parse(xhr.responseText); }
           catch (e) { payload = null; }
         }
-        if (xhr.status >= 200 && xhr.status < 300 && payload) {
-          if (payload.task_id) {
-            resolve({ kind: 'async', data: payload, taskId: payload.task_id });
-            return;
-          }
-          if (payload.ok) {
-            resolve({ kind: 'sync', data: payload });
-            return;
-          }
-          if (payload.error) {
-            reject(new Error(payload.error));
-            return;
-          }
-          resolve({ kind: 'sync', data: payload });
-        } else {
+        const ok = xhr.status >= 200 && xhr.status < 300;
+        if (!ok || !payload) {
           const message = payload?.error || payload?.message || 'Respuesta inválida al iniciar importación';
           reject(new Error(message));
+          return;
         }
+        if (payload.task_id) {
+          resolve({ kind: 'async', taskId: payload.task_id, data: payload });
+          return;
+        }
+        resolve({ kind: 'sync', data: payload });
       };
       xhr.send(fd);
     });
 
     if (startResult.kind === 'sync') {
+      tracker.step(1, 'Completado');
       await reloadTable({ skipProgress: true });
-      tracker.step(1);
-      finishTracker();
-      hideImportBanner();
       const importedCount = startResult.data?.imported ?? startResult.data?.rows_imported;
       if (Number.isFinite(importedCount) && importedCount > 0) {
         toast.success(`Importados ${importedCount}`);
@@ -534,28 +524,28 @@ async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IM
 
     const taskId = startResult.taskId;
     const idStr = typeof taskId === 'string' ? taskId : String(taskId);
-    tracker.step(IMPORT_UPLOAD_FRAC);
+    tracker.step(IMPORT_UPLOAD_FRAC, 'Archivo subido');
     localStorage.setItem(IMPORT_TASK_LS_KEY, idStr);
-    const result = await followImportTask(idStr, tracker, { statusUrl });
-    localStorage.removeItem(IMPORT_TASK_LS_KEY);
-    const importedCount = result?.imported ?? result?.rows_imported;
+
+    lastResult = await followImportTask(idStr, tracker, { statusUrl });
+
+    const importedCount = lastResult?.imported ?? lastResult?.rows_imported;
     if (Number.isFinite(importedCount) && importedCount > 0) {
       toast.success(`Importados ${importedCount}`);
     }
-    tracker.step(1);
-    finishTracker();
-    return result;
+    tracker.step(1, 'Completado');
+    return lastResult;
   } catch (err) {
-    localStorage.removeItem(IMPORT_TASK_LS_KEY);
-    hideImportBanner();
+    tracker.step(1, 'Error');
     toast.error(err?.message || 'Error al importar catálogo');
-    tracker.step(1);
-    finishTracker();
     throw err;
   } finally {
-    finishTracker();
+    tracker.done();
+    localStorage.removeItem(IMPORT_TASK_LS_KEY);
+    hideImportBanner();
   }
 }
+
 // Ensure the server shuts down cleanly when the tab or window is closed.
 // Using fetch with `keepalive` guarantees the request completes even during unload.
 window.addEventListener('beforeunload', () => {
@@ -1194,19 +1184,21 @@ window.onload = async () => {
   if (tid) {
     toast.info('Reanudando importación previa…');
     const tracker = LoadingHelpers.start('Importando catálogo');
-    tracker.step(IMPORT_UPLOAD_FRAC);
+    tracker.step(IMPORT_UPLOAD_FRAC, 'Reanudando…');
     try {
       const result = await followImportTask(tid, tracker);
       const importedCount = result?.imported ?? result?.rows_imported;
-      const statusVal = String(result?.state || result?.status || '').toLowerCase();
-      if (statusVal === 'done' || statusVal === 'completed' || statusVal === 'finished') {
-        if (Number.isFinite(importedCount) && importedCount > 0) {
-          toast.success(`Importados ${importedCount}`);
-        }
+      if (Number.isFinite(importedCount) && importedCount > 0) {
+        toast.success(`Importados ${importedCount}`);
       }
+      tracker.step(1, 'Completado');
+    } catch (err) {
+      tracker.step(1, 'Error');
+      toast.error(err?.message || 'Error en importación');
     } finally {
       localStorage.removeItem(IMPORT_TASK_LS_KEY);
       tracker.done();
+      hideImportBanner();
     }
   }
 };

--- a/product_research_app/static/js/loading.js
+++ b/product_research_app/static/js/loading.js
@@ -1,92 +1,105 @@
-// loading.js — progreso embebido en cabecera, sin overlay ni barra superior global
+// loading.js — barra gruesa en cabecera con % y mensaje de etapa
 const HeaderProgress = (() => {
-  let host, fill, label;
-  let active = 0;
-  const tasks = new Map(); // id -> progress [0..1]
+  let host, track, fill, pctEl, meta, titleEl, stageEl;
+  const tasks = new Map(); // id -> {progress, title, stage}
 
-  const ensure = () => {
+  function ensure(){
     if (host) return;
     host = document.querySelector('#header-progress');
     if (!host) return;
-    fill = host.querySelector('.hp-fill');
-    label = host.querySelector('.hp-label');
-  };
+    track = host.querySelector('.hp-track');
+    fill  = host.querySelector('.hp-fill');
+    pctEl = host.querySelector('.hp-percent');
+    meta  = host.querySelector('.hp-meta');
+    titleEl = meta.querySelector('.hp-title');
+    stageEl = meta.querySelector('.hp-stage');
+  }
 
-  const setPct = (pct) => {
+  function setPct(p){
     ensure(); if (!host) return;
-    const p = Math.max(0, Math.min(100, Math.round(pct)));
-    fill.style.width = p + '%';
-    host.setAttribute('aria-valuenow', String(p));
-    label.textContent = p > 0 && p < 100 ? p + '%' : '';
-    host.style.opacity = p === 0 ? 0 : 1;
-  };
-
-  const refresh = (finishing=false) => {
-    if (tasks.size === 0) {
-      if (finishing) setPct(100);
-      setTimeout(() => setPct(0), 220);
-      return;
+    const pct = Math.max(0, Math.min(100, Math.round(p)));
+    fill.style.width = pct + '%';
+    pctEl.textContent = pct + '%';
+    host.setAttribute('aria-valuenow', String(pct));
+    if (pct > 0 && pct < 100) host.classList.add('is-active');
+    else if (pct === 100) {
+      // pequeña pausa al 100% antes de ocultar
+      setTimeout(() => { host.classList.remove('is-active'); fill.style.width = '0%'; pctEl.textContent = '0%'; }, 350);
+    } else {
+      host.classList.remove('is-active');
     }
-    let sum = 0;
-    for (const v of tasks.values()) sum += (v ?? 0);
-    const avg = sum / tasks.size;
-    setPct(Math.min(99, avg * 100));
-  };
+  }
 
-  const startTask = (labelTxt = 'Cargando…') => {
+  function refresh(){
+    if (tasks.size === 0) { setPct(0); return; }
+    // promedio simple de progresos
+    let sum = 0; let last;
+    for (const t of tasks.values()){ sum += (t.progress || 0); last = t; }
+    const avg = Math.min(0.99, sum / tasks.size);
+    setPct(Math.round(avg * 100));
+    // muestra el título/etapa del último iniciado
+    if (last){
+      if (last.title) titleEl.textContent = last.title;
+      if (last.stage) stageEl.textContent = last.stage;
+    }
+  }
+
+  function startTask(title = 'Procesando…'){
     ensure();
     const id = `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
-    tasks.set(id, 0);
-    active++;
-    if (active === 1) setPct(2); // arranque visual
+    tasks.set(id, { progress: 0, title, stage: 'Iniciando' });
+    refresh();
+
     return {
       id,
-      step(frac) { tasks.set(id, Math.max(0, Math.min(1, frac))); refresh(false); },
-      done() { tasks.delete(id); active = Math.max(0, active - 1); refresh(true); }
+      step(frac, stage){
+        const t = tasks.get(id); if (!t) return;
+        t.progress = Math.max(0, Math.min(1, frac));
+        if (stage) { t.stage = stage; }
+        refresh();
+      },
+      setStage(stage){
+        const t = tasks.get(id); if (!t) return;
+        t.stage = stage; refresh();
+      },
+      done(){
+        tasks.delete(id);
+        if (tasks.size === 0) setPct(100); else refresh();
+      }
     };
-  };
+  }
 
   return { startTask };
 })();
 
 window.AppLoading = HeaderProgress;
 
-// --- Hooks globales de red (ligeros) ---
-// No estimamos porcentaje aquí; solo marcamos tarea en curso.
+// Hooks de red (opcionales: marcan actividad, sin %)
 (() => {
-  const SKIP_KEY = '__skipLoadingHook';
   const _fetch = window.fetch;
-  window.fetch = async function(input, init) {
-    if (init && init[SKIP_KEY]) {
-      const cloned = { ...init };
-      delete cloned[SKIP_KEY];
-      return _fetch.call(this, input, cloned);
-    }
-    const t = window.AppLoading.startTask('Red');
-    try { return await _fetch.call(this, input, init); }
+  window.fetch = async function(input, init){
+    const t = window.AppLoading.startTask('Cargando datos');
+    try { return await _fetch(input, init); }
     finally { t.done(); }
   };
 
   const _open = XMLHttpRequest.prototype.open;
   const _send = XMLHttpRequest.prototype.send;
-  XMLHttpRequest.prototype.open = function(method, url, async, user, password) {
+  XMLHttpRequest.prototype.open = function(method, url, async, user, password){
     this.__url = url; return _open.apply(this, arguments);
   };
-  XMLHttpRequest.prototype.send = function(body) {
-    if (this && this[SKIP_KEY]) {
-      return _send.apply(this, arguments);
-    }
-    const t = window.AppLoading.startTask('Red');
+  XMLHttpRequest.prototype.send = function(body){
+    const t = window.AppLoading.startTask('Comunicando…');
     const end = () => t.done();
     this.addEventListener('loadend', end);
     this.addEventListener('error', end);
     this.addEventListener('abort', end);
     try { return _send.apply(this, arguments); }
-    catch (e) { end(); throw e; }
+    catch(e){ end(); throw e; }
   };
 })();
 
-// Helper de pasos para procesos largos (con % real)
+// Helper para tareas con % real
 export const LoadingHelpers = {
-  start(label) { return window.AppLoading.startTask(label); }
+  start(title){ return window.AppLoading.startTask(title); }
 };


### PR DESCRIPTION
## Summary
- replace the header progress markup with the new track/fill/stage layout and wire import/resume logic to send stage text
- refresh the loading styles and helper script to render a solid 16px bar with percent and accessibility metadata
- update the catalog import flow to map upload/back-end progress into stages while preserving resume and toast behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc0b9d565c8328be73f0a53888a25a