### PR TITLE
Ensure winner order defaults and persistence

### DIFF
--- a/product_research_app/services/winner_score.py
+++ b/product_research_app/services/winner_score.py
@@ -672,6 +672,12 @@ def compute_winner_score_v2(
 
     sum_filtered = sum(eff_weights.values())
     score_float = sum(eff_weights.get(k, 0.0) * norms[k] for k in norms)
+    cfg_for_order = load_config()
+    persisted_order = cfg_for_order.get("winner_order") or list(CONFIG_DEFAULT_ORDER)
+    EPS = 1e-6
+    length = len(persisted_order)
+    for idx, key in enumerate(persisted_order):
+        score_float += (length - idx) * EPS * norms.get(key, 0.0)
     score_int = int(round(score_float * 100))
 
     eff_all_full = {k: eff_all.get(k, 0.0) for k in ALLOWED_FIELDS}


### PR DESCRIPTION
## Summary
- add a DEFAULT_ORDER constant and an ensure_winner_order helper so configuration always exposes the canonical factor order
- make config loaders, REST handlers, and GPT auto-weight updates enforce, persist, and log the canonical winner order with no-cache headers for UI responses
- apply a deterministic tie-breaker in winner score computation based on the persisted order

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0170dd7488328b56caf2ded3cf06d