### PR TITLE
Fix AI payload template formatting and add regression test

### DIFF
--- a/tests/test_ai_payload_template.py
+++ b/tests/test_ai_payload_template.py
@@ -1,0 +1,31 @@
+import re
+
+from product_research_app.services.ai_columns import RNG_SENTINEL, _build_payload
+
+
+def test_build_payload_template_replaces_placeholders():
+    batch = [
+        {
+            "id": 123,
+            "title": "Widget",
+            "description": "Descripción extensa",
+            "category": "Gadgets",
+            "brand": "Acme",
+            "price": 19.99,
+            "rating": 4.7,
+            "units_sold": 42,
+            "revenue": 1234.56,
+            "oldness": 0.3,
+        }
+    ]
+    weights = {"desire": 0.8, "winner_score": 0.6}
+
+    payload = _build_payload(batch, weights)
+    messages = payload["messages"]
+    assert len(messages) >= 2
+    user_content = messages[1]["content"]
+
+    assert '{"results":' in user_content
+    assert "0-100" in user_content
+    assert not re.findall(r"\{[A-Za-z_][A-Za-z0-9_]*\}", user_content)
+    assert RNG_SENTINEL not in user_content


### PR DESCRIPTION
## Summary
- replace the AI prompt template formatting with a sentinel-based replacement to avoid KeyError crashes
- avoid f-strings when assembling the JSON-heavy prompt content
- add a regression test ensuring the payload template no longer leaves format placeholders behind

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ce8ff308c88328b6feae73271ce526