### PR TITLE
Add default winner order and refresh weights UI

### DIFF
--- a/product_research_app/api/config.py
+++ b/product_research_app/api/config.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import request, jsonify, current_app
 from . import app
 
@@ -7,20 +9,32 @@ from product_research_app.services.winner_score import (
     save_settings,
     invalidate_weights_cache,
 )
+from product_research_app import config as app_config, gpt
 from product_research_app.services.config import (
     ALLOWED_FIELDS,
     compute_effective_int,
+    DEFAULT_ORDER,
+    DEFAULT_WEIGHTS_RAW,
+    validate_order,
 )
 
 
 def _coerce_weights(raw: dict | None) -> dict[str, int]:
     out: dict[str, int] = {}
     for k, v in (raw or {}).items():
+        if k not in ALLOWED_FIELDS:
+            continue
         try:
             iv = int(round(float(v)))
         except Exception:
             iv = 0
-        out[k] = max(0, min(100, iv))
+        if iv < 0:
+            iv = 0
+        if iv > 100:
+            iv = 100
+        if iv > 50:
+            iv = int(round(iv * 0.5))
+        out[k] = max(0, min(50, iv))
     return out
 
 
@@ -28,6 +42,19 @@ def _merge_winner_weights(current: dict | None, incoming: dict | None) -> dict:
     cur = dict(current or {})
     cur.update(incoming or {})
     return cur
+
+
+def _load_weights_state():
+    settings = load_settings()
+    base_weights = {k: DEFAULT_WEIGHTS_RAW.get(k, 0) for k in ALLOWED_FIELDS}
+    weights = base_weights.copy()
+    weights.update(_coerce_weights(settings.get("winner_weights")))
+    try:
+        order = validate_order(settings.get("winner_order"))
+    except ValueError:
+        order = DEFAULT_ORDER.copy()
+    enabled = {k: bool((settings.get("weights_enabled") or {}).get(k, True)) for k in ALLOWED_FIELDS}
+    return settings, weights, order, enabled
 
 
 """Endpoints for winner weight configuration.
@@ -43,23 +70,143 @@ accepts any of the shapes described above.
 # GET /api/config/winner-weights
 @app.route("/api/config/winner-weights", methods=["GET"])
 def api_get_winner_weights():
-    settings = load_settings()
-    weights = _coerce_weights(settings.get("winner_weights"))
-    order = settings.get("winner_order") or list(weights.keys())
-    enabled_raw = settings.get("weights_enabled") if isinstance(settings.get("weights_enabled"), dict) else {}
-    enabled = {k: bool(enabled_raw.get(k, True)) for k in weights.keys()}
-    weights_eff = {k: (weights.get(k, 0) if enabled.get(k, True) else 0) for k in weights.keys()}
+    settings, weights, order, enabled = _load_weights_state()
+    weights_eff = {k: (weights.get(k, 0) if enabled.get(k, True) else 0) for k in ALLOWED_FIELDS}
     eff = compute_effective_int(weights_eff, order)
+    payload = {k: weights.get(k, 0) for k in ALLOWED_FIELDS}
     resp = jsonify({
-        **weights,
-        "weights": weights,
+        **payload,
+        "weights": payload,
         "order": order,
         "effective": {"int": eff},
         "weights_enabled": enabled,
         "weights_order": settings.get("weights_order") or order,
+        "version": "v2",
     })
     resp.headers["Cache-Control"] = "no-store"
     return resp, 200
+
+
+# POST /api/config/winner-weights/ai
+@app.route("/api/config/winner-weights/ai", methods=["POST"])
+def api_ai_winner_weights():
+    body = request.get_json(force=True) or {}
+    can_reorder = str(request.args.get("can_reorder", "false")).lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    data_sample = body.get("data_sample") or []
+    target = (body.get("target") or "").strip()
+    if not data_sample or not target:
+        return jsonify({"error": "insufficient_data"}), 400
+
+    features = [f for f in (body.get("features") or ALLOWED_FIELDS) if f in ALLOWED_FIELDS]
+    samples: list[dict[str, float]] = []
+    for row in data_sample:
+        if not isinstance(row, dict):
+            continue
+        sample: dict[str, float] = {}
+        for key in features:
+            try:
+                sample[key] = float(row.get(key, 0.0))
+            except Exception:
+                sample[key] = 0.0
+        try:
+            sample["target"] = float(row.get("target", 0.0))
+        except Exception:
+            sample["target"] = 0.0
+        samples.append(sample)
+
+    if not samples:
+        return jsonify({"error": "insufficient_data"}), 400
+
+    api_key = app_config.get_api_key() or os.environ.get("OPENAI_API_KEY")
+    model = app_config.get_model()
+    if not api_key or not model:
+        return jsonify({"error": "missing_api_key"}), 400
+
+    try:
+        result = gpt.recommend_winner_weights(api_key, model, samples, target)
+    except Exception as exc:  # pragma: no cover - defensive
+        current_app.logger.warning("AI winner weights failed: %s", exc)
+        return jsonify({"error": "ai_error", "message": str(exc)}), 500
+
+    recommended = _coerce_weights(result.get("weights"))
+    settings, current_weights, current_order, current_enabled = _load_weights_state()
+    weights = {k: DEFAULT_WEIGHTS_RAW.get(k, 0) for k in ALLOWED_FIELDS}
+    weights.update(current_weights)
+    weights.update(recommended)
+
+    order_candidate = result.get("order") if isinstance(result, dict) else None
+    proposed_order = None
+    if isinstance(order_candidate, list):
+        try:
+            proposed_order = validate_order(order_candidate)
+        except ValueError:
+            proposed_order = None
+    if proposed_order is None:
+        pos = {k: idx for idx, k in enumerate(current_order)}
+        proposed_order = sorted(
+            ALLOWED_FIELDS,
+            key=lambda key: (-weights.get(key, 0), pos.get(key, len(ALLOWED_FIELDS))),
+        )
+
+    updated = 0
+    persisted = False
+    diagnostics = {"notes": result.get("justification", "") if isinstance(result, dict) else ""}
+
+    if can_reorder:
+        weight_changes = {
+            k: (current_weights.get(k, 0), weights.get(k, 0))
+            for k in ALLOWED_FIELDS
+            if current_weights.get(k, 0) != weights.get(k, 0)
+        }
+        previous_positions = {k: idx for idx, k in enumerate(current_order)}
+        order_moves = []
+        for idx, key in enumerate(proposed_order):
+            prev_idx = previous_positions.get(key)
+            if prev_idx is not None and prev_idx != idx:
+                order_moves.append({"metric": key, "from": prev_idx, "to": idx})
+        if weight_changes or order_moves:
+            current_app.logger.info(
+                "winner_weights.diff source=ai weights=%s order=%s",
+                weight_changes,
+                order_moves,
+            )
+        settings["winner_weights"] = {k: weights.get(k, 0) for k in ALLOWED_FIELDS}
+        settings["winner_weights_schema_version"] = 2
+        settings["winner_order"] = proposed_order
+        settings["weights_order"] = proposed_order
+        settings["weights_enabled"] = current_enabled
+        save_settings(settings)
+        invalidate_weights_cache()
+        try:
+            updated = recompute_scores_for_all_products(scope="all")
+        except Exception as exc:  # pragma: no cover - defensive
+            current_app.logger.warning("recompute on ai save failed: %s", exc)
+        persisted = True
+    weights_eff = {k: (weights.get(k, 0) if current_enabled.get(k, True) else 0) for k in ALLOWED_FIELDS}
+    order_for_effect = proposed_order if can_reorder else current_order
+    effective = compute_effective_int(weights_eff, order_for_effect)
+    payload = {k: weights.get(k, 0) for k in ALLOWED_FIELDS}
+    stored_order = proposed_order if can_reorder else current_order
+    response = {
+        "weights": payload,
+        "winner_weights": payload,
+        "order": proposed_order,
+        "winner_order": stored_order,
+        "weights_enabled": current_enabled,
+        "weights_order": stored_order,
+        "effective": {"int": effective},
+        "version": "v2",
+        "method": result.get("method", "gpt") if isinstance(result, dict) else "gpt",
+        "diagnostics": diagnostics,
+        "updated": updated,
+        "persisted": persisted,
+    }
+    return jsonify(response), 200
 
 
 # PATCH /api/config/winner-weights
@@ -73,27 +220,52 @@ def api_patch_winner_weights():
     )
     incoming = _coerce_weights(payload_map)
 
-    settings = load_settings()
-    current = _coerce_weights(settings.get("winner_weights"))
-    if "awareness" not in incoming and "awareness" not in current:
-        incoming["awareness"] = 50
-    settings["winner_weights"] = _merge_winner_weights(current, incoming)
+    settings, current_weights, current_order, current_enabled = _load_weights_state()
+    new_weights = current_weights.copy()
+    new_weights.update(incoming)
+    for key in ALLOWED_FIELDS:
+        new_weights.setdefault(key, DEFAULT_WEIGHTS_RAW.get(key, 0))
 
     order_in = body.get("order") or body.get("weights_order")
-    if isinstance(order_in, list):
-        order = [k for k in order_in if k in ALLOWED_FIELDS]
+    order_provided = isinstance(order_in, list)
+    if order_provided:
+        try:
+            order = validate_order(order_in)
+        except ValueError:
+            return jsonify({"error": "invalid_order"}), 400
     else:
-        order = settings.get("winner_order") or list(settings["winner_weights"].keys())
-    if "awareness" not in order:
-        order.append("awareness")
-    settings["winner_order"] = order
-    settings["weights_order"] = order
+        order = current_order
 
     en_in = body.get("weights_enabled")
     if isinstance(en_in, dict):
-        current_en = settings.get("weights_enabled", {})
-        enabled = {k: bool(en_in.get(k, current_en.get(k, True))) for k in ALLOWED_FIELDS}
-        settings["weights_enabled"] = enabled
+        enabled = {k: bool(en_in.get(k, current_enabled.get(k, True))) for k in ALLOWED_FIELDS}
+    else:
+        enabled = current_enabled
+
+    weight_changes = {
+        k: (current_weights.get(k, 0), new_weights.get(k, 0))
+        for k in ALLOWED_FIELDS
+        if current_weights.get(k, 0) != new_weights.get(k, 0)
+    }
+    order_moves = []
+    if order_provided:
+        previous_positions = {k: idx for idx, k in enumerate(current_order)}
+        for idx, key in enumerate(order):
+            prev_idx = previous_positions.get(key)
+            if prev_idx is not None and prev_idx != idx:
+                order_moves.append({"metric": key, "from": prev_idx, "to": idx})
+    if weight_changes or order_moves:
+        current_app.logger.info(
+            "winner_weights.diff weights=%s order=%s",
+            weight_changes,
+            order_moves,
+        )
+
+    settings["winner_weights"] = new_weights
+    settings["winner_weights_schema_version"] = 2
+    settings["winner_order"] = order
+    settings["weights_order"] = order
+    settings["weights_enabled"] = enabled
 
     save_settings(settings)
     invalidate_weights_cache()
@@ -104,6 +276,23 @@ def api_patch_winner_weights():
     except Exception as e:
         current_app.logger.warning("recompute on save failed: %s", e)
 
-    resp = jsonify({"ok": True, "winner_weights": settings["winner_weights"], "winner_order": order, "updated": updated})
+    weights_eff = {k: (new_weights.get(k, 0) if enabled.get(k, True) else 0) for k in ALLOWED_FIELDS}
+    eff = compute_effective_int(weights_eff, order)
+    resp_payload = {k: new_weights.get(k, 0) for k in ALLOWED_FIELDS}
+    resp = jsonify(
+        {
+            "ok": True,
+            **resp_payload,
+            "weights": resp_payload,
+            "winner_weights": new_weights,
+            "winner_order": order,
+            "order": order,
+            "weights_enabled": enabled,
+            "weights_order": order,
+            "effective": {"int": eff},
+            "version": "v2",
+            "updated": updated,
+        }
+    )
     resp.headers["Cache-Control"] = "no-store"
     return resp, 200

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -758,47 +758,83 @@ input[type="range"].weight-range { width: 100% !important; }
   list-style:none;
   margin:0;
   padding:0;
-  display:grid;
-  grid-template-columns:1fr;
+  display:flex;
+  flex-direction:column;
   gap:10px;
 }
 
-.weight-card {
-  display: grid;
-  grid-template-columns: 40px 1fr 24px;
-  align-items: center;
-  gap: 10px;
-  padding: 10px;
-  border-radius: 12px;
+.weight-item{
+  position:relative;
+  display:grid;
+  grid-template-columns: auto 1fr auto;
+  gap:12px;
+  align-items:center;
+  padding:12px;
+  border-radius:12px;
+  background:rgba(0,0,0,0.25);
+  transition:background .3s ease, transform .3s ease;
 }
-.weight-card:nth-child(odd) { background: rgba(0,0,0,0.03); }
-body.dark .weight-card:nth-child(odd) { background: rgba(255,255,255,0.03); }
-.weights-list .weight-card:nth-child(odd){ margin-bottom:0; }
+body.dark .weight-item{ background:rgba(255,255,255,0.05); }
+.weight-item.highlight{ background:rgba(122,83,214,0.25); }
+.weight-item.moved-up::after,
+.weight-item.moved-down::after{
+  content:"";
+  position:absolute;
+  left:8px;
+  top:50%;
+  width:6px;
+  height:6px;
+  border-radius:50%;
+  background:#7a53d6;
+  transform:translateY(-50%);
+}
+.weight-item.moved-up::after{ box-shadow:0 -12px 0 #7a53d6; }
+.weight-item.moved-down::after{ box-shadow:0 12px 0 #7a53d6; }
 
-.priority-badge {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: #7a53d6;
-  color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  font-size: 14px;
+.wi-head{ display:flex; align-items:center; gap:8px; }
+.wi-rank{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:28px;
+  padding:4px 8px;
+  border-radius:999px;
+  font-weight:600;
+  font-size:12px;
+  background:#7a53d6;
+  color:#fff;
+}
+.wi-title{ font-weight:600; font-size:14px; }
+.wi-handle{
+  border:none;
+  background:transparent;
+  color:inherit;
+  cursor:grab;
+  font-size:18px;
+  line-height:1;
 }
 
-.drag-handle {
-  cursor: grab;
-  text-align: center;
-  user-select: none;
-  opacity: .7;
+.wi-controls{ display:flex; align-items:center; gap:10px; }
+.weight-input{
+  width:70px;
+  padding:4px 6px;
+  border-radius:6px;
+  border:1px solid rgba(255,255,255,0.2);
+  background:rgba(0,0,0,0.3);
+  color:inherit;
+  font-weight:600;
+}
+body.dark .weight-input{ border-color:rgba(255,255,255,0.25); background:rgba(255,255,255,0.08); }
+.weight-input.changed{
+  animation: weightPulse 1s ease;
 }
 
-.weight-card .label{ margin-bottom:2px; }
-.weight-card .scale{ margin-top:2px; }
-.weight-card .meta{ margin-top:4px; }
-.weight-card.disabled{ opacity:0.5; }
+@keyframes weightPulse{
+  0%{ box-shadow:0 0 0 0 rgba(122,83,214,0.6); }
+  100%{ box-shadow:0 0 0 12px rgba(122,83,214,0); }
+}
+
+.weight-item.disabled{ opacity:0.5; }
 
 /* Awareness segmented slider */
 .segmented-range{ position:relative; margin:10px 0 6px; }
@@ -817,6 +853,29 @@ input[type="range"].seg-awareness{ width:100%; display:block; margin:0; }
   gap:0; margin-top:6px; font-size:12px; opacity:.95;
   text-align:center;
 }
+
+.weights-diff{
+  margin:12px 0;
+  padding:8px 12px;
+  border-radius:10px;
+  background:rgba(0,0,0,0.25);
+}
+body.dark .weights-diff{ background:rgba(255,255,255,0.05); }
+.weights-diff summary{
+  cursor:pointer;
+  font-weight:600;
+  outline:none;
+}
+.weights-diff .diff-body{
+  margin-top:8px;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  font-size:13px;
+}
+.diff-row{ display:flex; justify-content:space-between; gap:8px; }
+.diff-row strong{ font-weight:600; }
+.diff-move{ color:#7a53d6; font-weight:600; }
 
 /* Tarjetas más finas */
 .weights-section.compact .weight-item,

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -157,9 +157,13 @@ body.dark .skeleton{background:#333;}
 </div>
 <div id="weightsCard" class="card" style="display:none;">
   <strong>Ponderaciones Winner Score</strong>
-  <div class="legend">ℹ️ Arrastra para reordenar. Más arriba = mayor prioridad. El número (0–100) es el peso.</div>
+  <div class="legend">ℹ️ Arrastra para reordenar. Más arriba = mayor prioridad. El número (0–50) es el peso.</div>
   <ul id="weightsList" class="weights-list"></ul>
 </div>
+<details id="weightsDiffPanel" class="weights-diff" hidden>
+  <summary>Cambios recientes</summary>
+  <div class="diff-body"></div>
+</details>
 <div id="weightsFooter" class="config-footer" style="display:none;">
   <button id="btnReset" class="btn">Reset</button>
   <button id="btnAiWeights" class="btn primary">Ajustar pesos con IA</button>

--- a/product_research_app/tests/test_config_api.py
+++ b/product_research_app/tests/test_config_api.py
@@ -1,0 +1,77 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from product_research_app import config
+from product_research_app.api import app as flask_app
+from product_research_app.services import winner_score as ws
+
+
+def _setup_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(config, "CONFIG_FILE", cfg_file)
+    ws.invalidate_weights_cache()
+
+
+def test_default_order_applied(tmp_path, monkeypatch):
+    _setup_config(tmp_path, monkeypatch)
+    with flask_app.test_client() as client:
+        resp = client.get("/api/config/winner-weights")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["order"] == config.DEFAULT_WINNER_ORDER
+        assert data["version"] == "v2"
+        for key in config.DEFAULT_WINNER_WEIGHTS_INT:
+            assert 0 <= data["weights"][key] <= 50
+
+
+def test_patch_and_get_roundtrip(tmp_path, monkeypatch):
+    _setup_config(tmp_path, monkeypatch)
+    order = config.DEFAULT_WINNER_ORDER[:]
+    order[0], order[1] = order[1], order[0]
+    payload = {"weights": {"price": 18}, "order": order}
+    with flask_app.test_client() as client:
+        patch = client.patch(
+            "/api/config/winner-weights",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert patch.status_code == 200
+        body = patch.get_json()
+        assert body["weights"]["price"] == 18
+        assert body["order"] == order
+        get_resp = client.get("/api/config/winner-weights")
+        data = get_resp.get_json()
+        assert data["weights"]["price"] == 18
+        assert data["order"] == order
+
+
+def test_ai_endpoint_persists(tmp_path, monkeypatch):
+    from product_research_app.api import config as api_config
+
+    _setup_config(tmp_path, monkeypatch)
+    monkeypatch.setattr(config, "get_api_key", lambda: "test-key")
+    fake_result = {
+        "weights": {k: 14 for k in config.DEFAULT_WINNER_ORDER},
+        "order": config.DEFAULT_WINNER_ORDER[::-1],
+        "justification": "test",
+    }
+    monkeypatch.setattr(api_config.gpt, "recommend_winner_weights", lambda *args, **kwargs: fake_result)
+    monkeypatch.setattr(ws, "recompute_scores_for_all_products", lambda scope="all": 0)
+    payload = {
+        "features": list(config.DEFAULT_WINNER_ORDER),
+        "target": "revenue",
+        "data_sample": [{**{k: 1.0 for k in config.DEFAULT_WINNER_ORDER}, "target": 1.0}],
+    }
+    with flask_app.test_client() as client:
+        resp = client.post(
+            "/api/config/winner-weights/ai?can_reorder=true",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["persisted"] is True
+        assert body["order"] == fake_result["order"]
+        assert body["winner_weights"]["revenue"] == 14


### PR DESCRIPTION
## Summary
- set default winner order and weights in configuration and expose them through the config API responses
- update the winner score and configuration services so order changes, AI adjustments, and tie-break logging stay consistent
- rebuild the winner-weight settings UI with numeric inputs, drag-and-drop ordering, diff feedback, and AI-powered updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cffaf2761c832897e70fec568ed7cc