### PR TITLE
Reset winner weights from shared defaults

### DIFF
--- a/product_research_app/api/config.py
+++ b/product_research_app/api/config.py
@@ -1,4 +1,6 @@
 from flask import request, jsonify, current_app
+import time
+
 from . import app
 
 from product_research_app.services.winner_score import (
@@ -10,12 +12,16 @@ from product_research_app.services.winner_score import (
 from product_research_app.services.config import (
     ALLOWED_FIELDS,
     compute_effective_int,
+    get_default_winner_weights,
 )
+from product_research_app.config import DEFAULT_WINNER_ORDER
 
 
 def _coerce_weights(raw: dict | None) -> dict[str, int]:
     out: dict[str, int] = {}
     for k, v in (raw or {}).items():
+        if k not in ALLOWED_FIELDS:
+            continue
         try:
             iv = int(round(float(v)))
         except Exception:
@@ -28,6 +34,68 @@ def _merge_winner_weights(current: dict | None, incoming: dict | None) -> dict:
     cur = dict(current or {})
     cur.update(incoming or {})
     return cur
+
+
+def _normalize_order(order, weights: dict[str, int]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for key in order or []:
+        if key in weights and key not in seen:
+            out.append(key)
+            seen.add(key)
+    for key in DEFAULT_WINNER_ORDER:
+        if key in weights and key not in seen:
+            out.append(key)
+            seen.add(key)
+    for key in weights.keys():
+        if key not in seen:
+            out.append(key)
+            seen.add(key)
+    return out
+
+
+def _sanitize_enabled(raw_enabled, keys: list[str]) -> dict[str, bool]:
+    if not isinstance(raw_enabled, dict):
+        return {k: True for k in keys}
+    return {k: bool(raw_enabled.get(k, True)) for k in keys}
+
+
+def _apply_reset(settings: dict | None = None) -> dict:
+    cfg = dict(settings or load_settings() or {})
+    default_weights = get_default_winner_weights()
+    cfg["winner_weights"] = dict(default_weights)
+    order = list(DEFAULT_WINNER_ORDER)
+    cfg["winner_order"] = order[:]
+    cfg["weights_order"] = order[:]
+    raw_enabled = cfg.get("weights_enabled")
+    if isinstance(raw_enabled, dict):
+        enabled = {k: bool(raw_enabled.get(k, True)) for k in default_weights.keys()}
+    else:
+        enabled = {k: True for k in default_weights.keys()}
+    cfg["weights_enabled"] = enabled
+    cfg["weightsUpdatedAt"] = int(time.time())
+    save_settings(cfg)
+    try:
+        invalidate_weights_cache()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        current_app.logger.warning("reset invalidate failed: %s", exc)
+    return cfg
+
+
+def _build_reset_payload(cfg: dict) -> dict:
+    payload = {
+        "ok": True,
+        "weights": dict(cfg.get("winner_weights", {})),
+        "winner_weights": dict(cfg.get("winner_weights", {})),
+        "order": list(cfg.get("winner_order", [])),
+        "winner_order": list(cfg.get("winner_order", [])),
+        "weights_order": list(cfg.get("weights_order", [])),
+        "weights_enabled": dict(cfg.get("weights_enabled", {})),
+    }
+    for key in ("weightsUpdatedAt", "weightsVersion"):
+        if key in cfg:
+            payload[key] = cfg[key]
+    return payload
 
 
 """Endpoints for winner weight configuration.
@@ -44,21 +112,61 @@ accepts any of the shapes described above.
 @app.route("/api/config/winner-weights", methods=["GET"])
 def api_get_winner_weights():
     settings = load_settings()
+    changed = False
     weights = _coerce_weights(settings.get("winner_weights"))
-    order = settings.get("winner_order") or list(weights.keys())
-    enabled_raw = settings.get("weights_enabled") if isinstance(settings.get("weights_enabled"), dict) else {}
-    enabled = {k: bool(enabled_raw.get(k, True)) for k in weights.keys()}
-    weights_eff = {k: (weights.get(k, 0) if enabled.get(k, True) else 0) for k in weights.keys()}
+    if not weights:
+        weights = {k: 50 for k in DEFAULT_WINNER_ORDER}
+    else:
+        for key in DEFAULT_WINNER_ORDER:
+            weights.setdefault(key, 50)
+    if weights != settings.get("winner_weights"):
+        settings["winner_weights"] = dict(weights)
+        changed = True
+
+    order = settings.get("winner_order")
+    if not isinstance(order, list) or len(order) != 8:
+        order = list(DEFAULT_WINNER_ORDER)
+        settings["winner_order"] = order[:]
+        settings["weights_order"] = order[:]
+        changed = True
+
+    weights_order = settings.get("weights_order")
+    if not isinstance(weights_order, list) or len(weights_order) != 8:
+        settings["weights_order"] = order[:]
+        weights_order = settings["weights_order"]
+        changed = True
+
+    order = _normalize_order(weights_order, weights)
+    if order != settings.get("winner_order"):
+        settings["winner_order"] = order[:]
+        settings["weights_order"] = order[:]
+        changed = True
+
+    weights_enabled = _sanitize_enabled(settings.get("weights_enabled"), order)
+    if weights_enabled != settings.get("weights_enabled"):
+        settings["weights_enabled"] = weights_enabled
+        changed = True
+
+    if changed:
+        save_settings(settings)
+
+    weights_eff = {
+        k: (weights.get(k, 0) if weights_enabled.get(k, True) else 0)
+        for k in weights.keys()
+    }
     eff = compute_effective_int(weights_eff, order)
+    current_app.logger.info(
+        "CONFIG served weights_order=%s", settings.get("weights_order")
+    )
     resp = jsonify({
         **weights,
         "weights": weights,
         "order": order,
         "effective": {"int": eff},
-        "weights_enabled": enabled,
-        "weights_order": settings.get("weights_order") or order,
+        "weights_enabled": weights_enabled,
+        "weights_order": order,
     })
-    resp.headers["Cache-Control"] = "no-store"
+    resp.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
     return resp, 200
 
 
@@ -66,6 +174,15 @@ def api_get_winner_weights():
 @app.route("/api/config/winner-weights", methods=["PATCH"])
 def api_patch_winner_weights():
     body = request.get_json(force=True) or {}
+    if body.get("reset"):
+        cfg = _apply_reset()
+        current_app.logger.info(
+            "RESET applied weights_order=%s", cfg.get("weights_order")
+        )
+        payload = _build_reset_payload(cfg)
+        resp = jsonify(payload)
+        resp.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+        return resp, 200
     payload_map = (
         body.get("winner_weights")
         or body.get("weights")
@@ -75,26 +192,26 @@ def api_patch_winner_weights():
 
     settings = load_settings()
     current = _coerce_weights(settings.get("winner_weights"))
-    if "awareness" not in incoming and "awareness" not in current:
-        incoming["awareness"] = 50
-    settings["winner_weights"] = _merge_winner_weights(current, incoming)
+    merged = _merge_winner_weights(current, incoming)
+    for key in DEFAULT_WINNER_ORDER:
+        merged.setdefault(key, merged.get(key, 50))
+    settings["winner_weights"] = merged
 
     order_in = body.get("order") or body.get("weights_order")
-    if isinstance(order_in, list):
-        order = [k for k in order_in if k in ALLOWED_FIELDS]
-    else:
-        order = settings.get("winner_order") or list(settings["winner_weights"].keys())
-    if "awareness" not in order:
-        order.append("awareness")
-    settings["winner_order"] = order
-    settings["weights_order"] = order
+    if not isinstance(order_in, list) or not order_in:
+        order_in = settings.get("winner_order") or list(DEFAULT_WINNER_ORDER)
+    order = _normalize_order(order_in, merged)
+    settings["winner_order"] = order[:]
+    settings["weights_order"] = order[:]
 
     en_in = body.get("weights_enabled")
     if isinstance(en_in, dict):
-        current_en = settings.get("weights_enabled", {})
-        enabled = {k: bool(en_in.get(k, current_en.get(k, True))) for k in ALLOWED_FIELDS}
-        settings["weights_enabled"] = enabled
+        weights_enabled = _sanitize_enabled(en_in, order)
+    else:
+        weights_enabled = _sanitize_enabled(settings.get("weights_enabled"), order)
+    settings["weights_enabled"] = weights_enabled
 
+    settings["weightsUpdatedAt"] = int(time.time())
     save_settings(settings)
     invalidate_weights_cache()
 
@@ -104,6 +221,30 @@ def api_patch_winner_weights():
     except Exception as e:
         current_app.logger.warning("recompute on save failed: %s", e)
 
-    resp = jsonify({"ok": True, "winner_weights": settings["winner_weights"], "winner_order": order, "updated": updated})
-    resp.headers["Cache-Control"] = "no-store"
+    resp_payload = dict(settings)
+    resp_payload.pop("api_key", None)
+    resp_payload.update(
+        {
+            "weights": dict(settings["winner_weights"]),
+            "order": list(order),
+            "weights_order": list(order),
+            "ok": True,
+            "updated": updated,
+        }
+    )
+    resp = jsonify(resp_payload)
+    resp.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    return resp, 200
+
+
+# POST /api/config/winner-weights/reset
+@app.route("/api/config/winner-weights/reset", methods=["POST"])
+def api_reset_winner_weights():
+    cfg = _apply_reset()
+    current_app.logger.info(
+        "RESET applied weights_order=%s", cfg.get("weights_order")
+    )
+    payload = _build_reset_payload(cfg)
+    resp = jsonify(payload)
+    resp.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
     return resp, 200

--- a/product_research_app/services/config.py
+++ b/product_research_app/services/config.py
@@ -18,6 +18,13 @@ DEFAULT_WEIGHTS_RAW: Dict[str, int] = {k: 50 for k in ALLOWED_FIELDS}
 DEFAULT_ORDER: List[str] = list(DEFAULT_WINNER_ORDER)
 DEFAULT_ENABLED: Dict[str, bool] = {k: True for k in ALLOWED_FIELDS}
 
+
+def get_default_winner_weights() -> Dict[str, int]:
+    """Return a copy of the default weight map (0-100 scale)."""
+
+    return DEFAULT_WEIGHTS_RAW.copy()
+
+
 # Compatibility placeholder; not used but kept for tests that monkeypatch it
 DB_PATH = Path(__file__).resolve().parents[1] / "data.sqlite3"
 
@@ -35,13 +42,37 @@ def _coerce_weights(raw: Dict[str, object] | None) -> Dict[str, int]:
 
 def _normalize_order(order, weights: Dict[str, int]) -> List[str]:
     seen: set[str] = set()
-    out: List[str] = [k for k in (order or []) if k in weights and not (k in seen or seen.add(k))]
-    out += [k for k in weights.keys() if k not in out]
+    out: List[str] = []
+    for key in order or []:
+        if key in weights and key not in seen:
+            out.append(key)
+            seen.add(key)
+    for key in DEFAULT_WINNER_ORDER:
+        if key in weights and key not in seen:
+            out.append(key)
+            seen.add(key)
+    for key in weights.keys():
+        if key not in seen:
+            out.append(key)
+            seen.add(key)
     return out
 
 
 def init_app_config() -> None:
     cfg = load_config()
+    # Garantizar orden en ambas claves y persistir si faltaba
+    order = cfg.get("winner_order")
+    if not isinstance(order, list) or len(order) != 8:
+        order = list(DEFAULT_WINNER_ORDER)
+        cfg["winner_order"] = order[:]
+        cfg["weights_order"] = order[:]
+        save_config(cfg)  # persistir para sobrevivir reinicios
+
+    # Si solo falta weights_order, refléjalo desde winner_order
+    if not isinstance(cfg.get("weights_order"), list) or len(cfg["weights_order"]) != 8:
+        cfg["weights_order"] = cfg["winner_order"][:]
+        save_config(cfg)
+
     changed = False
     weights = cfg.get("winner_weights")
     if not isinstance(weights, dict):
@@ -56,14 +87,19 @@ def init_app_config() -> None:
 
     order = cfg.get("winner_order")
     if not isinstance(order, list):
-        cfg["winner_order"] = DEFAULT_ORDER.copy()
-        cfg["weights_order"] = DEFAULT_ORDER.copy()
+        order = DEFAULT_ORDER.copy()
+        cfg["winner_order"] = order[:]
+        cfg["weights_order"] = order[:]
         changed = True
-    else:
-        if "awareness" not in order:
-            order.append("awareness")
-            changed = True
-        cfg.setdefault("weights_order", order.copy())
+    normalized_order = _normalize_order(order, cfg["winner_weights"])
+    if normalized_order != order:
+        cfg["winner_order"] = normalized_order[:]
+        order = normalized_order
+        changed = True
+    weights_order = cfg.get("weights_order")
+    if not isinstance(weights_order, list) or weights_order != order:
+        cfg["weights_order"] = order[:]
+        changed = True
 
     enabled = cfg.get("weights_enabled")
     if not isinstance(enabled, dict):
@@ -90,12 +126,23 @@ def _load() -> Tuple[Dict[str, int], List[str], Dict[str, bool]]:
     weights = _coerce_weights(weights)
     for k, v in DEFAULT_WEIGHTS_RAW.items():
         weights.setdefault(k, v)
-    order = _normalize_order(cfg.get("winner_order"), weights)
+    order_raw = cfg.get("winner_order")
+    order = _normalize_order(order_raw, weights)
+    cfg_changed = False
+    if order_raw != order:
+        cfg["winner_order"] = order[:]
+        cfg_changed = True
+    weights_order = cfg.get("weights_order")
+    if not isinstance(weights_order, list) or weights_order != order:
+        cfg["weights_order"] = order[:]
+        cfg_changed = True
     enabled = cfg.get("weights_enabled")
     if not isinstance(enabled, dict):
         enabled = DEFAULT_ENABLED.copy()
     else:
         enabled = {k: bool(enabled.get(k, True)) for k in DEFAULT_ENABLED.keys()}
+    if cfg_changed:
+        save_config(cfg)
     return weights, order, enabled
 
 
@@ -130,8 +177,8 @@ def update_winner_settings(
         }
 
     cfg["winner_weights"] = weights
-    cfg["winner_order"] = order
-    cfg["weights_order"] = order
+    cfg["winner_order"] = order[:]
+    cfg["weights_order"] = order[:]
     cfg["weights_enabled"] = enabled
     cfg["weightsUpdatedAt"] = int(time.time())
     save_config(cfg)

--- a/product_research_app/services/winner_score.py
+++ b/product_research_app/services/winner_score.py
@@ -15,10 +15,9 @@ from .config import (
     get_winner_weights_raw,
     set_winner_weights_raw,
     get_winner_order_raw,
-    DEFAULT_ORDER as CONFIG_DEFAULT_ORDER,
     DB_PATH as CONFIG_DB_PATH,
 )
-from ..config import load_config, save_config
+from ..config import load_config, save_config, DEFAULT_WINNER_ORDER
 
 logger = logging.getLogger(__name__)
 
@@ -318,6 +317,8 @@ def load_winner_settings() -> tuple[Dict[str, float], list[str], Dict[str, bool]
         return WEIGHTS_CACHE, ORDER_CACHE, ENABLED_CACHE
     weights = get_winner_weights_raw()
     order = get_winner_order_raw()
+    if not order:
+        order = list(DEFAULT_WINNER_ORDER)
     from .config import get_weights_enabled_raw
 
     enabled = get_weights_enabled_raw()
@@ -655,7 +656,7 @@ def compute_winner_score_v2(
     if order is None:
         order = get_winner_order_raw()
     if not order:
-        order = list(CONFIG_DEFAULT_ORDER)
+        order = list(DEFAULT_WINNER_ORDER)
     seen: set[str] = set()
     normalized_order: list[str] = []
     for key in order:
@@ -715,6 +716,8 @@ def generate_winner_scores(
         from .config import get_weights_enabled_raw
 
         enabled = get_weights_enabled_raw()
+        if not order:
+            order = list(DEFAULT_WINNER_ORDER)
 
     dir_old, w_old_intensity = _oldness_pref_and_weight(weights)
     oldness_ui = float(weights.get("oldness", 50))

--- a/product_research_app/static/js/config.js
+++ b/product_research_app/static/js/config.js
@@ -6,10 +6,19 @@ const SettingsCache = (() => {
   let inflight = null;
 
   const norm = (cfg) => {
-    const weights = cfg?.weights || {};
-    const order = (Array.isArray(cfg?.weights_order) && cfg.weights_order.length)
-      ? cfg.weights_order.slice()
-      : Object.keys(weights);
+    const weights = cfg?.weights || cfg?.winner_weights || {};
+    let order =
+      (Array.isArray(cfg?.weights_order) && cfg.weights_order.length)
+        ? cfg.weights_order.slice()
+        : (Array.isArray(cfg?.winner_order) && cfg.winner_order.length)
+          ? cfg.winner_order.slice()
+          : [
+              'awareness','desire','revenue','competition',
+              'units_sold','price','oldness','rating'
+            ];
+    for (const key of Object.keys(weights || {})) {
+      if (!order.includes(key)) order.push(key);
+    }
     const enabled = {};
     for (const k of order) enabled[k] = cfg?.weights_enabled?.[k] ?? true;
     return { order, weights, enabled };
@@ -254,14 +263,56 @@ function renderWeightsUI(state){
   window.factors = factors;
 }
 
-function resetWeights(){
-  const state = {
-    order: WEIGHT_FIELDS.map(f => f.key),
-    weights: Object.fromEntries(WEIGHT_FIELDS.map(f => [f.key, 50])),
-    enabled: Object.fromEntries(WEIGHT_FIELDS.map(f => [f.key, true]))
-  };
-  renderWeightsUI(state);
-  markDirty();
+async function resetWeights(ev){
+  try { ev?.preventDefault?.(); } catch (_) {}
+  const btn = ev?.currentTarget;
+  if (btn) btn.disabled = true;
+  const fallbackOrder = [
+    'awareness','desire','revenue','competition',
+    'units_sold','price','oldness','rating'
+  ];
+  try{
+    const res = await fetch('/api/config/winner-weights/reset', {
+      method: 'POST',
+      headers: { 'Cache-Control': 'no-store' }
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const serverOrder = Array.isArray(data?.weights_order) && data.weights_order.length
+      ? data.weights_order.slice()
+      : Array.isArray(data?.order) && data.order.length
+        ? data.order.slice()
+        : [];
+    const mergedOrder = serverOrder.filter(k => typeof k === 'string' && k);
+    const finalOrder = (() => {
+      const next = mergedOrder.slice();
+      fallbackOrder.forEach(key => { if (!next.includes(key)) next.push(key); });
+      return next;
+    })();
+    const rawWeights = (data && typeof data === 'object' && (data.weights || data.winner_weights)) || {};
+    const payloadForCache = {
+      ...data,
+      weights: rawWeights,
+      winner_weights: rawWeights,
+      winner_order: finalOrder.slice(),
+      weights_order: finalOrder.slice(),
+      weights_enabled: (data && typeof data === 'object' && data.weights_enabled) || {},
+    };
+    SettingsCache.set(payloadForCache);
+    const normalized = await SettingsCache.get();
+    const state = {
+      order: normalized.order.slice(),
+      weights: { ...normalized.weights },
+      enabled: { ...normalized.enabled }
+    };
+    try { localStorage.setItem('winner_order', JSON.stringify(state.order)); } catch (_) {}
+    renderWeightsUI(state);
+  }catch(err){
+    console.error('resetWeights error', err);
+    if (typeof toast !== 'undefined' && toast.error) toast.error('No se pudo restablecer los pesos');
+  }finally{
+    if (btn) btn.disabled = false;
+  }
 }
 
 async function saveSettings(){

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -45,6 +45,7 @@ from . import config
 from .services import ai_columns
 from .services import winner_score as winner_calc
 from .services import trends_service
+from .services.config import get_default_winner_weights
 from .services.importer_fast import DEFAULT_BATCH_SIZE, fast_import, fast_import_records
 from . import gpt
 from .prompts.registry import normalize_task
@@ -76,6 +77,91 @@ logger = logging.getLogger(__name__)
 DEBUG = bool(os.environ.get("DEBUG"))
 
 DATE_FORMATS = ("%Y-%m-%d", "%d/%m/%Y")
+
+
+DEFAULT_ORDER_LIST = list(config.DEFAULT_WINNER_ORDER)
+
+
+def _clamp_weight_value(value: Any) -> int:
+    try:
+        return int(max(0, min(100, float(value))))
+    except Exception:
+        return 0
+
+
+def _sanitize_weights_map(raw: Dict[str, Any] | None) -> Dict[str, int]:
+    sanitized: Dict[str, int] = {}
+    base = raw or {}
+    for key in DEFAULT_ORDER_LIST:
+        sanitized[key] = _clamp_weight_value(base.get(key, 50))
+    for key, value in base.items():
+        if key not in sanitized:
+            sanitized[key] = _clamp_weight_value(value)
+    return sanitized
+
+
+def _normalize_order_list(order, available: Dict[str, Any]) -> List[str]:
+    seen: set[str] = set()
+    out: List[str] = []
+    keys = list(available.keys())
+    for key in order or []:
+        if key in available and key not in seen:
+            out.append(key)
+            seen.add(key)
+    for key in DEFAULT_ORDER_LIST:
+        if key in available and key not in seen:
+            out.append(key)
+            seen.add(key)
+    for key in keys:
+        if key not in seen:
+            out.append(key)
+            seen.add(key)
+    return out
+
+
+def _apply_weights_reset(existing: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    cfg = dict(existing or config.load_config())
+    default_weights = get_default_winner_weights()
+    cfg["winner_weights"] = dict(default_weights)
+    order = list(config.DEFAULT_WINNER_ORDER)
+    cfg["winner_order"] = order[:]
+    cfg["weights_order"] = order[:]
+    raw_enabled = cfg.get("weights_enabled")
+    if isinstance(raw_enabled, dict):
+        enabled = {k: bool(raw_enabled.get(k, True)) for k in default_weights.keys()}
+    else:
+        enabled = {k: True for k in default_weights.keys()}
+    cfg["weights_enabled"] = enabled
+    cfg["weightsUpdatedAt"] = int(time.time())
+    config.save_config(cfg)
+    try:
+        winner_calc.invalidate_weights_cache()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("reset invalidate failed: %s", exc)
+    return cfg
+
+
+def _build_weights_payload(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    payload = {
+        "ok": True,
+        "weights": dict(cfg.get("winner_weights", {})),
+        "winner_weights": dict(cfg.get("winner_weights", {})),
+        "order": list(cfg.get("winner_order", [])),
+        "winner_order": list(cfg.get("winner_order", [])),
+        "weights_order": list(cfg.get("weights_order", [])),
+        "weights_enabled": dict(cfg.get("weights_enabled", {})),
+    }
+    if "weightsUpdatedAt" in cfg:
+        payload["weightsUpdatedAt"] = cfg["weightsUpdatedAt"]
+    if "weightsVersion" in cfg:
+        payload["weightsVersion"] = cfg["weightsVersion"]
+    return payload
+
+
+def _sanitize_enabled_map(raw_enabled, keys: List[str]) -> Dict[str, bool]:
+    if not isinstance(raw_enabled, dict):
+        return {k: True for k in keys}
+    return {k: bool(raw_enabled.get(k, True)) for k in keys}
 
 
 _DB_INIT = False
@@ -730,6 +816,9 @@ class RequestHandler(BaseHTTPRequestHandler):
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
         self.send_header("Access-Control-Allow-Methods", "GET, POST, PATCH, OPTIONS")
+        self.send_header(
+            "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0"
+        )
         self.end_headers()
 
     def _set_html(self, status=200):
@@ -877,25 +966,51 @@ class RequestHandler(BaseHTTPRequestHandler):
             self.wfile.write(json.dumps(resp).encode("utf-8"))
             return
         if path == "/api/config/winner-weights":
-            from .services.config import (
-                get_winner_weights_raw,
-                get_winner_order_raw,
-                get_weights_enabled_raw,
-                compute_effective_int,
-            )
+            cfg = config.load_config()
+            changed = False
+            order = cfg.get("winner_order")
+            if not isinstance(order, list) or len(order) != 8:
+                order = list(config.DEFAULT_WINNER_ORDER)
+                cfg["winner_order"] = order[:]
+                cfg["weights_order"] = order[:]
+                changed = True
+            weights_order = cfg.get("weights_order")
+            if not isinstance(weights_order, list) or len(weights_order) != 8:
+                cfg["weights_order"] = cfg["winner_order"][:]
+                weights_order = cfg["weights_order"]
+                changed = True
 
-            raw = get_winner_weights_raw()
-            order = get_winner_order_raw()
-            enabled = get_weights_enabled_raw()
-            raw_eff = {k: (raw.get(k, 0) if enabled.get(k, True) else 0) for k in raw}
-            eff_int = compute_effective_int(raw_eff, order)
+            weights_map = _sanitize_weights_map(cfg.get("winner_weights"))
+            weights_enabled = _sanitize_enabled_map(
+                cfg.get("weights_enabled"),
+                list(weights_map.keys()),
+            )
+            if weights_enabled != cfg.get("weights_enabled"):
+                cfg["weights_enabled"] = weights_enabled
+                changed = True
+
+            order = _normalize_order_list(cfg.get("weights_order"), weights_map)
+            if order != cfg.get("winner_order"):
+                cfg["winner_order"] = order[:]
+                cfg["weights_order"] = order[:]
+                changed = True
+
+            if changed:
+                config.save_config(cfg)
+
+            logger.info("CONFIG served weights_order=%s", cfg.get("weights_order"))
+            raw_eff = {
+                k: (weights_map.get(k, 0) if weights_enabled.get(k, True) else 0)
+                for k in weights_map
+            }
+            eff_int = winner_calc.compute_effective_int(raw_eff, order)
             logger.info("weights_effective_int=%s order=%s", eff_int, order)
             resp = {
-                **raw,
-                "weights": raw,
+                **weights_map,
+                "weights": weights_map,
                 "order": order,
                 "effective": {"int": eff_int},
-                "weights_enabled": enabled,
+                "weights_enabled": weights_enabled,
                 "weights_order": order,
             }
             self._set_json()
@@ -1039,17 +1154,43 @@ class RequestHandler(BaseHTTPRequestHandler):
         if path == "/config":
             # return stored configuration (without exposing the API key)
             cfg = config.load_config()
+            changed = False
+            order = cfg.get("winner_order")
+            if not isinstance(order, list) or len(order) != 8:
+                order = list(config.DEFAULT_WINNER_ORDER)
+                cfg["winner_order"] = order[:]
+                cfg["weights_order"] = order[:]
+                changed = True
+            if not isinstance(cfg.get("weights_order"), list) or len(cfg["weights_order"]) != 8:
+                cfg["weights_order"] = cfg["winner_order"][:]
+                changed = True
+            if changed:
+                config.save_config(cfg)
+
+            weights_map = _sanitize_weights_map(cfg.get("winner_weights"))
+            weights_enabled = _sanitize_enabled_map(
+                cfg.get("weights_enabled"),
+                list(weights_map.keys()),
+            )
             key = cfg.get("api_key") or ""
             data = {
                 "model": cfg.get("model", "gpt-4o"),
-                "weights": config.get_weights(),
+                "weights": weights_map,
+                "winner_weights": weights_map,
+                "winner_order": list(cfg.get("winner_order", list(DEFAULT_ORDER_LIST))),
+                "weights_order": list(cfg.get("weights_order", list(DEFAULT_ORDER_LIST))),
+                "weights_enabled": weights_enabled,
+                "order": list(cfg.get("winner_order", list(DEFAULT_ORDER_LIST))),
                 "has_api_key": bool(key),
                 "oldness_preference": cfg.get("oldness_preference", "newer"),
+                "weightsUpdatedAt": cfg.get("weightsUpdatedAt", 0),
+                "weightsVersion": cfg.get("weightsVersion", 0),
             }
             if key:
                 data["api_key_last4"] = key[-4:]
                 data["api_key_length"] = len(key)
                 data["api_key_hash"] = hashlib.sha256(key.encode("utf-8")).hexdigest()
+            logger.info("CONFIG served weights_order=%s", data["weights_order"])
             self._set_json()
             self.wfile.write(json.dumps(data).encode("utf-8"))
             return
@@ -1516,6 +1657,13 @@ class RequestHandler(BaseHTTPRequestHandler):
         if path == "/api/config/winner-weights/ai":
             self.handle_scoring_v2_auto_weights_gpt()
             return
+        if path == "/api/config/winner-weights/reset":
+            cfg = _apply_weights_reset()
+            payload = _build_weights_payload(cfg)
+            logger.info("RESET applied weights_order=%s", cfg.get("weights_order"))
+            self._set_json()
+            self.wfile.write(json.dumps(payload).encode('utf-8'))
+            return
         if path == "/scoring/v2/auto-weights-gpt":
             self.handle_scoring_v2_auto_weights_gpt()
             return
@@ -1741,52 +1889,61 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self._set_json(400)
                 self.wfile.write(json.dumps({"error": "Invalid JSON"}).encode('utf-8'))
                 return
-            from .services.config import (
-                set_winner_weights_raw,
-                set_winner_order_raw,
-                get_winner_order_raw,
-                set_weights_enabled_raw,
-                get_weights_enabled_raw,
-                compute_effective_int,
-                ALLOWED_FIELDS,
+            if data.get("reset"):
+                cfg = _apply_weights_reset()
+                payload = _build_weights_payload(cfg)
+                logger.info("RESET applied weights_order=%s", cfg.get("weights_order"))
+                self._set_json()
+                self.wfile.write(json.dumps(payload).encode('utf-8'))
+                return
+            weights_in = (
+                data.get("weights")
+                or data.get("winner_weights")
+                or {k: v for k, v in data.items() if k in winner_calc.ALLOWED_FIELDS}
             )
-            from .services import winner_score
+            if not isinstance(weights_in, dict):
+                weights_in = {}
 
-            payload_map = (
-                data.get("winner_weights")
-                or data.get("weights")
-                or {k: v for k, v in data.items() if k in ALLOWED_FIELDS}
-            )
-            saved = set_winner_weights_raw(payload_map)
-            order_in = data.get("order") if isinstance(data, dict) else None
-            if isinstance(order_in, list):
-                order = [k for k in order_in if k in saved]
+            cfg = config.load_config()
+            sanitized = _sanitize_weights_map(cfg.get("winner_weights"))
+            for key, value in weights_in.items():
+                if key in winner_calc.ALLOWED_FIELDS:
+                    sanitized[key] = _clamp_weight_value(value)
+            for key in DEFAULT_ORDER_LIST:
+                sanitized.setdefault(key, 50)
+
+            order_in = data.get("order") or data.get("weights_order")
+            if not isinstance(order_in, list) or not order_in:
+                order_in = cfg.get("winner_order") or list(DEFAULT_ORDER_LIST)
+            order = _normalize_order_list(order_in, sanitized)
+
+            weights_enabled_in = data.get("weights_enabled")
+            if isinstance(weights_enabled_in, dict):
+                weights_enabled = _sanitize_enabled_map(weights_enabled_in, order)
             else:
-                order = get_winner_order_raw()
-            if "awareness" not in order:
-                order.append("awareness")
-            saved_order = set_winner_order_raw(order)
-            en_in = data.get("weights_enabled") if isinstance(data, dict) else None
-            if isinstance(en_in, dict):
-                set_weights_enabled_raw(en_in)
-            enabled = get_weights_enabled_raw()
-            winner_score.invalidate_weights_cache()
-            eff_map = {k: (saved.get(k, 0) if enabled.get(k, True) else 0) for k in saved}
-            resp = {
-                **saved,
-                "weights": saved,
-                "order": saved_order,
-                "effective": {"int": compute_effective_int(eff_map, saved_order)},
-                "weights_enabled": enabled,
-                "weights_order": saved_order,
-            }
+                weights_enabled = _sanitize_enabled_map(cfg.get("weights_enabled"), order)
+
+            cfg["winner_weights"] = sanitized
+            cfg["winner_order"] = order[:]
+            cfg["weights_order"] = order[:]
+            cfg["weights_enabled"] = weights_enabled
+            cfg["weightsUpdatedAt"] = int(time.time())
+            config.save_config(cfg)
+            winner_calc.invalidate_weights_cache()
+
+            resp_cfg = dict(cfg)
+            resp_cfg.pop("api_key", None)
+            resp_cfg["weights"] = dict(cfg["winner_weights"])
+            resp_cfg["order"] = list(order)
+            resp_cfg["weights_order"] = list(order)
+
             publish_progress({
                 "event": "weights",
                 "action": "updated",
-                "payload": resp,
+                "payload": resp_cfg,
             })
             self._set_json()
-            self.wfile.write(json.dumps(resp).encode('utf-8'))
+            self.wfile.write(json.dumps(resp_cfg).encode('utf-8'))
             return
         self.send_error(404)
 
@@ -2625,29 +2782,35 @@ class RequestHandler(BaseHTTPRequestHandler):
             ),
         )
 
-        from .services.config import set_winner_weights_raw, set_winner_order_raw
+        int_weights = {k: int(final_weights.get(k, 0)) for k in allowed}
+        new_order = list(order)
 
-        saved_weights = set_winner_weights_raw(final_weights)
-        saved_order = set_winner_order_raw(order)
+        cfg = config.load_config()
+        cfg["winner_weights"] = int_weights
+        cfg["winner_order"] = new_order[:]
+        cfg["weights_order"] = new_order[:]
+        cfg["weights_enabled"] = _sanitize_enabled_map(
+            cfg.get("weights_enabled"), new_order
+        )
+        cfg["weightsUpdatedAt"] = int(time.time())
+        config.save_config(cfg)
         winner_calc.invalidate_weights_cache()
-        order = list(saved_order)
-        final_weights = saved_weights
 
         # Logs (útiles para ti): ahora ai_raw/ints son lo mismo (0..100 independientes)
         logger.info(
             "ai_raw=%s enabled_only=%s ints=%s order=%s sum=%s",
-            final_weights,
-            final_weights,
-            final_weights,
-            order,
-            sum(final_weights.values()),
+            int_weights,
+            int_weights,
+            int_weights,
+            new_order,
+            sum(int_weights.values()),
         )
 
         # Respuesta para el frontend; los valores ya quedaron persistidos en backend.
         resp = {
-            "weights": final_weights,      # 0..100 independientes
-            "weights_order": order,        # prioridad explícita
-            "order": order,
+            "weights": int_weights,      # 0..100 independientes
+            "weights_order": new_order,  # prioridad explícita
+            "order": new_order,
             "method": "gpt",
             "diagnostics": {"notes": notes},
         }


### PR DESCRIPTION
## Summary
- add a reusable helper for default winner weights and use it from the Flask and built-in servers to reset both stored orders while logging cache updates
- ensure the configuration GET handlers persist and return `weights_order` consistently with no-cache headers and informational logs
- wire the frontend reset control to the server reset endpoint so the UI rehydrates weights and order from the latest configuration and stores the order locally

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d01b6110788328b4dafd1667c2ac42