### PR TITLE
Improve bulk import performance and tracking

### DIFF
--- a/product_research_app/database.py
+++ b/product_research_app/database.py
@@ -107,6 +107,9 @@ def initialize_database(conn: sqlite3.Connection) -> None:
         cur.execute("ALTER TABLE products ADD COLUMN winner_score_raw REAL")
     if "winner_score_updated_at" not in cols:
         cur.execute("ALTER TABLE products ADD COLUMN winner_score_updated_at TEXT")
+    if "sig_hash" not in cols:
+        cur.execute("ALTER TABLE products ADD COLUMN sig_hash TEXT")
+    cur.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_products_sig_hash ON products(sig_hash)")
     metric_text_cols = [
         "magnitud_deseo",
         "nivel_consciencia_headroom",
@@ -287,12 +290,18 @@ def initialize_database(conn: sqlite3.Connection) -> None:
         CREATE TABLE IF NOT EXISTS import_jobs (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             status TEXT NOT NULL,
+            phase TEXT NOT NULL DEFAULT 'parse',
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
+            total INTEGER DEFAULT 0,
+            processed INTEGER DEFAULT 0,
             rows_imported INTEGER DEFAULT 0,
             winner_score_updated INTEGER DEFAULT 0,
             error TEXT,
             temp_path TEXT,
+            config JSON,
+            budget_cents INTEGER,
+            metrics JSON,
             ai_total INTEGER DEFAULT 0,
             ai_done INTEGER DEFAULT 0,
             ai_error TEXT,
@@ -325,6 +334,102 @@ def initialize_database(conn: sqlite3.Connection) -> None:
         cur.execute("ALTER TABLE import_jobs ADD COLUMN winner_score_updated INTEGER DEFAULT 0")
     except Exception:
         pass
+    try:
+        cur.execute("ALTER TABLE import_jobs ADD COLUMN phase TEXT DEFAULT 'parse'")
+    except Exception:
+        pass
+    try:
+        cur.execute("ALTER TABLE import_jobs ADD COLUMN total INTEGER DEFAULT 0")
+    except Exception:
+        pass
+    try:
+        cur.execute("ALTER TABLE import_jobs ADD COLUMN processed INTEGER DEFAULT 0")
+    except Exception:
+        pass
+    try:
+        cur.execute("ALTER TABLE import_jobs ADD COLUMN config JSON")
+    except Exception:
+        pass
+    try:
+        cur.execute("ALTER TABLE import_jobs ADD COLUMN budget_cents INTEGER")
+    except Exception:
+        pass
+    try:
+        cur.execute("ALTER TABLE import_jobs ADD COLUMN metrics JSON")
+    except Exception:
+        pass
+    try:
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_import_jobs_phase ON import_jobs(phase)")
+    except Exception:
+        pass
+
+    # Staging table for high volume imports
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS products_staging (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id INTEGER NOT NULL,
+            sig_hash TEXT NOT NULL,
+            name TEXT NOT NULL,
+            description TEXT,
+            category TEXT,
+            price REAL,
+            currency TEXT,
+            image_url TEXT,
+            brand TEXT,
+            asin TEXT,
+            product_url TEXT,
+            source TEXT,
+            import_date TEXT NOT NULL,
+            desire TEXT,
+            desire_magnitude TEXT,
+            awareness_level TEXT,
+            competition_level TEXT,
+            date_range TEXT,
+            winner_score INTEGER,
+            extra JSON,
+            FOREIGN KEY(job_id) REFERENCES import_jobs(id) ON DELETE CASCADE
+        )
+        """
+    )
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_products_staging_job ON products_staging(job_id)")
+    cur.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_products_staging_job_sig ON products_staging(job_id, sig_hash)"
+    )
+
+    # Import job items to track row state transitions
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id INTEGER NOT NULL,
+            sig_hash TEXT NOT NULL,
+            raw JSON NOT NULL,
+            state TEXT NOT NULL CHECK(state IN ('raw','pending_enrich','enriched','failed')),
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY(job_id) REFERENCES import_jobs(id) ON DELETE CASCADE
+        )
+        """
+    )
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_items_job ON items(job_id)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_items_state ON items(state)")
+
+    # Batch metrics for observability
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS import_job_metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id INTEGER NOT NULL,
+            batch_no INTEGER NOT NULL,
+            rows INTEGER NOT NULL,
+            duration_ms REAL NOT NULL,
+            throughput REAL NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY(job_id) REFERENCES import_jobs(id) ON DELETE CASCADE
+        )
+        """
+    )
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_import_job_metrics_job ON import_job_metrics(job_id)")
     conn.commit()
 
 
@@ -345,6 +450,7 @@ def insert_product(
     extra: Optional[Dict[str, Any]] = None,
     commit: bool = True,
     product_id: Optional[int] = None,
+    sig_hash: Optional[str] = None,
 ) -> int:
     """Insert a new product into the database.
 
@@ -389,8 +495,8 @@ def insert_product(
             INSERT INTO products (
                 id, name, description, category, price, currency, image_url, source,
                 import_date, desire, desire_magnitude, awareness_level,
-                competition_level, date_range, extra)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, json(?))
+                competition_level, date_range, extra, sig_hash)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, json(?), ?)
             """,
             (
                 product_id,
@@ -408,6 +514,7 @@ def insert_product(
                 competition_level,
                 date_range,
                 json_dump(extra) if extra is not None else "{}",
+                sig_hash,
             ),
         )
     else:
@@ -416,8 +523,8 @@ def insert_product(
             INSERT INTO products (
                 name, description, category, price, currency, image_url, source,
                 import_date, desire, desire_magnitude, awareness_level,
-                competition_level, date_range, extra)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, json(?))
+                competition_level, date_range, extra, sig_hash)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, json(?), ?)
             """,
             (
                 name,
@@ -434,6 +541,7 @@ def insert_product(
                 competition_level,
                 date_range,
                 json_dump(extra) if extra is not None else "{}",
+                sig_hash,
             ),
         )
     if commit:
@@ -776,16 +884,41 @@ def delete_product(conn: sqlite3.Connection, product_id: int) -> None:
     conn.commit()
 
 
-def create_import_job(conn: sqlite3.Connection, temp_path: str) -> int:
+def create_import_job(
+    conn: sqlite3.Connection,
+    temp_path: Optional[str] = None,
+    *,
+    status: str = "pending",
+    phase: str = "parse",
+    total: int = 0,
+    processed: int = 0,
+    config: Optional[Dict[str, Any]] = None,
+    budget_cents: Optional[int] = None,
+) -> int:
     """Create a new pending import job and return its ID."""
+
     now = datetime.utcnow().isoformat()
     cur = conn.cursor()
     cur.execute(
         """
-        INSERT INTO import_jobs (status, created_at, updated_at, rows_imported, winner_score_updated, error, temp_path, ai_total, ai_done, ai_error)
-        VALUES ('pending', ?, ?, 0, 0, NULL, ?, 0, 0, NULL)
+        INSERT INTO import_jobs (
+            status, phase, created_at, updated_at, total, processed,
+            rows_imported, winner_score_updated, error, temp_path,
+            config, budget_cents, metrics, ai_total, ai_done, ai_error, ai_counts, ai_pending
+        )
+        VALUES (?, ?, ?, ?, ?, ?, 0, 0, NULL, ?, json(?), ?, NULL, 0, 0, NULL, NULL, NULL)
         """,
-        (now, now, temp_path),
+        (
+            status,
+            phase,
+            now,
+            now,
+            int(total or 0),
+            int(processed or 0),
+            temp_path,
+            json_dump(config) if config is not None else None,
+            budget_cents,
+        ),
     )
     conn.commit()
     return cur.lastrowid
@@ -800,10 +933,17 @@ def complete_import_job(
     cur.execute(
         """
         UPDATE import_jobs
-        SET status='done', updated_at=?, rows_imported=?, winner_score_updated=?, error=NULL
+        SET status='done',
+            phase='done',
+            updated_at=?,
+            rows_imported=?,
+            processed=?,
+            total=CASE WHEN total < ? THEN ? ELSE total END,
+            winner_score_updated=?,
+            error=NULL
         WHERE id=?
         """,
-        (now, rows, winner_score_updated, job_id),
+        (now, rows, rows, rows, rows, winner_score_updated, job_id),
     )
     conn.commit()
 
@@ -815,7 +955,7 @@ def fail_import_job(conn: sqlite3.Connection, job_id: int, error: str) -> None:
     cur.execute(
         """
         UPDATE import_jobs
-        SET status='error', updated_at=?, error=?
+        SET status='error', phase='done', updated_at=?, error=?
         WHERE id=?
         """,
         (now, error, job_id),
@@ -873,7 +1013,31 @@ def get_import_history(conn: sqlite3.Connection, limit: int = 20) -> List[sqlite
     """Return recent import jobs ordered by creation time."""
     cur = conn.cursor()
     cur.execute(
-        "SELECT id AS task_id, status, rows_imported, winner_score_updated, created_at, updated_at, error, ai_total, ai_done, ai_error, ai_counts, ai_pending FROM import_jobs ORDER BY created_at DESC LIMIT ?",
+        """
+        SELECT
+            id AS task_id,
+            status,
+            phase,
+            total,
+            processed,
+            rows_imported,
+            winner_score_updated,
+            created_at,
+            updated_at,
+            error,
+            temp_path,
+            config,
+            budget_cents,
+            metrics,
+            ai_total,
+            ai_done,
+            ai_error,
+            ai_counts,
+            ai_pending
+        FROM import_jobs
+        ORDER BY created_at DESC
+        LIMIT ?
+        """,
         (limit,),
     )
     return cur.fetchall()
@@ -883,10 +1047,191 @@ def get_import_job(conn: sqlite3.Connection, job_id: int) -> Optional[sqlite3.Ro
     """Return a single import job by ID."""
     cur = conn.cursor()
     cur.execute(
-        "SELECT id AS task_id, status, rows_imported, winner_score_updated, created_at, updated_at, error, ai_total, ai_done, ai_error, ai_counts, ai_pending FROM import_jobs WHERE id=?",
+        """
+        SELECT
+            id AS task_id,
+            status,
+            phase,
+            total,
+            processed,
+            rows_imported,
+            winner_score_updated,
+            created_at,
+            updated_at,
+            error,
+            temp_path,
+            config,
+            budget_cents,
+            metrics,
+            ai_total,
+            ai_done,
+            ai_error,
+            ai_counts,
+            ai_pending
+        FROM import_jobs
+        WHERE id=?
+        """,
         (job_id,),
     )
     return cur.fetchone()
+
+
+def update_import_job_progress(
+    conn: sqlite3.Connection,
+    job_id: int,
+    *,
+    phase: Optional[str] = None,
+    status: Optional[str] = None,
+    processed: Optional[int] = None,
+    total: Optional[int] = None,
+    rows_imported: Optional[int] = None,
+    error: Optional[str] = None,
+    metrics: Optional[Dict[str, Any]] = None,
+    config: Optional[Dict[str, Any]] = None,
+    commit: bool = True,
+) -> None:
+    """Update phase/progress information for an import job."""
+
+    assignments = ["updated_at=?"]
+    params: List[Any] = [datetime.utcnow().isoformat()]
+    rows_value: Optional[int] = None
+    if phase is not None:
+        assignments.append("phase=?")
+        params.append(phase)
+    if status is not None:
+        assignments.append("status=?")
+        params.append(status)
+    if processed is not None:
+        assignments.append("processed=?")
+        processed_val = int(processed)
+        params.append(processed_val)
+        rows_value = processed_val
+    if total is not None:
+        assignments.append("total=?")
+        params.append(int(total))
+    if rows_imported is not None:
+        rows_value = int(rows_imported)
+
+    if rows_value is not None:
+        assignments.append("rows_imported=?")
+        params.append(rows_value)
+    if error is not None:
+        assignments.append("error=?")
+        params.append(error)
+    if metrics is not None:
+        assignments.append("metrics=json(?)")
+        params.append(json_dump(metrics))
+    if config is not None:
+        assignments.append("config=json(?)")
+        params.append(json_dump(config))
+
+    if len(assignments) == 1:
+        return
+
+    params.append(job_id)
+    sql = f"UPDATE import_jobs SET {', '.join(assignments)} WHERE id=?"
+    cur = conn.cursor()
+    cur.execute(sql, params)
+    if commit:
+        conn.commit()
+
+
+def append_import_job_metrics(
+    conn: sqlite3.Connection,
+    job_id: int,
+    batch_no: int,
+    rows: int,
+    duration_ms: float,
+    throughput: float,
+    *,
+    commit: bool = False,
+) -> None:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO import_job_metrics (job_id, batch_no, rows, duration_ms, throughput)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (job_id, batch_no, int(rows), float(duration_ms), float(throughput)),
+    )
+    if commit:
+        conn.commit()
+
+
+def get_recent_import_metrics(conn: sqlite3.Connection, limit: int = 50) -> List[sqlite3.Row]:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT job_id, batch_no, rows, duration_ms, throughput, created_at
+        FROM import_job_metrics
+        ORDER BY id DESC
+        LIMIT ?
+        """,
+        (limit,),
+    )
+    return cur.fetchall()
+
+
+def transition_job_items(
+    conn: sqlite3.Connection,
+    job_id: int,
+    from_state: str,
+    to_state: str,
+    *,
+    commit: bool = False,
+) -> int:
+    now = datetime.utcnow().isoformat()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE items SET state=?, updated_at=? WHERE job_id=? AND state=?",
+        (to_state, now, job_id, from_state),
+    )
+    if commit:
+        conn.commit()
+    return cur.rowcount
+
+
+def merge_staging_into_products(conn: sqlite3.Connection, job_id: int) -> None:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO products (
+            name, description, category, price, currency, image_url, source,
+            import_date, desire, desire_magnitude, awareness_level,
+            competition_level, date_range, winner_score, extra, sig_hash
+        )
+        SELECT
+            name, description, category, price, currency, image_url, source,
+            import_date, desire, desire_magnitude, awareness_level,
+            competition_level, date_range, winner_score, extra, sig_hash
+        FROM products_staging
+        WHERE job_id=?
+        ON CONFLICT(sig_hash) DO UPDATE SET
+            name=excluded.name,
+            description=excluded.description,
+            category=excluded.category,
+            price=excluded.price,
+            currency=excluded.currency,
+            image_url=excluded.image_url,
+            source=excluded.source,
+            import_date=excluded.import_date,
+            desire=excluded.desire,
+            desire_magnitude=excluded.desire_magnitude,
+            awareness_level=excluded.awareness_level,
+            competition_level=excluded.competition_level,
+            date_range=excluded.date_range,
+            winner_score=COALESCE(excluded.winner_score, products.winner_score),
+            extra=excluded.extra
+        """,
+        (job_id,),
+    )
+
+
+def clear_staging_for_job(conn: sqlite3.Connection, job_id: int, *, commit: bool = False) -> None:
+    cur = conn.cursor()
+    cur.execute("DELETE FROM products_staging WHERE job_id=?", (job_id,))
+    if commit:
+        conn.commit()
 
 def mark_stale_pending_imports(conn: sqlite3.Connection, minutes: int) -> None:
     """Mark pending imports older than X minutes as errored after restart."""

--- a/product_research_app/db.py
+++ b/product_research_app/db.py
@@ -1,10 +1,75 @@
+import logging
 import sqlite3
 import threading
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
+
+
+logger = logging.getLogger(__name__)
 
 _DB: Optional[sqlite3.Connection] = None
 _DB_PATH: Optional[str] = None
 _DB_LOCK = threading.Lock()
+_PERF_APPLIED: dict[str, bool] = {}
+_PERF_CONFIG: dict[str, Union[str, int]] = {
+    "journal_mode": "WAL",
+    "synchronous": "NORMAL",
+    "temp_store": "MEMORY",
+    "mmap_size": 268_435_456,
+}
+
+
+def _is_sqlite_url(target: Union[str, Path]) -> bool:
+    target_str = str(target)
+    if target_str.startswith("sqlite://"):
+        return True
+    if ":memory:" in target_str:
+        return True
+    return not any(target_str.startswith(prefix) for prefix in ("postgresql://", "mysql://", "mariadb://", "oracle://"))
+
+
+def init_db_performance(db_url_or_path: Union[str, Path], connection: Optional[sqlite3.Connection] = None) -> None:
+    """Apply high performance PRAGMA settings for SQLite databases.
+
+    The function is a no-op for non-SQLite URLs.  When ``connection`` is not
+    provided a temporary connection is opened and closed immediately after the
+    PRAGMAs are set.  The call is idempotent and the settings are only logged
+    once per database path.
+    """
+
+    target = str(db_url_or_path)
+    if not _is_sqlite_url(target):
+        return
+
+    if _PERF_APPLIED.get(target):
+        return
+
+    close_after = False
+    conn = connection
+    if conn is None:
+        conn = sqlite3.connect(target, check_same_thread=False)
+        close_after = True
+    try:
+        cur = conn.cursor()
+        cur.execute("PRAGMA journal_mode=WAL;")
+        cur.execute("PRAGMA synchronous=NORMAL;")
+        cur.execute("PRAGMA temp_store=MEMORY;")
+        cur.execute("PRAGMA mmap_size=268435456;")
+        conn.commit()
+        _PERF_APPLIED[target] = True
+        logger.info("PRAGMA set: WAL,NORMAL,MEMORY,mmap=256MB")
+    finally:
+        if close_after and conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def get_last_performance_config() -> dict[str, Union[str, int]]:
+    """Return the last applied PRAGMA configuration."""
+
+    return dict(_PERF_CONFIG)
 
 
 def get_db(path: str = "product_research_app/data.sqlite3", write: bool = False) -> sqlite3.Connection:
@@ -30,6 +95,7 @@ def get_db(path: str = "product_research_app/data.sqlite3", write: bool = False)
             if _DB is None:
                 conn = sqlite3.connect(target_path, check_same_thread=False, isolation_level=None)
                 conn.execute("PRAGMA foreign_keys=ON;")
+                init_db_performance(target_path, connection=conn)
                 conn.row_factory = sqlite3.Row
                 _DB = conn
                 _DB_PATH = target_path

--- a/product_research_app/services/importer_fast.py
+++ b/product_research_app/services/importer_fast.py
@@ -1,34 +1,31 @@
+from __future__ import annotations
+
 import csv
 import io
+import hashlib
+import logging
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Iterator, Mapping, Optional, Sequence
 
-from product_research_app.db import get_db
-from product_research_app.database import json_dump
+from product_research_app.db import get_db, get_last_performance_config, init_db_performance
+from product_research_app.database import (
+    append_import_job_metrics,
+    clear_staging_for_job,
+    create_import_job,
+    json_dump,
+    merge_staging_into_products,
+    transition_job_items,
+    update_import_job_progress,
+)
 
-UPSERT_SQL = """
-INSERT INTO products (
-    id, name, description, category, price, currency, image_url, source,
-    import_date, desire, desire_magnitude, awareness_level, competition_level,
-    date_range, winner_score, extra
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, json(?))
-ON CONFLICT(id) DO UPDATE SET
-    name=excluded.name,
-    description=excluded.description,
-    category=excluded.category,
-    price=excluded.price,
-    currency=excluded.currency,
-    image_url=excluded.image_url,
-    source=excluded.source,
-    import_date=excluded.import_date,
-    desire=excluded.desire,
-    desire_magnitude=excluded.desire_magnitude,
-    awareness_level=excluded.awareness_level,
-    competition_level=excluded.competition_level,
-    date_range=excluded.date_range,
-    winner_score=COALESCE(excluded.winner_score, products.winner_score),
-    extra=excluded.extra;
-"""
+logger = logging.getLogger(__name__)
+
+StatusCallback = Callable[..., None]
+DEFAULT_BATCH_SIZE = 2000
 
 
 def _sanitize(name: str) -> str:
@@ -67,6 +64,19 @@ FIELD_ALIASES: dict[str, Sequence[str]] = {
     "conversion_rate": ["conversion_rate", "conversion", "tasaconversion", "cr", "conversionrate"],
     "winner_score": ["winner_score", "winnerscore"],
     "source": ["source", "fuente"],
+    "brand": ["brand", "marca", "seller"],
+    "asin": ["asin", "productasin", "asin13"],
+    "url": [
+        "url",
+        "producturl",
+        "product_url",
+        "link",
+        "productlink",
+        "landingpage",
+        "landing_page",
+        "landingpageurl",
+        "landing_page_url",
+    ],
 }
 
 ALIASES_SANITIZED = {
@@ -74,13 +84,31 @@ ALIASES_SANITIZED = {
     for field, aliases in FIELD_ALIASES.items()
 }
 
+_SIG_NORMALIZE_RE = re.compile(r"\s+")
 
-def _num(value) -> float:
+
+def _normalize_sig_part(value: Optional[str]) -> str:
     if value is None:
-        return 0.0
+        return ""
+    text = str(value).strip().lower()
+    if not text:
+        return ""
+    return _SIG_NORMALIZE_RE.sub(" ", text)
+
+
+def _compute_sig_hash(name: str, brand: Optional[str], asin: Optional[str], url: Optional[str]) -> str:
+    payload = "|".join(
+        _normalize_sig_part(part) for part in (name, brand, asin, url)
+    )
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def _parse_optional_number(value: Any, *, as_int: bool = False) -> Optional[float]:
+    if value in (None, ""):
+        return None
     s = str(value).strip()
     if not s:
-        return 0.0
+        return None
     multiplier = 1.0
     if s.lower().endswith("m"):
         multiplier = 1_000_000.0
@@ -96,24 +124,23 @@ def _num(value) -> float:
         .replace(",", ".")
     )
     try:
-        return float(s) * multiplier
+        num = float(s) * multiplier
     except Exception:
-        return 0.0
-
-
-def _parse_optional_number(value, as_int: bool = False):
-    if value in (None, ""):
         return None
-    num = _num(value)
     if as_int:
         try:
-            return int(round(num))
+            return float(int(round(num)))
         except Exception:
             return None
     return num
 
 
-def _pick(row: Mapping[str, object], sanitized: Mapping[str, str], field: str, recognised: set[str]):
+def _pick(
+    row: Mapping[str, Any],
+    sanitized: Mapping[str, str],
+    field: str,
+    recognised: set[str],
+) -> tuple[Optional[str], Optional[Any]]:
     for alias in ALIASES_SANITIZED.get(field, ()):  # type: ignore[arg-type]
         original = sanitized.get(alias)
         if original is None:
@@ -128,96 +155,198 @@ def _pick(row: Mapping[str, object], sanitized: Mapping[str, str], field: str, r
     return None, None
 
 
-def _prepare_rows(records: Iterable[Mapping[str, object]], source: str | None = None):
-    prepared = []
-    for record in records:
+def _resolve_db_path(conn: sqlite3.Connection) -> str:
+    cur = conn.execute("PRAGMA database_list;")
+    rows = cur.fetchall()
+    for _, name, path in rows:
+        if name == "main" and path:
+            return str(path)
+    return "product_research_app/data.sqlite3"
+
+
+def _iter_csv_bytes(payload: bytes) -> Iterator[Mapping[str, Any]]:
+    buffer = io.BytesIO(payload)
+    with io.TextIOWrapper(buffer, encoding="utf-8", errors="ignore", newline="") as text_stream:
+        reader = csv.DictReader(text_stream)
+        for row in reader:
+            yield {k: v for k, v in row.items()}
+
+
+@dataclass
+class ImportSummary:
+    job_id: int
+    total_rows: int
+    unique_rows: int
+    batches: int
+    total_ms: float
+    throughput_rps: float
+
+
+class BulkImporter:
+    def __init__(
+        self,
+        db_path: str,
+        job_id: int,
+        *,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        source: Optional[str] = None,
+        status_cb: Optional[StatusCallback] = None,
+    ) -> None:
+        self.db_path = db_path
+        self.job_id = job_id
+        self.batch_size = max(1000, min(batch_size, 5000))
+        self.source = source or "upload"
+        self.status_cb: StatusCallback = status_cb or (lambda **_: None)
+        self.write_conn = self._open_connection()
+        self.status_conn = self._open_connection()
+        self.pending: list[dict[str, Any]] = []
+        self.processed = 0
+        self.batches = 0
+        self._unique_hashes: set[str] = set()
+        self._summary: Optional[ImportSummary] = None
+        self._start = 0.0
+
+    def _open_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, check_same_thread=False, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys=ON;")
+        init_db_performance(self.db_path, connection=conn)
+        return conn
+
+    def close(self) -> None:
+        for conn in (self.write_conn, self.status_conn):
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    @property
+    def summary(self) -> ImportSummary:
+        if self._summary is None:
+            return ImportSummary(self.job_id, 0, 0, 0, 0.0, 0.0)
+        return self._summary
+
+    def run(self, rows: Iterator[Mapping[str, Any]]) -> ImportSummary:
+        self._start = time.perf_counter()
+        self._update_status(phase="parse", status="running", processed=0, total=0)
+        self.status_cb(stage="prepare", done=0, total=0)
+        self.write_conn.execute("BEGIN IMMEDIATE;")
+        try:
+            for record in rows:
+                prepared = self._prepare_record(record)
+                if not prepared:
+                    continue
+                self.pending.append(prepared)
+                self.processed += 1
+                if len(self.pending) >= self.batch_size:
+                    self._flush_pending()
+            if self.pending:
+                self._flush_pending()
+            transition_job_items(self.write_conn, self.job_id, "raw", "pending_enrich")
+            merge_staging_into_products(self.write_conn, self.job_id)
+            unique_rows = len(self._unique_hashes)
+            clear_staging_for_job(self.write_conn, self.job_id)
+            self.write_conn.execute("COMMIT;")
+        except Exception:
+            self.write_conn.execute("ROLLBACK;")
+            raise
+        total_ms = (time.perf_counter() - self._start) * 1000 if self._start else 0.0
+        throughput = (self.processed / (total_ms / 1000.0)) if total_ms else 0.0
+        self.status_cb(stage="commit", done=self.processed, total=self.processed)
+        self._summary = ImportSummary(
+            self.job_id,
+            self.processed,
+            len(self._unique_hashes),
+            self.batches,
+            total_ms,
+            throughput,
+        )
+        logger.info(
+            "Import finished job=%s rows=%d unique=%d ms=%.2f batches=%d throughput=%.2f",
+            self.job_id,
+            self.processed,
+            len(self._unique_hashes),
+            total_ms,
+            self.batches,
+            throughput,
+        )
+        return self.summary
+
+    def _prepare_record(self, record: Mapping[str, Any]) -> Optional[dict[str, Any]]:
         if not isinstance(record, Mapping):
-            continue
+            return None
         row = dict(record)
-        sanitized_keys: dict[str, str] = {}
-        for key in row.keys():
+        sanitized: dict[str, str] = {}
+        for key in list(row.keys()):
             if key is None:
                 continue
             norm = _sanitize(str(key))
             if not norm:
                 continue
-            sanitized_keys.setdefault(norm, key)
+            sanitized.setdefault(norm, str(key))
         recognised: set[str] = set()
-
-        _, raw_id = _pick(row, sanitized_keys, "id", recognised)
-        row_id = _parse_optional_number(raw_id, as_int=True)
-        if row_id is not None and row_id <= 0:
-            row_id = None
-
-        name_key, raw_name = _pick(row, sanitized_keys, "name", recognised)
+        _, raw_name = _pick(row, sanitized, "name", recognised)
         if raw_name is None:
-            continue
-        name = str(raw_name)
-
-        _, raw_description = _pick(row, sanitized_keys, "description", recognised)
+            return None
+        name = str(raw_name).strip()
+        if not name:
+            return None
+        _, raw_description = _pick(row, sanitized, "description", recognised)
         description = str(raw_description).strip() if raw_description not in (None, "") else None
-
-        _, raw_category_path = _pick(row, sanitized_keys, "category_path", recognised)
+        _, raw_category_path = _pick(row, sanitized, "category_path", recognised)
         category_path = str(raw_category_path).strip() if raw_category_path not in (None, "") else None
-
-        _, raw_category = _pick(row, sanitized_keys, "category", recognised)
-        category_value = raw_category if raw_category not in (None, "") else category_path
-        category = str(category_value).strip() if category_value not in (None, "") else None
-
-        _, raw_price = _pick(row, sanitized_keys, "price", recognised)
+        _, raw_category = _pick(row, sanitized, "category", recognised)
+        category_val = raw_category if raw_category not in (None, "") else category_path
+        category = str(category_val).strip() if category_val not in (None, "") else None
+        _, raw_price = _pick(row, sanitized, "price", recognised)
         price = _parse_optional_number(raw_price)
-
-        _, raw_currency = _pick(row, sanitized_keys, "currency", recognised)
+        _, raw_currency = _pick(row, sanitized, "currency", recognised)
         currency = str(raw_currency).strip() if raw_currency not in (None, "") else None
-
-        _, raw_image = _pick(row, sanitized_keys, "image_url", recognised)
+        _, raw_image = _pick(row, sanitized, "image_url", recognised)
         image_url = str(raw_image).strip() if raw_image not in (None, "") else None
-
-        _, raw_desire = _pick(row, sanitized_keys, "desire", recognised)
+        _, raw_brand = _pick(row, sanitized, "brand", recognised)
+        brand = str(raw_brand).strip() if raw_brand not in (None, "") else None
+        _, raw_asin = _pick(row, sanitized, "asin", recognised)
+        asin = str(raw_asin).strip() if raw_asin not in (None, "") else None
+        _, raw_url = _pick(row, sanitized, "url", recognised)
+        product_url = str(raw_url).strip() if raw_url not in (None, "") else None
+        _, raw_desire = _pick(row, sanitized, "desire", recognised)
         desire = str(raw_desire).strip() if raw_desire not in (None, "") else None
-
-        _, raw_desire_mag = _pick(row, sanitized_keys, "desire_magnitude", recognised)
+        _, raw_desire_mag = _pick(row, sanitized, "desire_magnitude", recognised)
         desire_mag = str(raw_desire_mag).strip() if raw_desire_mag not in (None, "") else None
-
-        _, raw_awareness = _pick(row, sanitized_keys, "awareness_level", recognised)
+        _, raw_awareness = _pick(row, sanitized, "awareness_level", recognised)
         awareness = str(raw_awareness).strip() if raw_awareness not in (None, "") else None
-
-        _, raw_competition = _pick(row, sanitized_keys, "competition_level", recognised)
+        _, raw_competition = _pick(row, sanitized, "competition_level", recognised)
         competition = str(raw_competition).strip() if raw_competition not in (None, "") else None
-
-        _, raw_range = _pick(row, sanitized_keys, "date_range", recognised)
-        date_range = str(raw_range).strip() if raw_range not in (None, "") else ""
-
-        _, raw_launch = _pick(row, sanitized_keys, "launch_date", recognised)
-        launch_date = str(raw_launch).strip() if raw_launch not in (None, "") else ""
+        _, raw_range = _pick(row, sanitized, "date_range", recognised)
+        date_range = str(raw_range).strip() if raw_range not in (None, "") else None
+        _, raw_launch = _pick(row, sanitized, "launch_date", recognised)
+        launch_date = str(raw_launch).strip() if raw_launch not in (None, "") else None
         if launch_date:
             launch_date = launch_date[:10]
-
-        _, raw_rating = _pick(row, sanitized_keys, "rating", recognised)
+        _, raw_rating = _pick(row, sanitized, "rating", recognised)
         rating = _parse_optional_number(raw_rating)
-
-        _, raw_units = _pick(row, sanitized_keys, "units_sold", recognised)
+        _, raw_units = _pick(row, sanitized, "units_sold", recognised)
         units_sold = _parse_optional_number(raw_units, as_int=True)
-
-        _, raw_revenue = _pick(row, sanitized_keys, "revenue", recognised)
+        _, raw_revenue = _pick(row, sanitized, "revenue", recognised)
         revenue = _parse_optional_number(raw_revenue)
-
-        _, raw_conversion = _pick(row, sanitized_keys, "conversion_rate", recognised)
+        _, raw_conversion = _pick(row, sanitized, "conversion_rate", recognised)
         conversion_rate = _parse_optional_number(raw_conversion)
-
-        _, raw_winner = _pick(row, sanitized_keys, "winner_score", recognised)
-        winner_score = _parse_optional_number(raw_winner, as_int=True)
-
-        _, raw_source = _pick(row, sanitized_keys, "source", recognised)
+        _, raw_winner = _pick(row, sanitized, "winner_score", recognised)
+        winner_score = None
+        if raw_winner not in (None, ""):
+            winner_score = _parse_optional_number(raw_winner, as_int=True)
+            if winner_score is not None:
+                winner_score = int(winner_score)
+        _, raw_source = _pick(row, sanitized, "source", recognised)
         source_val = str(raw_source).strip() if raw_source not in (None, "") else None
         if not source_val:
-            source_val = source or "upload"
-
-        extras: dict[str, object] = {}
+            source_val = self.source
+        extras: dict[str, Any] = {}
         if rating is not None:
             extras["rating"] = rating
         if units_sold is not None:
-            extras["units_sold"] = units_sold
+            extras["units_sold"] = int(units_sold)
         if revenue is not None:
             extras["revenue"] = revenue
         if conversion_rate is not None:
@@ -226,7 +355,12 @@ def _prepare_rows(records: Iterable[Mapping[str, object]], source: str | None = 
             extras["launch_date"] = launch_date
         if category_path and (not category or category_path != category):
             extras["category_path"] = category_path
-
+        if brand:
+            extras["brand"] = brand
+        if asin:
+            extras["asin"] = asin
+        if product_url:
+            extras["product_url"] = product_url
         for key, value in row.items():
             if key in recognised or key is None:
                 continue
@@ -235,72 +369,309 @@ def _prepare_rows(records: Iterable[Mapping[str, object]], source: str | None = 
                 if not value:
                     continue
             extras[key] = value
+        sig_hash = _compute_sig_hash(name, brand, asin, product_url)
+        if not sig_hash:
+            return None
+        return {
+            "sig_hash": sig_hash,
+            "name": name,
+            "description": description,
+            "category": category,
+            "price": float(price) if price is not None else None,
+            "currency": currency,
+            "image_url": image_url,
+            "brand": brand,
+            "asin": asin,
+            "product_url": product_url,
+            "source": source_val,
+            "import_date": datetime.utcnow().isoformat(),
+            "desire": desire,
+            "desire_magnitude": desire_mag,
+            "awareness_level": awareness,
+            "competition_level": competition,
+            "date_range": date_range,
+            "winner_score": winner_score,
+            "extra": extras,
+            "raw": row,
+        }
 
-        prepared.append(
+    def _flush_pending(self) -> None:
+        if not self.pending:
+            return
+        batch_start = time.perf_counter()
+        now = datetime.utcnow().isoformat()
+        batch = list(self.pending)
+        self.pending.clear()
+        cur = self.write_conn.cursor()
+        items_payload = [
+            (self.job_id, row["sig_hash"], json_dump(row["raw"]), "raw", now)
+            for row in batch
+        ]
+        staging_payload = [
             (
-                row_id,
-                name,
-                description,
-                category,
-                price,
-                currency,
-                image_url,
-                source_val,
-                datetime.utcnow().isoformat(),
-                desire,
-                desire_mag,
-                awareness,
-                competition,
-                date_range,
-                winner_score,
-                json_dump(extras),
+                self.job_id,
+                row["sig_hash"],
+                row["name"],
+                row.get("description"),
+                row.get("category"),
+                row.get("price"),
+                row.get("currency"),
+                row.get("image_url"),
+                row.get("brand"),
+                row.get("asin"),
+                row.get("product_url"),
+                row["source"],
+                row["import_date"],
+                row.get("desire"),
+                row.get("desire_magnitude"),
+                row.get("awareness_level"),
+                row.get("competition_level"),
+                row.get("date_range"),
+                row.get("winner_score"),
+                json_dump(row["extra"]),
             )
+            for row in batch
+        ]
+        cur.executemany(
+            """
+            INSERT INTO items (job_id, sig_hash, raw, state, updated_at)
+            VALUES (?, ?, json(?), ?, ?)
+            """,
+            items_payload,
         )
-    return prepared
+        cur.executemany(
+            """
+            INSERT OR REPLACE INTO products_staging (
+                job_id, sig_hash, name, description, category, price, currency,
+                image_url, brand, asin, product_url, source, import_date,
+                desire, desire_magnitude, awareness_level, competition_level,
+                date_range, winner_score, extra
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, json(?))
+            """,
+            staging_payload,
+        )
+        batch_size = len(batch)
+        for row in batch:
+            self._unique_hashes.add(row["sig_hash"])
+        self.batches += 1
+        elapsed_ms = (time.perf_counter() - batch_start) * 1000
+        batch_throughput = batch_size / ((elapsed_ms / 1000.0) or 1.0)
+        append_import_job_metrics(
+            self.write_conn,
+            self.job_id,
+            self.batches,
+            batch_size,
+            elapsed_ms,
+            batch_throughput,
+            commit=False,
+        )
+        logger.info(
+            "Import batch job=%s batch=%d rows=%d unique=%d ms=%.2f throughput=%.2f",
+            self.job_id,
+            self.batches,
+            batch_size,
+            len(self._unique_hashes),
+            elapsed_ms,
+            batch_throughput,
+        )
+        self.status_cb(
+            stage="insert",
+            done=self.processed,
+            total=self.processed,
+            batch=batch_size,
+        )
+        self._update_status(
+            phase="insert",
+            processed=self.processed,
+            total=self.processed,
+            rows_imported=len(self._unique_hashes),
+        )
+
+    def _update_status(self, **kwargs: Any) -> None:
+        update_import_job_progress(self.status_conn, self.job_id, **kwargs)
 
 
-def parse_csv_bytes(payload: bytes, source: str | None = None):
-    text = payload.decode("utf-8", errors="ignore")
-    reader = csv.DictReader(io.StringIO(text))
-    return _prepare_rows(reader, source=source)
+def _prepare_rows(records: Iterable[Mapping[str, Any]]) -> Iterator[Mapping[str, Any]]:
+    for record in records:
+        if isinstance(record, Mapping):
+            yield record
 
 
-def prepare_rows(records: Iterable[Mapping[str, object]], source: str | None = None):
-    return _prepare_rows(records, source=source)
-
-
-def _bulk_insert(rows, status_cb):
-    db = get_db()
-    db.execute("PRAGMA journal_mode=WAL;")
-    db.execute("PRAGMA synchronous=NORMAL;")
-    db.execute("PRAGMA temp_store=MEMORY;")
-    db.execute("PRAGMA cache_size=-20000;")
-    db.execute("BEGIN IMMEDIATE;")
+def fast_import(
+    csv_bytes: bytes,
+    *,
+    status_cb: StatusCallback = lambda **_: None,
+    source: Optional[str] = None,
+    job_id: Optional[int] = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    db_path: Optional[str] = None,
+) -> int:
+    base_conn = get_db()
+    resolved_path = db_path or _resolve_db_path(base_conn)
+    pragmas = get_last_performance_config()
+    config = {"batch_size": batch_size, "pragmas": pragmas, "source": source or "upload"}
+    created_here = False
+    if job_id is None:
+        job_id = create_import_job(
+            base_conn,
+            status="running",
+            phase="parse",
+            total=0,
+            processed=0,
+            config=config,
+        )
+        created_here = True
+    else:
+        update_import_job_progress(base_conn, job_id, status="running", phase="parse", processed=0, total=0, config=config)
+    importer = BulkImporter(
+        resolved_path,
+        job_id,
+        batch_size=batch_size,
+        source=source,
+        status_cb=status_cb,
+    )
     try:
-        total = len(rows)
-        status_cb(stage="prepare", done=0, total=total)
-        batch = 1000
-        for idx in range(0, total, batch):
-            chunk = rows[idx: idx + batch]
-            if not chunk:
-                continue
-            db.executemany(UPSERT_SQL, chunk)
-            status_cb(stage="insert", done=min(idx + len(chunk), total), total=total)
-        db.execute("COMMIT;")
-        status_cb(stage="commit", done=total, total=total)
-        return total
-    except Exception:
-        db.execute("ROLLBACK;")
+        summary = importer.run(_iter_csv_bytes(csv_bytes))
+        update_import_job_progress(
+            base_conn,
+            job_id,
+            phase="done",
+            status="done",
+            processed=summary.total_rows,
+            total=summary.total_rows,
+            rows_imported=summary.unique_rows,
+            metrics={
+                "total_rows": summary.total_rows,
+                "unique_rows": summary.unique_rows,
+                "batches": summary.batches,
+                "total_ms": summary.total_ms,
+                "throughput_rps": summary.throughput_rps,
+                "batch_size": batch_size,
+            },
+        )
+        return summary.unique_rows
+    except Exception as exc:
+        logger.exception("Fast import failed job=%s", job_id)
+        update_import_job_progress(
+            base_conn,
+            job_id,
+            status="error",
+            phase="done",
+            error=str(exc),
+        )
         raise
     finally:
-        db.execute("PRAGMA synchronous=NORMAL;")
+        importer.close()
+        if created_here:
+            base_conn.commit()
 
 
-def fast_import(csv_bytes: bytes, status_cb=lambda **_: None, source: str | None = None):
-    rows = parse_csv_bytes(csv_bytes, source=source)
-    return _bulk_insert(rows, status_cb)
+def fast_import_records(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    status_cb: StatusCallback = lambda **_: None,
+    source: Optional[str] = None,
+    job_id: Optional[int] = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    db_path: Optional[str] = None,
+) -> int:
+    base_conn = get_db()
+    resolved_path = db_path or _resolve_db_path(base_conn)
+    pragmas = get_last_performance_config()
+    config = {"batch_size": batch_size, "pragmas": pragmas, "source": source or "upload"}
+    created_here = False
+    if job_id is None:
+        job_id = create_import_job(
+            base_conn,
+            status="running",
+            phase="parse",
+            total=0,
+            processed=0,
+            config=config,
+        )
+        created_here = True
+    else:
+        update_import_job_progress(base_conn, job_id, status="running", phase="parse", processed=0, total=0, config=config)
+    importer = BulkImporter(
+        resolved_path,
+        job_id,
+        batch_size=batch_size,
+        source=source,
+        status_cb=status_cb,
+    )
+    try:
+        summary = importer.run(_prepare_rows(records))
+        update_import_job_progress(
+            base_conn,
+            job_id,
+            phase="done",
+            status="done",
+            processed=summary.total_rows,
+            total=summary.total_rows,
+            rows_imported=summary.unique_rows,
+            metrics={
+                "total_rows": summary.total_rows,
+                "unique_rows": summary.unique_rows,
+                "batches": summary.batches,
+                "total_ms": summary.total_ms,
+                "throughput_rps": summary.throughput_rps,
+                "batch_size": batch_size,
+            },
+        )
+        return summary.unique_rows
+    except Exception as exc:
+        logger.exception("Fast record import failed job=%s", job_id)
+        update_import_job_progress(
+            base_conn,
+            job_id,
+            status="error",
+            phase="done",
+            error=str(exc),
+        )
+        raise
+    finally:
+        importer.close()
+        if created_here:
+            base_conn.commit()
 
 
-def fast_import_records(records: Iterable[Mapping[str, object]], status_cb=lambda **_: None, source: str | None = None):
-    rows = prepare_rows(records, source=source)
-    return _bulk_insert(rows, status_cb)
+def benchmark_bulk_import(
+    row_count: int = 10_000,
+    *,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    db_path: Optional[str] = None,
+) -> ImportSummary:
+    logger.info(
+        "Starting benchmark import rows=%d batch_size=%d", row_count, batch_size
+    )
+
+    def _records() -> Iterator[Mapping[str, Any]]:
+        for idx in range(row_count):
+            yield {
+                "title": f"Synthetic Product {idx}",
+                "price": 19.99,
+                "brand": f"Brand {idx % 50}",
+                "asin": f"B00{idx:06d}",
+                "url": f"https://example.com/product/{idx}",
+                "category": "synthetic",
+            }
+
+    start = time.perf_counter()
+    unique_rows = fast_import_records(
+        _records(),
+        source="benchmark",
+        batch_size=batch_size,
+        db_path=db_path,
+        status_cb=lambda **_: None,
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    throughput = row_count / ((elapsed_ms / 1000) or 1.0)
+    logger.info(
+        "Benchmark completed rows=%d unique=%d ms=%.2f throughput=%.2f",
+        row_count,
+        unique_rows,
+        elapsed_ms,
+        throughput,
+    )
+    return ImportSummary(0, row_count, unique_rows, 0, elapsed_ms, throughput)

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -40,12 +40,12 @@ from datetime import date, datetime, timedelta
 from typing import Dict, Any, List
 
 from . import database
-from .db import get_db
+from .db import get_db, get_last_performance_config
 from . import config
 from .services import ai_columns
 from .services import winner_score as winner_calc
 from .services import trends_service
-from .services.importer_fast import fast_import, fast_import_records
+from .services.importer_fast import DEFAULT_BATCH_SIZE, fast_import, fast_import_records
 from . import gpt
 from .prompts.registry import normalize_task
 from . import title_analyzer
@@ -147,12 +147,83 @@ def _set_import_progress(
     return _update_import_status(task_id, **payload)
 
 
+def _maybe_json(value):
+    if value in (None, ""):
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(value)
+    except Exception:
+        return None
+
+
+def _job_payload_from_row(row):
+    if row is None:
+        return None
+    data = row_to_dict(row)
+    job_id = data.get("task_id") or data.get("id")
+    if job_id is not None:
+        try:
+            job_int = int(job_id)
+        except Exception:
+            job_int = job_id
+        data["job_id"] = job_int
+        data["task_id"] = str(job_id)
+    else:
+        data["job_id"] = None
+        data["task_id"] = None
+    for key in ("config", "metrics", "ai_counts", "ai_pending"):
+        parsed = _maybe_json(data.get(key))
+        if parsed is None:
+            parsed = {} if key in {"config", "metrics", "ai_counts"} else []
+        data[key] = parsed
+    data["total"] = int(data.get("total") or 0)
+    data["processed"] = int(data.get("processed") or 0)
+    rows_imported = data.get("rows_imported")
+    data["rows_imported"] = int(rows_imported or data["processed"] or 0)
+    data["imported"] = data["rows_imported"]
+    if data["total"] and not data.get("pct"):
+        try:
+            pct = int(round((data["processed"] / max(data["total"], 1)) * 100))
+            data["pct"] = max(0, min(100, pct))
+        except Exception:
+            pass
+    data.setdefault("phase", data.get("phase") or "parse")
+    data.setdefault("status", data.get("status") or "pending")
+    data.setdefault("state", data.get("state") or data["status"])
+    return data
+
+
 def _get_import_status(task_id: str) -> Dict[str, Any] | None:
     with _IMPORT_STATUS_LOCK:
-        status = IMPORT_STATUS.get(task_id)
-        if status is None:
-            return None
-        return dict(status)
+        snapshot = dict(IMPORT_STATUS.get(task_id) or {})
+    job_id = snapshot.get("job_id")
+    if job_id is None:
+        try:
+            job_id = int(task_id)
+        except Exception:
+            job_id = None
+    if job_id is not None:
+        try:
+            conn = ensure_db()
+            row = database.get_import_job(conn, int(job_id))
+        except Exception:
+            row = None
+        payload = _job_payload_from_row(row)
+        if payload is not None:
+            payload.update(snapshot)
+            payload["job_id"] = payload.get("job_id") or job_id
+            payload["task_id"] = payload.get("task_id") or (str(job_id) if job_id is not None else task_id)
+            return payload
+    if not snapshot:
+        return None
+    if job_id is not None:
+        snapshot.setdefault("job_id", job_id)
+        snapshot.setdefault("task_id", str(job_id))
+    else:
+        snapshot.setdefault("task_id", task_id)
+    return snapshot
 
 
 def _ensure_desire(product: Dict[str, Any], extras: Dict[str, Any]) -> str:
@@ -813,48 +884,61 @@ class RequestHandler(BaseHTTPRequestHandler):
             rows = [row_to_dict(r) for r in database.get_import_history(conn, limit)]
             self.safe_write(lambda: self.send_json(rows))
             return
-        if path == "/_import_status":
+        if path in {"/_import_status", "/import/status"}:
             params = parse_qs(parsed.query)
-            task_id_param = params.get("task_id", [""])[0]
-            if not task_id_param:
+            target = ""
+            if path == "/import/status":
+                target = params.get("job_id", [""])[0] or params.get("task_id", [""])[0]
+            else:
+                target = params.get("task_id", [""])[0] or params.get("job_id", [""])[0]
+            if not target:
                 self.safe_write(lambda: self.send_json({"state": "unknown"}))
                 return
-            status = _get_import_status(task_id_param)
+            status = _get_import_status(str(target))
+            if status is None and str(target).isdigit():
+                conn = ensure_db()
+                row = database.get_import_job(conn, int(target))
+                status = _job_payload_from_row(row)
             if status:
-                if "task_id" not in status:
-                    status["task_id"] = task_id_param
+                status.setdefault("task_id", str(status.get("task_id") or target))
+                if str(target).isdigit():
+                    status.setdefault("job_id", int(target))
                 self.safe_write(lambda: self.send_json(status))
-                return
-            try:
-                task_id = int(task_id_param)
-            except Exception:
-                self.safe_write(lambda: self.send_json({"state": "unknown"}))
-                return
-            conn = ensure_db()
-            row = database.get_import_job(conn, task_id)
-            if row:
-                data = row_to_dict(row)
-                try:
-                    if data.get("ai_counts"):
-                        data["ai_counts"] = json.loads(data["ai_counts"])
-                except Exception:
-                    data["ai_counts"] = {}
-                try:
-                    if data.get("ai_pending"):
-                        data["pending_ids"] = json.loads(data["ai_pending"])
-                    else:
-                        data["pending_ids"] = []
-                except Exception:
-                    data["pending_ids"] = []
-                data.pop("ai_pending", None)
-                data["message"] = (
-                    "Importando productos, por favor espera... El winner score se ha calculado."
-                )
-                data["imported"] = data.get("rows_imported", 0)
-                data["winner_score_updated"] = data.get("winner_score_updated", 0)
-                self.safe_write(lambda: self.send_json(data))
             else:
                 self.safe_write(lambda: self.send_json({"state": "unknown"}))
+            return
+        if path == "/metrics":
+            params = parse_qs(parsed.query)
+            try:
+                limit = int(params.get("limit", ["20"])[0])
+            except Exception:
+                limit = 20
+            conn = ensure_db()
+            batches = [
+                {
+                    "job_id": row["job_id"],
+                    "batch": row["batch_no"],
+                    "rows": row["rows"],
+                    "duration_ms": row["duration_ms"],
+                    "throughput": row["throughput"],
+                    "created_at": row["created_at"],
+                }
+                for row in database.get_recent_import_metrics(conn, limit)
+            ]
+            jobs_payload = []
+            for row in database.get_import_history(conn, limit):
+                payload = _job_payload_from_row(row)
+                if payload:
+                    jobs_payload.append(payload)
+            config_payload = {
+                "pragmas": get_last_performance_config(),
+                "default_batch_size": DEFAULT_BATCH_SIZE,
+            }
+            self.safe_write(
+                lambda: self.send_json(
+                    {"jobs": jobs_payload, "batches": batches, "config": config_payload}
+                )
+            )
             return
         if path in ("/products", "/api/products"):
             # Return a list of products including extra metadata for UI display
@@ -1766,10 +1850,20 @@ class RequestHandler(BaseHTTPRequestHandler):
             return
 
         if ext == ".csv":
-            ensure_db()
-            task_id = str(int(time.time() * 1000))
+            conn = ensure_db()
+            job_config = {"filename": filename, "batch_size": DEFAULT_BATCH_SIZE}
+            job_id = database.create_import_job(
+                conn,
+                status="running",
+                phase="parse",
+                total=0,
+                processed=0,
+                config=job_config,
+            )
+            task_id = str(job_id)
             _update_import_status(
                 task_id,
+                job_id=job_id,
                 state="queued",
                 stage="queued",
                 done=0,
@@ -1782,7 +1876,13 @@ class RequestHandler(BaseHTTPRequestHandler):
             csv_bytes = data
 
             def run_csv():
-                _update_import_status(task_id, state="running", stage="running", started_at=time.time())
+                _update_import_status(
+                    task_id,
+                    job_id=job_id,
+                    state="running",
+                    stage="running",
+                    started_at=time.time(),
+                )
                 _set_import_progress(task_id, pct=5, message="Preparando importación")
                 try:
                     def cb(**kwargs):
@@ -1801,7 +1901,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                             )
                         elif stage == "insert":
                             frac = done / max(total, 1) if total else 0.0
-                            pct = 20 + min(60, 60 * frac)
+                            pct = 20 + min(60, int(round(60 * frac)))
                             msg = f"Insertando registros ({done}/{total})" if total else "Insertando registros"
                             _set_import_progress(
                                 task_id,
@@ -1814,7 +1914,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                         elif stage == "commit":
                             _set_import_progress(
                                 task_id,
-                                pct=82,
+                                pct=90,
                                 message="Guardando cambios",
                                 done=done,
                                 total=total,
@@ -1823,21 +1923,17 @@ class RequestHandler(BaseHTTPRequestHandler):
                         else:
                             _update_import_status(task_id, **kwargs)
 
-                    count = fast_import(csv_bytes, status_cb=cb, source=filename)
-                    _set_import_progress(
-                        task_id,
-                        pct=88,
-                        message="Normalizando datos",
-                        done=count,
-                        total=count,
+                    imported_count = fast_import(
+                        csv_bytes,
+                        job_id=job_id,
+                        status_cb=cb,
+                        source=filename,
                     )
-                    snapshot = _get_import_status(task_id) or {}
-                    done_val = int(snapshot.get("done", 0) or 0)
-                    if done_val < count:
-                        done_val = count
-                    total_val = int(snapshot.get("total", 0) or 0)
-                    if total_val < done_val:
-                        total_val = done_val
+                    job_row = database.get_import_job(conn, job_id)
+                    snapshot = _job_payload_from_row(job_row) or {}
+                    done_val = int(snapshot.get("processed") or imported_count or 0)
+                    total_val = int(snapshot.get("total") or done_val)
+                    imported_val = int(snapshot.get("rows_imported") or imported_count or done_val)
                     _set_import_progress(
                         task_id,
                         pct=95,
@@ -1847,11 +1943,12 @@ class RequestHandler(BaseHTTPRequestHandler):
                     )
                     _update_import_status(
                         task_id,
+                        job_id=job_id,
                         state="done",
                         stage="done",
                         done=done_val,
                         total=total_val,
-                        imported=count,
+                        imported=imported_val,
                         finished_at=time.time(),
                         pct=100,
                         message="Completado",
@@ -1860,6 +1957,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                     logger.exception("Fast CSV import failed: filename=%s", filename)
                     _update_import_status(
                         task_id,
+                        job_id=job_id,
                         state="error",
                         stage="error",
                         error=str(exc),
@@ -1869,7 +1967,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                     )
 
             threading.Thread(target=run_csv, daemon=True).start()
-            self.safe_write(lambda: self.send_json({"task_id": task_id}, status=202))
+            self.safe_write(lambda: self.send_json({"task_id": task_id, "job_id": job_id}, status=202))
             return
 
         if ext == ".json":
@@ -1882,14 +1980,29 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self.safe_write(lambda: self.send_json({"error": "invalid_json"}, status=400))
                 return
             records = [item for item in payload if isinstance(item, dict)]
-            ensure_db()
-            task_id = str(int(time.time() * 1000))
+            conn = ensure_db()
+            total_records = len(records)
+            job_config = {
+                "filename": filename,
+                "batch_size": DEFAULT_BATCH_SIZE,
+                "expected": total_records,
+            }
+            job_id = database.create_import_job(
+                conn,
+                status="running",
+                phase="parse",
+                total=total_records,
+                processed=0,
+                config=job_config,
+            )
+            task_id = str(job_id)
             _update_import_status(
                 task_id,
+                job_id=job_id,
                 state="queued",
                 stage="queued",
                 done=0,
-                total=len(records),
+                total=total_records,
                 error=None,
                 imported=0,
                 filename=filename,
@@ -1897,13 +2010,19 @@ class RequestHandler(BaseHTTPRequestHandler):
             _set_import_progress(task_id, pct=0, message="En cola", state="queued")
 
             def run_json():
-                _update_import_status(task_id, state="running", stage="running", started_at=time.time())
-                _set_import_progress(task_id, pct=5, message="Preparando importación", total=len(records))
+                _update_import_status(
+                    task_id,
+                    job_id=job_id,
+                    state="running",
+                    stage="running",
+                    started_at=time.time(),
+                )
+                _set_import_progress(task_id, pct=5, message="Preparando importación", total=total_records)
                 try:
                     def cb(**kwargs):
                         stage = kwargs.get("stage")
                         done = int(kwargs.get("done", 0) or 0)
-                        total = int(kwargs.get("total", len(records)) or 0)
+                        total = int(kwargs.get("total", total_records) or total_records)
                         extra = {k: v for k, v in kwargs.items() if k not in {"stage", "done", "total"}}
                         if stage == "prepare":
                             _set_import_progress(
@@ -1938,21 +2057,17 @@ class RequestHandler(BaseHTTPRequestHandler):
                         else:
                             _update_import_status(task_id, **kwargs)
 
-                    count = fast_import_records(records, status_cb=cb, source=filename)
-                    _set_import_progress(
-                        task_id,
-                        pct=88,
-                        message="Normalizando datos",
-                        done=count,
-                        total=count,
+                    imported_count = fast_import_records(
+                        records,
+                        job_id=job_id,
+                        status_cb=cb,
+                        source=filename,
                     )
-                    snapshot = _get_import_status(task_id) or {}
-                    done_val = int(snapshot.get("done", 0) or 0)
-                    if done_val < count:
-                        done_val = count
-                    total_val = int(snapshot.get("total", len(records)) or 0)
-                    if total_val < done_val:
-                        total_val = done_val
+                    job_row = database.get_import_job(conn, job_id)
+                    snapshot = _job_payload_from_row(job_row) or {}
+                    done_val = int(snapshot.get("processed") or imported_count or total_records)
+                    total_val = int(snapshot.get("total") or total_records)
+                    imported_val = int(snapshot.get("rows_imported") or imported_count or done_val)
                     _set_import_progress(
                         task_id,
                         pct=95,
@@ -1962,11 +2077,12 @@ class RequestHandler(BaseHTTPRequestHandler):
                     )
                     _update_import_status(
                         task_id,
+                        job_id=job_id,
                         state="done",
                         stage="done",
                         done=done_val,
                         total=total_val,
-                        imported=count,
+                        imported=imported_val,
                         finished_at=time.time(),
                         pct=100,
                         message="Completado",
@@ -1975,6 +2091,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                     logger.exception("Fast JSON import failed: filename=%s", filename)
                     _update_import_status(
                         task_id,
+                        job_id=job_id,
                         state="error",
                         stage="error",
                         error=str(exc),
@@ -1984,7 +2101,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                     )
 
             threading.Thread(target=run_json, daemon=True).start()
-            self.safe_write(lambda: self.send_json({"task_id": task_id}, status=202))
+            self.safe_write(lambda: self.send_json({"task_id": task_id, "job_id": job_id}, status=202))
             return
 
         self.safe_write(lambda: self.send_json({"error": "unsupported_format"}, status=400))


### PR DESCRIPTION
## Summary
- configure SQLite connections with high-throughput PRAGMA settings
- add staging, item tracking, and metrics tables plus job progress helpers
- stream bulk imports through new staging pipeline with SHA1 dedupe and expose job status/metrics endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc89f669d08328bc7fbca712e5b7df