### PR TITLE
Remove flame decorations from product names

### DIFF
--- a/product_research_app/routes_export_minimal.py
+++ b/product_research_app/routes_export_minimal.py
@@ -26,6 +26,7 @@ from openpyxl.worksheet.table import Table, TableStyleInfo
 from openpyxl.worksheet.cell_range import CellRange
 
 from . import database
+from .utils import sanitize_product_name
 from .utils.db import row_to_dict
 
 logger = logging.getLogger(__name__)
@@ -647,6 +648,7 @@ def _convert_row(row: Mapping[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]
     sources = _prepare_sources(row, extras)
 
     product_name = _coerce_text(_value_from_sources(sources, TEXT_FIELD_KEYS["Product Name"]))
+    product_name = sanitize_product_name(product_name) or ""
     tiktok_url = _coerce_text(_value_from_sources(sources, TEXT_FIELD_KEYS["TikTokUrl"]))
     kalodata_url = _coerce_text(_value_from_sources(sources, TEXT_FIELD_KEYS["KalodataUrl"]))
     image_url = _coerce_text(_value_from_sources(sources, TEXT_FIELD_KEYS["Img_url"]))

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -172,8 +172,6 @@ body.dark .popover {
   overflow: auto;
 }
 
-.selected .fires { filter: grayscale(1); opacity: .6; }
-
 .table tbody tr.selected { background: #cde8ff; }
 body.dark .table tbody tr.selected { background: #243150; }
 

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -249,7 +249,6 @@ body.dark .skeleton{background:#333;}
   </div>
   <div id="legendPop" class="popover hidden">
   <div>• Fila roja: duplicado</div>
-  <div>• 🔥 x1–x5: tendencia en el nombre</div>
   </div>
   <div id="columnsPanel" class="popover hidden"></div>
 </section>
@@ -945,19 +944,12 @@ function renderTable() {
           showOverlay(value);
         };
         td.appendChild(img);
-      } else if (key === 'name' && value) {
-        const fireCount = item.trending || 0;
-        const fireText = firesFor(fireCount);
-        const nameSpan = document.createElement('span');
-        nameSpan.textContent = value + (fireText ? ' ' : '');
-        td.appendChild(nameSpan);
-        if (fireCount > 0) {
-          const fireSpan = document.createElement('span');
-          fireSpan.className = 'fires';
-          fireSpan.textContent = fireText;
-          fireSpan.setAttribute('aria-label', `Tendencia: x${fireCount}`);
-          fireSpan.title = `Tendencia: x${fireCount}`;
-          td.appendChild(fireSpan);
+      } else if (key === 'name') {
+        const safeName = value == null ? '' : String(value);
+        if (safeName) {
+          const nameSpan = document.createElement('span');
+          nameSpan.textContent = safeName;
+          td.appendChild(nameSpan);
         }
         // If Kalodata URL exists, add copy link button
         const kal = item.extras && item.extras['KalodataUrl'];

--- a/product_research_app/static/js/format.js
+++ b/product_research_app/static/js/format.js
@@ -33,3 +33,7 @@ export function fmtPct(n) {
   return fmtNumber(n, 1) + '%';
 }
 
+export function nameWithFlames(name/*, trendingScore*/) {
+  return String(name ?? "");
+}
+

--- a/product_research_app/static/js/table.js
+++ b/product_research_app/static/js/table.js
@@ -51,10 +51,6 @@ function updateMasterState(){
   }
 }
 
-function firesFor(score0to5){
-  const n = Math.max(0, Math.min(5, Math.round(score0to5 || 0)));
-  return '🔥'.repeat(n);
-}
 const table = document.getElementById('productTable');
 if(bottomBar){
   const legendBtn = document.getElementById('legendBtn');

--- a/product_research_app/utils/__init__.py
+++ b/product_research_app/utils/__init__.py
@@ -1,1 +1,19 @@
 """Utility helpers for the Product Research app."""
+
+from __future__ import annotations
+
+import re
+
+FLAME = "\U0001F525"
+_FLAMES_RE = re.compile(rf"{FLAME}+$")
+
+
+def sanitize_product_name(name: str | None):
+    """Remove trailing flame emojis from product names."""
+
+    if not isinstance(name, str):
+        return name
+    return _FLAMES_RE.sub("", name).strip()
+
+
+__all__ = ["sanitize_product_name"]


### PR DESCRIPTION
## Summary
- render product names without flame decorations in the UI and remove the legend entry
- sanitize product names server-side and keep exports free of flame emojis by reusing a shared helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cff6c413a08328968d510f226f9cac