### PR TITLE
Ensure image preview leads export columns

### DIFF
--- a/product_research_app/routes_export_minimal.py
+++ b/product_research_app/routes_export_minimal.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 ResponseHandler = Any
 EnsureDbFn = Callable[[], Any]
 
-COLUMNS: Sequence[str] = (
+BASE_COLUMNS: Sequence[str] = (
     "Product Name",
     "TikTokUrl",
     "KalodataUrl",
@@ -47,6 +47,141 @@ COLUMNS: Sequence[str] = (
     "Awareness Level",
     "Competition Level",
 )
+
+COLUMNS: Sequence[str] = (
+    "image preview",
+    "name",
+    "category",
+    "launch date",
+    "price",
+    "rating",
+    "revenue",
+    "items sold",
+    "desire",
+    "desire magnitude",
+    "awareness level",
+    "competition level",
+    "TikTokUrl",
+    "KalodataUrl",
+    "Img_url",
+)
+
+
+def reorder_columns(df: pd.DataFrame) -> pd.DataFrame:
+    desired_labels = [
+        "image preview",
+        "name",
+        "category",
+        "launch date",
+        "price",
+        "rating",
+        "revenue",
+        "items sold",
+        "desire",
+        "desire magnitude",
+        "awareness level",
+        "competition level",
+    ]
+
+    lower_map = {c.lower(): c for c in df.columns}
+
+    synonyms = {
+        "image preview": [
+            "image preview",
+            "image_preview",
+            "preview image",
+            "thumbnail",
+            "miniatura",
+            "img",
+            "product image",
+            "image url",
+            "image_url",
+            "img_url",
+            "imagen",
+            "image",
+        ],
+        "name": ["name", "title", "product name", "nombre", "producto"],
+        "category": ["category", "categories", "categoria", "categoría"],
+        "launch date": [
+            "launch date",
+            "launch_date",
+            "launched at",
+            "launched_at",
+            "release date",
+            "release_date",
+            "first seen",
+            "first_seen",
+            "fecha de lanzamiento",
+            "fecha lanzamiento",
+            "date launched",
+            "launchdate",
+        ],
+        "price": ["price", "precio", "price($)", "price usd", "price$"],
+        "rating": ["rating", "rate", "stars", "product rating", "valoración", "valoracion"],
+        "revenue": [
+            "revenue",
+            "total revenue",
+            "total revenue($)",
+            "income",
+            "ingresos",
+        ],
+        "items sold": [
+            "items sold",
+            "units_sold",
+            "units sold",
+            "item sold",
+            "sold",
+            "unidades vendidas",
+        ],
+        "desire": ["desire", "desires"],
+        "desire magnitude": [
+            "desire magnitude",
+            "desire_magnitude",
+            "desire mag",
+            "desire_mag",
+            "magnitud del deseo",
+        ],
+        "awareness level": [
+            "awareness level",
+            "awareness",
+            "nivel de awareness",
+            "nivel awareness",
+        ],
+        "competition level": [
+            "competition level",
+            "competition",
+            "nivel de competencia",
+        ],
+    }
+
+    resolved: List[str] = []
+    rename_map: Dict[str, str] = {}
+
+    for canonical in desired_labels:
+        found = None
+        for variant in synonyms.get(canonical, [canonical]):
+            key = variant.lower()
+            if key in lower_map:
+                found = lower_map[key]
+                break
+        if found and found not in resolved:
+            resolved.append(found)
+            if found != canonical:
+                rename_map[found] = canonical
+
+    remaining = [c for c in df.columns if c not in resolved]
+
+    ordered_cols = resolved + remaining
+    df_out = df.reindex(columns=ordered_cols)
+
+    if rename_map:
+        df_out = df_out.rename(columns=rename_map)
+
+    cols_lower = {c.lower(): c for c in df_out.columns}
+    if "image preview" in cols_lower and "image" in cols_lower:
+        df_out = df_out.drop(columns=[cols_lower["image"]])
+
+    return df_out
 
 TEXT_FIELD_KEYS: Dict[str, Sequence[str]] = {
     "Product Name": ("name", "product_name", "title"),
@@ -133,12 +268,29 @@ _AWARENESS_LABELS = {
 
 _IMG_MAX_WIDTH = 240
 _IMG_MAX_HEIGHT = 160
-_IMG_COLUMN_INDEX = 5
 _IMG_ROW_HEIGHT = 150
 
 _IMAGE_SESSION = requests.Session()
 _IMAGE_SESSION.headers.update({"User-Agent": "product-research-exporter/1.0"})
 _IMG_CACHE: Dict[str, Optional[bytes]] = {}
+
+
+def _build_header_index_map(ws) -> Dict[str, int]:
+    mapping: Dict[str, int] = {}
+    for cell in ws[1]:
+        value = cell.value
+        if isinstance(value, str):
+            mapping[value.strip().lower()] = cell.col_idx
+    return mapping
+
+
+def _resolve_column_index(mapping: Mapping[str, int], *names: str) -> Optional[int]:
+    for name in names:
+        key = name.strip().lower()
+        if key in mapping:
+            return mapping[key]
+    return None
+
 
 def export_kalodata_minimal(handler: ResponseHandler, ensure_db: EnsureDbFn) -> None:
     start = time.perf_counter()
@@ -219,7 +371,8 @@ def _build_workbook(rows: Sequence[Mapping[str, Any]]) -> bytes:
                 ", ".join(missing),
             )
 
-    df = pd.DataFrame(records, columns=COLUMNS)
+    df = pd.DataFrame(records, columns=BASE_COLUMNS)
+    df = reorder_columns(df)
 
     buffer = io.BytesIO()
     with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
@@ -242,34 +395,48 @@ def _apply_sheet_format(ws) -> None:
         cell.font = header_font
         cell.alignment = Alignment(vertical="center", wrap_text=True)
 
-    widths = {
-        1: 40,
-        2: 35,
-        3: 35,
-        4: 40,
-        5: 38,
-        6: 18,
-        7: 12,
-        8: 14,
-        9: 12,
-        10: 16,
-        11: 14,
-        12: 45,
-        13: 18,
-        14: 18,
-        15: 18,
-    }
-    for idx, width in widths.items():
-        ws.column_dimensions[get_column_letter(idx)].width = width
+    header_map = _build_header_index_map(ws)
 
-    text_cols = [1, 4, 6, 12, 14, 15]
+    width_preferences = {
+        ("image", "img_url", "image url"): 40,
+        ("name", "product name"): 40,
+        ("category",): 18,
+        ("price", "price($)", "price usd", "price$"): 12,
+        ("rating", "product rating"): 14,
+        ("revenue", "total revenue($)", "total revenue"): 16,
+        ("items sold", "item sold", "units sold"): 12,
+        ("desire",): 45,
+        ("desire magnitude", "desire_mag"): 18,
+        ("awareness level",): 18,
+        ("competition level",): 18,
+        ("tiktokurl", "tiktok url"): 35,
+        ("kalodataurl", "kalodata url"): 35,
+        ("image preview",): 38,
+        ("launch date",): 14,
+    }
+    for headers, width in width_preferences.items():
+        idx = _resolve_column_index(header_map, *headers)
+        if idx is not None:
+            ws.column_dimensions[get_column_letter(idx)].width = width
+
+    text_column_candidates = [
+        ("image", "img_url", "image url"),
+        ("name", "product name"),
+        ("category",),
+        ("desire",),
+        ("awareness level",),
+        ("competition level",),
+    ]
     if ws.max_row >= 2:
-        for col in text_cols:
+        for headers in text_column_candidates:
+            col_idx = _resolve_column_index(header_map, *headers)
+            if col_idx is None:
+                continue
             for row in ws.iter_rows(
                 min_row=2,
                 max_row=ws.max_row,
-                min_col=col,
-                max_col=col,
+                min_col=col_idx,
+                max_col=col_idx,
             ):
                 cell = row[0]
                 cell.alignment = Alignment(vertical="top", wrap_text=True)
@@ -280,44 +447,68 @@ def _apply_sheet_format(ws) -> None:
         num_fmt_date = "yyyy-mm-dd"
         num_fmt_desire = "0"
 
-        for column in ws.iter_cols(9, 9, 2, ws.max_row):
-            for cell in column:
-                cell.number_format = num_fmt_int
-        for column in ws.iter_cols(7, 7, 2, ws.max_row):
-            for cell in column:
-                cell.number_format = num_fmt_money
-        for column in ws.iter_cols(8, 8, 2, ws.max_row):
-            for cell in column:
-                cell.number_format = num_fmt_rating
-        for column in ws.iter_cols(10, 10, 2, ws.max_row):
-            for cell in column:
-                cell.number_format = num_fmt_money
-        for column in ws.iter_cols(11, 11, 2, ws.max_row):
-            for cell in column:
-                cell.number_format = num_fmt_date
-        for column in ws.iter_cols(13, 13, 2, ws.max_row):
-            for cell in column:
-                cell.number_format = num_fmt_desire
+        items_col = _resolve_column_index(header_map, "items sold", "item sold", "units sold")
+        if items_col is not None:
+            for column in ws.iter_cols(items_col, items_col, 2, ws.max_row):
+                for cell in column:
+                    cell.number_format = num_fmt_int
 
-        dv = DataValidation(
-            type="whole",
-            operator="between",
-            formula1="0",
-            formula2="100",
-            allow_blank=True,
+        price_col = _resolve_column_index(header_map, "price", "price($)", "price usd", "price$")
+        if price_col is not None:
+            for column in ws.iter_cols(price_col, price_col, 2, ws.max_row):
+                for cell in column:
+                    cell.number_format = num_fmt_money
+
+        rating_col = _resolve_column_index(header_map, "rating", "product rating")
+        if rating_col is not None:
+            for column in ws.iter_cols(rating_col, rating_col, 2, ws.max_row):
+                for cell in column:
+                    cell.number_format = num_fmt_rating
+
+        revenue_col = _resolve_column_index(
+            header_map, "revenue", "total revenue($)", "total revenue"
         )
-        ws.add_data_validation(dv)
-        dv_range = f"{get_column_letter(13)}2:{get_column_letter(13)}{ws.max_row}"
-        dv.add(dv_range)
-        bar_rule = DataBarRule(
-            start_type="num",
-            start_value=0,
-            end_type="num",
-            end_value=100,
-            color="1F497D",
-            showValue=None,
+        if revenue_col is not None:
+            for column in ws.iter_cols(revenue_col, revenue_col, 2, ws.max_row):
+                for cell in column:
+                    cell.number_format = num_fmt_money
+
+        launch_col = _resolve_column_index(header_map, "launch date")
+        if launch_col is not None:
+            for column in ws.iter_cols(launch_col, launch_col, 2, ws.max_row):
+                for cell in column:
+                    cell.number_format = num_fmt_date
+
+        desire_mag_col = _resolve_column_index(
+            header_map, "desire magnitude", "desire_mag"
         )
-        ws.conditional_formatting.add(dv_range, bar_rule)
+        if desire_mag_col is not None:
+            for column in ws.iter_cols(desire_mag_col, desire_mag_col, 2, ws.max_row):
+                for cell in column:
+                    cell.number_format = num_fmt_desire
+
+            dv = DataValidation(
+                type="whole",
+                operator="between",
+                formula1="0",
+                formula2="100",
+                allow_blank=True,
+            )
+            ws.add_data_validation(dv)
+            dv_range = (
+                f"{get_column_letter(desire_mag_col)}2:"
+                f"{get_column_letter(desire_mag_col)}{ws.max_row}"
+            )
+            dv.add(dv_range)
+            bar_rule = DataBarRule(
+                start_type="num",
+                start_value=0,
+                end_type="num",
+                end_value=100,
+                color="1F497D",
+                showValue=None,
+            )
+            ws.conditional_formatting.add(dv_range, bar_rule)
 
     table_ref = f"A1:{get_column_letter(ws.max_column)}{ws.max_row}"
     table = Table(displayName="tbl_products", ref=table_ref)
@@ -448,12 +639,20 @@ def _rank_percentile(value: Any, sorted_values: Sequence[float]) -> float:
 
 
 def _embed_images(ws) -> None:
-    column_letter = get_column_letter(_IMG_COLUMN_INDEX)
+    header_map = _build_header_index_map(ws)
+    image_col = _resolve_column_index(header_map, "image", "img_url", "image url")
+    preview_col = _resolve_column_index(header_map, "image preview")
+
+    if image_col is None or preview_col is None:
+        logger.warning("Unable to locate image columns for embedding")
+        return
+
+    column_letter = get_column_letter(preview_col)
     ws.column_dimensions[column_letter].width = 38
     for row_idx in range(2, ws.max_row + 1):
-        url = ws.cell(row=row_idx, column=4).value
+        url = ws.cell(row=row_idx, column=image_col).value
         bio = _fetch_and_resize(url)
-        target_cell = ws.cell(row=row_idx, column=_IMG_COLUMN_INDEX)
+        target_cell = ws.cell(row=row_idx, column=preview_col)
         if bio is not None:
             pic = XLImage(bio)
             anchor = f"{column_letter}{row_idx}"

--- a/product_research_app/tests/test_app_flow.py
+++ b/product_research_app/tests/test_app_flow.py
@@ -922,52 +922,60 @@ def test_export_kalodata_minimal_success(tmp_path, monkeypatch):
     assert len(rows) == 3
     row1, row2, row3 = rows
 
-    assert row1[0] == "Alpha"
-    assert row2[0] == "Beta"
-    assert row3[0] == "Gamma"
-    assert row1[4] is None
-    assert row3[4] == "(no image)"
-    assert row1[5] == "Beauty"
-    assert row1[6] == 19.99
-    assert row1[7] == 4.8
-    assert row1[8] == 1200
-    assert row1[9] == 1550.0
-    assert row1[10].strftime("%Y-%m-%d") == "2024-01-01"
-    assert row1[11] == "Fuerte deseo"
-    assert row1[12] == 80
-    assert row1[13] == "Solution-aware"
-    assert row1[14] == "Low"
+    assert row1[0] is None
+    assert row2[0] is None
+    assert row3[0] == "(no image)"
+    assert row1[1] == "Alpha"
+    assert row2[1] == "Beta"
+    assert row3[1] == "Gamma"
+    assert row1[2] == "Beauty"
+    assert row2[2] == "Home"
+    assert row3[2] == "Kitchen"
+    assert row1[3] and row1[3].strftime("%Y-%m-%d") == "2024-01-01"
+    assert row2[3] and row2[3].strftime("%Y-%m-%d") == "2023-12-15"
+    assert row3[3] and row3[3].strftime("%Y-%m-%d") == "2023-11-30"
+    assert row1[4] == 19.99
+    assert row2[4] == 29.0
+    assert row3[4] == 15.5
+    assert row1[5] == 4.8
+    assert row2[5] == 4.1
+    assert row3[5] == 4.5
+    assert row1[6] == 1550.0
+    assert row2[6] == 500.0
+    assert row3[6] == 300.0
+    assert row1[7] == 1200
+    assert row2[7] == 80
+    assert row3[7] == 500
+    assert row1[8] == "Fuerte deseo"
+    assert row2[8] == "Resuelve dolor"
+    assert row3[8] == "Resolver frustración"
+    assert row1[9] == 80
+    assert row2[9] == 65
+    assert row3[9] == 50
+    assert row1[10] == "Solution-aware"
+    assert row2[10] == "Product-aware"
+    assert row3[10] == "Most aware"
+    assert row1[11] == "Low"
+    assert row2[11] == "Medium"
+    assert row3[11] == "High"
+    assert row1[12] == "https://tiktok.example/alpha"
+    assert row2[12] == "https://tiktok.example/beta"
+    assert row3[12] == "https://tiktok.example/gamma"
+    assert row1[13] == "https://kalodata.example/alpha"
+    assert row2[13] == "https://kalodata.example/beta"
+    assert row3[13] == "https://kalodata.example/gamma"
+    assert row1[14] == "https://img.example/alpha.jpg"
+    assert row2[14] == "https://img.example/beta.png"
+    assert row3[14] == "https://img.example/gamma-missing.png"
 
-    assert row2[5] == "Home"
-    assert row2[6] == 29.0
-    assert row2[7] == 4.1
-    assert row2[8] == 80
-    assert row2[9] == 500.0
-    assert row2[10].strftime("%Y-%m-%d") == "2023-12-15"
-    assert row2[11] == "Resuelve dolor"
-    assert row2[12] == 65
-    assert row2[13] == "Product-aware"
-    assert row2[14] == "Medium"
-
-    assert row3[5] == "Kitchen"
-    assert row3[6] == 15.5
-    assert row3[7] == 4.5
-    assert row3[8] == 500
-    assert row3[9] == 300.0
-    assert row3[10].strftime("%Y-%m-%d") == "2023-11-30"
-    assert row3[11] == "Resolver frustración"
-    assert row3[12] == 50
-    assert row3[13] == "Most aware"
-    assert row3[14] == "High"
-
-    assert ws.column_dimensions["A"].width == 40
-    assert ws.column_dimensions["E"].width == 38
-    assert ws.column_dimensions["L"].width == 45
+    assert ws.column_dimensions["A"].width == 38
+    assert ws.column_dimensions["I"].width == 45
+    assert ws.column_dimensions["O"].width == 40
     assert "tbl_products" in ws.tables
     assert ws.tables["tbl_products"].ref == "A1:O4"
 
     dv_ranges = [dv.sqref for dv in ws.data_validations.dataValidation]
-    assert any(str(dv) == "M2:M4" for dv in dv_ranges)
+    assert any(str(dv) == "J2:J4" for dv in dv_ranges)
 
     cf_ranges = list(ws.conditional_formatting)
 


### PR DESCRIPTION
## Summary
- update the export column reordering helper to promote `image preview`, normalize synonyms, and remove redundant `image` columns ahead of serialization
- refresh the minimal export flow test to reflect the new column order, widths, and data positions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfe8ec4aac83288410f0b2a85d8dd1