### PR TITLE
Add SSE blueprint and health endpoint for Flask server

### DIFF
--- a/product_research_app/__main__.py
+++ b/product_research_app/__main__.py
@@ -1,7 +1,13 @@
 from product_research_app.services.config import init_app_config
 from product_research_app.api import app
 
-init_app_config()
+
+def main() -> None:
+    """Initialize configuration and start the Flask development server."""
+
+    init_app_config()
+    app.run(host="127.0.0.1", port=8000, debug=False, threaded=True, use_reloader=False)
+
 
 if __name__ == "__main__":
-    app.run()
+    main()

--- a/product_research_app/api/__init__.py
+++ b/product_research_app/api/__init__.py
@@ -1,6 +1,27 @@
-from flask import Flask
+from datetime import datetime
+
+from flask import Flask, jsonify, current_app
+
+from product_research_app.db import get_db
+from product_research_app.sse import sse_bp
 
 app = Flask(__name__)
+app.register_blueprint(sse_bp)
+
+
+@app.get("/healthz")
+def healthz():
+    """Return a JSON health report with a quick database connectivity test."""
+
+    timestamp = datetime.utcnow().isoformat() + "Z"
+    try:
+        conn = get_db()
+        cur = conn.execute("SELECT 1;")
+        cur.fetchone()
+    except Exception as exc:  # pragma: no cover - best effort logging
+        current_app.logger.exception("healthcheck failed: %s", exc)
+        return jsonify({"ok": False, "error": str(exc), "time": timestamp}), 500
+    return jsonify({"ok": True, "time": timestamp}), 200
 
 # Import API modules which attach routes to ``app``.
 from . import config  # noqa: E402,F401

--- a/product_research_app/product_enrichment.py
+++ b/product_research_app/product_enrichment.py
@@ -25,7 +25,7 @@ import httpx
 
 from . import config, database
 from .db import get_db
-from .progress_events import publish_progress
+from .sse import publish_progress
 from .student_model import StudentModelManager, build_feature_sample as build_student_sample
 from .similarity_engine import SimilarityEngine, SimilarityMatch
 

--- a/product_research_app/sse.py
+++ b/product_research_app/sse.py
@@ -1,0 +1,86 @@
+"""Server-Sent Events helpers and blueprint."""
+
+from __future__ import annotations
+
+import json
+import queue
+from typing import Any, Dict, Iterable, Iterator, Optional
+
+from flask import Blueprint, Response, stream_with_context
+
+from . import progress_events
+
+sse_bp = Blueprint("sse", __name__)
+
+_HEADERS = {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+    "Access-Control-Allow-Origin": "*",
+}
+
+
+def _event_stream(subscriber: Any) -> Iterator[str]:
+    """Yield events from a subscriber queue with keepalive comments."""
+
+    timeout = getattr(progress_events, "KEEPALIVE_INTERVAL", 10.0)
+    q: "queue.Queue[Dict[str, Any]]" = getattr(subscriber, "queue", None)
+    if q is None:
+        maxsize = getattr(progress_events, "QUEUE_SIZE", 0) or 0
+        q = queue.Queue(maxsize=maxsize or 0)
+    while True:
+        try:
+            event = q.get(timeout=timeout)
+        except queue.Empty:
+            yield ":keepalive\n\n"
+            continue
+        try:
+            payload = json.dumps(event, ensure_ascii=False, separators=(",", ":"))
+        except Exception:
+            continue
+        yield f"data: {payload}\n\n"
+
+
+@sse_bp.route("/events")
+def events() -> Response:
+    """Stream progress events to connected clients using SSE."""
+
+    subscriber = progress_events.subscribe()
+
+    def generate() -> Iterable[str]:
+        try:
+            yield from _event_stream(subscriber)
+        finally:
+            progress_events.unsubscribe(subscriber)
+
+    return Response(stream_with_context(generate()), headers=_HEADERS)
+
+
+def publish_progress(
+    job_id_or_payload: Any,
+    payload: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Publish a progress event to all subscribers.
+
+    Supports both ``publish_progress(payload_dict)`` and
+    ``publish_progress(job_id, payload_dict)`` call styles for backwards
+    compatibility with existing modules.
+    """
+
+    if payload is None:
+        if job_id_or_payload is None:
+            return
+        if not isinstance(job_id_or_payload, dict):
+            raise TypeError("publish_progress requires a dict payload when called with a single argument")
+        event = dict(job_id_or_payload)
+        job_id = event.get("job_id")
+    else:
+        job_id = job_id_or_payload
+        event = dict(payload or {})
+        if job_id is not None:
+            event.setdefault("job_id", job_id)
+    progress_events.publish_progress(job_id, event)
+
+
+__all__ = ["sse_bp", "publish_progress"]

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -54,10 +54,10 @@ from . import product_enrichment
 from . import student_model
 from .progress_events import (
     KEEPALIVE_INTERVAL,
-    publish_progress,
     subscribe as progress_subscribe,
     unsubscribe as progress_unsubscribe,
 )
+from .sse import publish_progress
 from .utils.db import row_to_dict, rget
 
 WINNER_SCORE_FIELDS = list(winner_calc.FEATURE_MAP.keys())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Flask
 requests
 beautifulsoup4
 Pillow


### PR DESCRIPTION
## Summary
- implement an SSE blueprint backed by the existing progress bus and expose the /events stream via Flask
- add a /healthz endpoint with a database connectivity probe and update the Flask entrypoint to use a threaded server configuration
- update modules and dependencies to consume the new SSE helper and ensure Flask is listed as a requirement

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd6d37fd4c83288ad80ce6800338d3