### PR TITLE
Adjust layout for sticky header and enhance export images

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -8,6 +8,10 @@ body {
 }
 
 :root {
+  --topbar-h: 56px;
+  --progress-h: 0px;
+  --sticky-offset: calc(var(--topbar-h) + var(--progress-h));
+  --thead-bg: #12142a;
   --dup-bg: #ffe5e5;
   --dup-accent: #ff3b30;
   --bar-btn-bg: #e0f0ff;
@@ -33,12 +37,63 @@ body.dark {
   --bar-btn-focus: #3A6FD8;
 }
 
+.page-root, .main-content { overflow: initial; }
+
 table {
   width: 100%;
   border-collapse: collapse;
   border-spacing: 0;
   margin-top: 0;
 }
+
+.table-wrap {
+  position: relative;
+  overflow: auto;
+  max-height: calc(100vh - var(--topbar-h) - 12px);
+}
+
+.products-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.products-table thead th {
+  position: sticky;
+  top: var(--sticky-offset);
+  z-index: 6;
+  background: var(--thead-bg);
+  box-shadow: 0 1px 0 rgba(255,255,255,.06), 0 6px 12px rgba(0,0,0,.25);
+}
+
+.products-table td,
+.products-table th {
+  padding: 10px 12px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.products-table td.num { text-align: right; }
+
+.products-table col.select { width: 48px; }
+.products-table col.id { width: 56px; }
+.products-table col.imagen { width: 136px; }
+.products-table col.nombre { width: 320px; }
+.products-table col.categoria { width: 220px; }
+.products-table col.price { width: 96px; }
+.products-table col.rating { width: 80px; }
+.products-table col.unidades { width: 120px; }
+.products-table col.ingresos { width: 120px; }
+.products-table col.conv { width: 120px; }
+.products-table col.fecha { width: 120px; }
+.products-table col.rango { width: 140px; }
+.products-table col.desire { width: 380px; }
+.products-table col.magnet { width: 120px; }
+.products-table col.aware { width: 140px; }
+.products-table col.comp { width: 120px; }
+.products-table col.wscore { width: 110px; }
+.products-table col.actions { width: 56px; }
 
 .table-toolbar {
   position: sticky;
@@ -296,22 +351,66 @@ header.app-header {
 body.dark header.app-header {
   background: #1a1b2e;
 }
-#global-progress-wrapper,
-#global-progress-bar {
-  pointer-events: none;
+
+#global-progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 15px 10px;
 }
-.global-progress-overlay {
+
+.progress-host { display: flex; align-items: center; gap: 10px; }
+
+.progress-bar {
+  flex: 1;
   position: relative;
-  inset: auto;
-  width: auto;
-  height: auto;
+  min-height: 26px;
+  padding: 4px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(27,31,58,0.65);
+  color: #e6e6f0;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
 }
-.app-modal-backdrop {
-  z-index: 40;
+
+.progress-bar .progress-label {
+  position: relative;
+  z-index: 2;
+  font-size: 12px;
+  opacity: .9;
 }
-header.app-header .progress-hitbox {
-  pointer-events: none;
+
+.progress-bar .progress-rail {
+  position: absolute;
+  inset: 0;
+  height: 100%;
+  border-radius: inherit;
 }
+
+.progress-bar .progress-meta,
+.progress-bar .progress-percent {
+  opacity: 0;
+}
+
+.btn-cancel {
+  padding: 6px 12px;
+  min-width: 92px;
+  border-radius: 999px;
+  border: 1px solid #6b6f86;
+  background: #1b1f3a;
+  color: #e6e6f0;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.btn-cancel[hidden] { display: none !important; }
+
+.progress-bar.is-cancelled { background: #6c7280 !important; }
 #searchRow {
   display: flex;
   flex-wrap: wrap;

--- a/product_research_app/static/css/loading.css
+++ b/product_research_app/static/css/loading.css
@@ -5,7 +5,7 @@
 .progress-slot { height: 0; overflow: clip; transition: height 160ms ease; }
 
 /* Cuando hay progreso, el slot se expande y empuja el contenido (sin solapar) */
-.progress-slot.active { height: 18px; }
+.progress-slot.active { height: 30px; }
 
 /* ======= RAIL ======= */
 .progress-rail {

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="/static/css/loading.css">
 <script type="module" src="/static/js/config.js" defer></script>
 <script type="module" src="/static/js/net.js" defer></script>
+<script src="/static/js/layout.js" defer></script>
 <script defer src="/static/js/legacy-progress-shim.js"></script>
 <style>
 /* Basic layout */
@@ -98,7 +99,7 @@ body.dark .skeleton{background:#333;}
 <body class="dark">
 <header id="topBar" class="app-header">
   <div id="app-header">
-    <div class="app-toolbar" style="padding:8px 15px; display:flex; align-items:center; justify-content:space-between; position:relative;">
+    <div class="app-toolbar topbar" style="padding:8px 15px; display:flex; align-items:center; justify-content:space-between; position:relative;">
       <div style="display:flex; align-items:center; gap:8px;">
         <h1 style="margin:0; font-size:1.4rem;">Ecom Testing App</h1>
         <p style="margin:0;font-size:12px; opacity:0.8;">By El Tito 🤙</p>
@@ -112,10 +113,11 @@ body.dark .skeleton{background:#333;}
         <button id="configBtn" title="Configuración avanzada">⚙️</button>
       </div>
     </div>
-    <div id="global-progress-wrapper">
-      <div id="global-progress-bar" class="progress-hitbox">
-        <div id="progress-slot-global" class="progress-slot" aria-live="polite"></div>
+    <div id="global-progress" class="progress-host" role="status" aria-live="polite">
+      <div id="progress-slot-global" class="progress-bar progress-slot">
+        <span class="progress-label">Importando catálogo…</span>
       </div>
+      <button id="btn-cancel-import" class="btn-cancel" hidden>Cancelar</button>
     </div>
   </div>
   <!-- Search bar row with controls -->
@@ -231,12 +233,22 @@ body.dark .skeleton{background:#333;}
 </section>
 
 <section id="section-products">
-  <table id="productTable">
-  <thead class="sticky-thead">
-    <tr id="headerRow"></tr>
-  </thead>
-  <tbody></tbody>
-  </table>
+  <div class="table-wrap">
+    <table id="productTable" class="products-table">
+      <colgroup>
+        <col class="select">
+        <col class="id"><col class="imagen"><col class="nombre"><col class="categoria">
+        <col class="price"><col class="rating"><col class="unidades"><col class="ingresos">
+        <col class="conv"><col class="fecha"><col class="rango"><col class="desire">
+        <col class="magnet"><col class="aware"><col class="comp"><col class="wscore">
+        <col class="actions">
+      </colgroup>
+      <thead>
+        <tr id="headerRow"></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
   <div id="bottomBar" class="bottombar hidden">
   <button id="legendBtn" class="legend-btn" title="Mostrar leyenda" aria-label="Mostrar leyenda">ℹ️</button>
   <span id="selCount"></span>
@@ -382,6 +394,53 @@ const IMPORT_START_URL = '/upload';
 let savedApiKeyHash = null;
 let savedApiKeyLength = 0;
 
+(function dropProgressDuplicates(){
+  document.querySelectorAll('#global-progress ~ .progress-text, #global-progress .status-text, .progress-info')
+    .forEach(n => n.remove());
+})();
+
+const cancelBtn = document.getElementById('btn-cancel-import');
+const pbar = document.querySelector('#global-progress .progress-bar');
+const plabel = document.querySelector('#global-progress .progress-label');
+
+function showCancel(v){ if(cancelBtn) cancelBtn.hidden = !v; }
+function setStatusLabel(t){ if(plabel) plabel.textContent = t || ''; }
+function resetProgressState(){ pbar?.classList.remove('is-cancelled'); }
+
+async function cancelImport(){
+  if(!cancelBtn || !window.currentTaskId) return;
+  cancelBtn.disabled = true;
+  try{
+    await fetch('/_import_cancel', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ task_id: window.currentTaskId })
+    });
+  }catch(e){}
+  stopImportPolling?.();
+  pbar?.classList.add('is-cancelled');
+  setStatusLabel('Cancelado');
+  showCancel(false);
+  cancelBtn.disabled = false;
+  window.currentTaskId = null;
+  window.onImportEnd?.();
+}
+cancelBtn?.addEventListener('click', cancelImport);
+
+window.onImportStart = (taskId)=>{
+  window.currentTaskId = taskId;
+  resetProgressState();
+  showCancel(true);
+  setStatusLabel('Importando catálogo…');
+};
+window.onImportEnd = ()=>{
+  window.currentTaskId = null;
+  showCancel(false);
+};
+
+setStatusLabel('');
+showCancel(false);
+resetProgressState();
+
 const getGlobalProgressHost = () => document.querySelector('#progress-slot-global');
 const getActionHost = () => document.querySelector('#bottomBar') || getGlobalProgressHost();
 
@@ -441,6 +500,7 @@ async function followImportTask(taskId, tracker, { statusUrl = IMPORT_STATUS_URL
     serverPct = Math.max(0, Math.min(100, serverPct));
     const stage = (data.message || data.stage || data.state || '').toString() || 'Procesando…';
     tracker?.step(mapServerFraction(serverPct), stage);
+    setStatusLabel(stage);
 
     const statusVal = String(data.state || data.status || '').toLowerCase();
     if (statusVal === 'error' || data.error) {
@@ -452,6 +512,7 @@ async function followImportTask(taskId, tracker, { statusUrl = IMPORT_STATUS_URL
     if (serverPct >= 100 || statusVal === 'done' || statusVal === 'completed' || statusVal === 'finished') {
       await reloadTable({ skipProgress: true });
       hideImportBanner();
+      setStatusLabel('Completado');
       return data;
     }
     await sleep(450);
@@ -460,6 +521,8 @@ async function followImportTask(taskId, tracker, { statusUrl = IMPORT_STATUS_URL
 
 async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IMPORT_STATUS_URL } = {}) {
   if (!file) throw new Error('Archivo no válido');
+  resetProgressState();
+  setStatusLabel('Preparando importación…');
   const host = getGlobalProgressHost();
   const tracker = LoadingHelpers.start('Importando catálogo', { host });
   tracker.setStage('Subiendo archivo…');
@@ -477,6 +540,7 @@ async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IM
         if (!event.lengthComputable) return;
         const frac = Math.min(IMPORT_UPLOAD_FRAC, (event.loaded / event.total) * IMPORT_UPLOAD_FRAC);
         tracker.step(frac, 'Subiendo archivo…');
+        setStatusLabel('Subiendo archivo…');
       };
       xhr.onerror = () => reject(new Error('Error de red subiendo archivo'));
       xhr.onload = () => {
@@ -507,12 +571,15 @@ async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IM
       if (Number.isFinite(importedCount) && importedCount > 0) {
         toast.success(`Importados ${importedCount}`);
       }
+      setStatusLabel('Completado');
       return startResult.data;
     }
 
     const taskId = startResult.taskId;
     const idStr = typeof taskId === 'string' ? taskId : String(taskId);
+    window.onImportStart?.(idStr);
     tracker.step(IMPORT_UPLOAD_FRAC, 'Archivo subido');
+    setStatusLabel('Archivo subido');
     localStorage.setItem(IMPORT_TASK_LS_KEY, idStr);
 
     lastResult = await followImportTask(idStr, tracker, { statusUrl, host });
@@ -522,15 +589,18 @@ async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IM
       toast.success(`Importados ${importedCount}`);
     }
     tracker.step(1, 'Completado');
+    setStatusLabel('Completado');
     return lastResult;
   } catch (err) {
     tracker.step(1, 'Error');
     toast.error(err?.message || 'Error al importar catálogo');
+    setStatusLabel('Error');
     throw err;
   } finally {
     tracker.done();
     localStorage.removeItem(IMPORT_TASK_LS_KEY);
     hideImportBanner();
+    window.onImportEnd?.();
   }
 }
 
@@ -1155,6 +1225,9 @@ window.onload = async () => {
     const host = getGlobalProgressHost();
     const tracker = LoadingHelpers.start('Importando catálogo', { host });
     tracker.step(IMPORT_UPLOAD_FRAC, 'Reanudando…');
+    window.onImportStart?.(tid);
+    resetProgressState();
+    setStatusLabel('Reanudando…');
     try {
       const result = await followImportTask(tid, tracker, { host });
       const importedCount = result?.imported ?? result?.rows_imported;
@@ -1162,13 +1235,16 @@ window.onload = async () => {
         toast.success(`Importados ${importedCount}`);
       }
       tracker.step(1, 'Completado');
+      setStatusLabel('Completado');
     } catch (err) {
       tracker.step(1, 'Error');
       toast.error(err?.message || 'Error en importación');
+      setStatusLabel('Error');
     } finally {
       localStorage.removeItem(IMPORT_TASK_LS_KEY);
       tracker.done();
       hideImportBanner();
+      window.onImportEnd?.();
     }
   }
 };

--- a/product_research_app/static/js/layout.js
+++ b/product_research_app/static/js/layout.js
@@ -1,0 +1,20 @@
+(function stickyOffsets(){
+  const root = document.documentElement;
+  const px = n => (n||0)+'px';
+  function update(){
+    const header = document.querySelector('.app-header');
+    const progress = document.querySelector('#global-progress');
+    const progressBar = progress?.querySelector('.progress-slot');
+    const cancelBtn = progress?.querySelector('.btn-cancel');
+    const isActive = Boolean(progress && progress.offsetParent !== null && (
+      (progressBar && progressBar.classList.contains('active')) || (cancelBtn && !cancelBtn.hidden)
+    ));
+    const progressHeight = isActive ? progress.offsetHeight : 0;
+    root.style.setProperty('--progress-h', px(progressHeight));
+    const headerHeight = (header?.offsetHeight || 0) - progressHeight;
+    root.style.setProperty('--topbar-h', px(headerHeight > 0 ? headerHeight : 0));
+  }
+  window.addEventListener('resize', update);
+  new MutationObserver(update).observe(document.body, {subtree:true, attributes:true, attributeFilter:['class','style','hidden']});
+  requestAnimationFrame(update);
+})();

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import os
 import io
+from io import BytesIO
 import re
 import logging
 import requests
@@ -75,6 +76,65 @@ logger = logging.getLogger(__name__)
 DEBUG = bool(os.environ.get("DEBUG"))
 
 DATE_FORMATS = ("%Y-%m-%d", "%d/%m/%Y")
+
+
+IMG_BASE = 64
+IMG_SCALE = 2.5
+IMG_MAX_PX = 256
+
+
+def _fetch_img_bytes(url: str) -> BytesIO | None:
+    try:
+        resp = requests.get(url, timeout=6)
+        resp.raise_for_status()
+    except Exception:
+        return None
+    return BytesIO(resp.content)
+
+
+def _set_col_width_px(ws, col_letter: str, px: int) -> None:
+    width_chars = max(8, (px - 5) / 7.0)
+    ws.column_dimensions[col_letter].width = width_chars
+
+
+def _add_img_cell(ws, col_letter: str, row_idx: int, url: str) -> bool:
+    try:
+        from openpyxl.drawing.image import Image as XLImage
+        from PIL import Image as PILImage
+    except Exception:
+        return False
+
+    bio = _fetch_img_bytes(url)
+    if not bio:
+        return False
+
+    try:
+        img = PILImage.open(bio).convert("RGBA")
+    except Exception:
+        return False
+
+    w, h = img.size
+    target_w = min(int(IMG_BASE * IMG_SCALE), IMG_MAX_PX)
+    if w and w != target_w:
+        ratio = target_w / float(w)
+        img = img.resize((target_w, max(1, int(h * ratio))), PILImage.LANCZOS)
+
+    out = BytesIO()
+    try:
+        img.save(out, format="PNG")
+    except Exception:
+        return False
+    out.seek(0)
+
+    try:
+        xlimg = XLImage(out)
+    except Exception:
+        return False
+
+    _set_col_width_px(ws, col_letter, target_w + 16)
+    ws.row_dimensions[row_idx].height = target_w + 18
+    ws.add_image(xlimg, f"{col_letter}{row_idx}")
+    return True
 
 
 _DB_INIT = False
@@ -1379,30 +1439,42 @@ class RequestHandler(BaseHTTPRequestHandler):
                         items.append(p)
             else:
                 items = database.list_products(conn)
-            rows = []
+            row_dicts: list[dict[str, Any]] = []
             for p in items:
+                pdata = row_to_dict(p)
                 scores = database.get_scores_for_product(conn, p['id'])
                 score_val = None
                 if scores:
                     sc = scores[0]
                     if 'winner_score' in sc.keys():
                         score_val = sc['winner_score']
-                rows.append(
-                    [
-                        p['id'],
-                        p['name'],
-                        score_val,
-                        p['desire'],
-                        p['desire_magnitude'],
-                        p['awareness_level'],
-                        p['competition_level'],
-                        p['date_range'],
-                    ]
-                )
-            headers = ["id", "name", "Winner Score", "Desire", "Desire Magnitude", "Awareness Level", "Competition Level", "Date Range"]
+                row_dicts.append({
+                    'id': pdata.get('id'),
+                    'image_url': pdata.get('image_url'),
+                    'name': pdata.get('name'),
+                    'winner_score': score_val,
+                    'desire': pdata.get('desire'),
+                    'desire_magnitude': pdata.get('desire_magnitude'),
+                    'awareness_level': pdata.get('awareness_level'),
+                    'competition_level': pdata.get('competition_level'),
+                    'date_range': pdata.get('date_range'),
+                })
+            columns = [
+                ('id', 'ID'),
+                ('image_url', 'Imagen'),
+                ('name', 'Nombre'),
+                ('winner_score', 'Winner Score'),
+                ('desire', 'Desire'),
+                ('desire_magnitude', 'Desire Magnitude'),
+                ('awareness_level', 'Awareness Level'),
+                ('competition_level', 'Competition Level'),
+                ('date_range', 'Date Range'),
+            ]
+            headers = [label for _, label in columns]
             if fmt == 'xlsx':
                 try:
                     from openpyxl import Workbook
+                    from openpyxl.utils import get_column_letter
                 except Exception:
                     self._set_json(500)
                     self.wfile.write(json.dumps({"error": "openpyxl not installed"}).encode('utf-8'))
@@ -1410,9 +1482,17 @@ class RequestHandler(BaseHTTPRequestHandler):
                 wb = Workbook()
                 ws = wb.active
                 ws.append(headers)
-                for r in rows:
-                    ws.append(r)
-                from io import BytesIO
+                col_index = {key: idx for idx, (key, _) in enumerate(columns, start=1)}
+                col_letter_by_key = {key: get_column_letter(idx) for key, idx in col_index.items()}
+                img_key = next((k for k in ('image', 'image_url', 'img') if k in col_index), None)
+                for r_idx, item in enumerate(row_dicts, start=2):
+                    for key, _ in columns:
+                        ws.cell(row=r_idx, column=col_index[key], value=item.get(key))
+                    if img_key:
+                        url = str(item.get(img_key, '') or '').strip()
+                        if url.startswith('http'):
+                            if _add_img_cell(ws, col_letter_by_key[img_key], r_idx, url):
+                                ws.cell(row=r_idx, column=col_index[img_key], value=None)
                 bio = BytesIO()
                 wb.save(bio)
                 data = bio.getvalue()
@@ -1428,7 +1508,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                 output = StringIO()
                 writer = csv.writer(output)
                 writer.writerow(headers)
-                writer.writerows(rows)
+                csv_rows = [[row.get(key) for key, _ in columns] for row in row_dicts]
+                writer.writerows(csv_rows)
                 csv_data = output.getvalue().encode('utf-8')
                 self.send_response(200)
                 self.send_header("Content-Type", "text/csv; charset=utf-8")


### PR DESCRIPTION
## Summary
- wrap the product table in a scrollable container with a sticky header and refreshed progress host markup
- recalc layout offsets at runtime and update styles for the top bar, progress bar, and table column widths
- enlarge embedded product images in XLSX exports while widening rows/columns appropriately

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cee241b72083289426d5ba4537bae0