### PR TITLE
Implement real-time streaming and delta endpoints

### DIFF
--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -665,7 +665,8 @@ def test_logging_and_explain_endpoint(tmp_path, monkeypatch):
     resp = json.loads(handler2.wfile.getvalue().decode("utf-8"))
     info = resp[str(pid)]
     assert "rating" in info["present"]
-    assert "oldness" in info["missing"]
+    assert "oldness" in info["present"]
+    assert "oldness" not in info["missing"]
     eff = info["effective_weights"]
     assert set(eff.keys()) == set(winner_score.ALLOWED_FIELDS)
     assert abs(sum(eff.values()) - 1.0) < 1e-2


### PR DESCRIPTION
## Summary
- add persistent timestamps and stream cursor tracking to support streaming and delta polling queries
- emit chunked import and enrichment SSE updates with logging, batching, and metrics counters
- expose delta polling endpoints and surface SSE counters via the web app metrics endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd822e05308328b34c7bf1121e44ec