### PR TITLE
Switch AI fill job to async OpenAI Responses batching

### DIFF
--- a/product_research_app/services/ai_columns.py
+++ b/product_research_app/services/ai_columns.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import math
 import os
-import queue
 import random
-import threading
+import re
 import time
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
-from .. import config, database, gpt
+from openai import APIError, APIStatusError, AsyncOpenAI, RateLimitError
+
+from .. import config, database
 from ..utils.signature import compute_sig_hash
 
 logger = logging.getLogger(__name__)
@@ -34,28 +35,374 @@ class Candidate:
     extra: Dict[str, Any]
 
 
-class _RateLimiter:
-    def __init__(self, limit_tokens_per_minute: Optional[int], est_in: int, est_out: int) -> None:
-        self.limit = int(limit_tokens_per_minute or 0)
-        self.est_in = max(0, int(est_in))
-        self.est_out = max(0, int(est_out))
-        self._lock = threading.Lock()
-        self._next_available = 0.0
+TRI_LEVELS = {"low": "Low", "medium": "Medium", "high": "High"}
+SYSTEM_PROMPT = (
+    "Eres un clasificador de productos e-commerce. Devuelve SOLO JSON válido con cuatro campos por producto."
+)
+LABELS_SCHEMA = {
+    "desire": ["Low", "Medium", "High"],
+    "desire_magnitude": ["Low", "Medium", "High"],
+    "awareness_level": ["Low", "Medium", "High"],
+    "competition_level": ["Low", "Medium", "High"],
+}
+DEFAULT_EST_TOKENS_PER_ITEM = 120
+DEFAULT_EST_OUTPUT_TOKENS_PER_ITEM = 32
+BRAND_MAX_CHARS = 60
+CATEGORY_MAX_CHARS = 80
 
-    def acquire(self, item_count: int) -> None:
-        if not self.limit or item_count <= 0:
+
+def _clean_text(value: Optional[str], max_chars: int) -> str:
+    text = (value or "").strip()
+    if not text:
+        return ""
+    text = re.sub(r"\s+", " ", text)
+    return text[:max_chars]
+
+
+def _get(obj: Dict[str, Any], key: str) -> Any:
+    return obj.get(key) or obj.get(key.replace("_level", "")) or obj.get(key.replace("_", ""))
+
+
+def _normalize_tri(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    return TRI_LEVELS.get(text)
+
+
+class AsyncRateLimiter:
+    def __init__(self, tpm_limit: Optional[int], rpm_limit: Optional[int]) -> None:
+        self.tpm_limit = max(0, int(tpm_limit or 0))
+        self.rpm_limit = max(0, int(rpm_limit or 0))
+        self._lock = asyncio.Lock()
+        self._window_start = time.monotonic()
+        self._tokens_used = 0
+        self._requests = 0
+
+    async def acquire(self, tokens: int, requests: int = 1) -> None:
+        if self.tpm_limit <= 0 and self.rpm_limit <= 0:
             return
-        tokens = (self.est_in + self.est_out) * max(1, item_count)
-        if tokens <= 0:
+        tokens = max(0, int(tokens))
+        requests = max(1, int(requests))
+        while True:
+            async with self._lock:
+                now = time.monotonic()
+                elapsed = now - self._window_start
+                if elapsed >= 60:
+                    self._window_start = now
+                    self._tokens_used = 0
+                    self._requests = 0
+                wait_time = 0.0
+                if self.tpm_limit > 0 and tokens > 0 and self._tokens_used + tokens > self.tpm_limit:
+                    wait_time = max(wait_time, 60.0 - elapsed)
+                if self.rpm_limit > 0 and self._requests + requests > self.rpm_limit:
+                    wait_time = max(wait_time, 60.0 - elapsed)
+                if wait_time <= 0:
+                    self._tokens_used += tokens
+                    self._requests += requests
+                    return
+            await asyncio.sleep(max(wait_time, 0.05))
+
+
+def _estimate_input_tokens(user_content: str, item_count: int) -> int:
+    payload_tokens = max(1, len(user_content) // 4)
+    prompt_tokens = max(16, len(SYSTEM_PROMPT) // 4)
+    return max(DEFAULT_EST_TOKENS_PER_ITEM * max(1, item_count), payload_tokens + prompt_tokens)
+
+
+def _estimate_output_tokens(item_count: int) -> int:
+    return DEFAULT_EST_OUTPUT_TOKENS_PER_ITEM * max(1, item_count)
+
+
+def _extract_response_text(response_dict: Dict[str, Any]) -> str:
+    outputs = response_dict.get("output") or []
+    pieces: List[str] = []
+    for block in outputs:
+        if not isinstance(block, dict):
+            continue
+        for part in block.get("content") or []:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    pieces.append(text)
+                elif isinstance(text, dict):
+                    nested = text.get("text")
+                    if isinstance(nested, str):
+                        pieces.append(nested)
+            elif isinstance(part, str):
+                pieces.append(part)
+    return "".join(pieces).strip()
+
+
+def _normalize_desire(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if len(text) > 160:
+        return text[:160]
+    return text
+
+
+def _parse_batch_response(
+    data: Dict[str, Any], item_ids: Sequence[int]
+) -> tuple[Dict[str, Dict[str, Any]], Dict[str, str]]:
+    if not isinstance(data, dict):
+        raise ValueError("invalid_response")
+    results = data.get("results")
+    if not isinstance(results, list):
+        raise ValueError("missing_results")
+    expected = {str(int(pid)) for pid in item_ids}
+    successes: Dict[str, Dict[str, Any]] = {}
+    errors: Dict[str, str] = {}
+    for entry in results:
+        if not isinstance(entry, dict):
+            continue
+        pid = entry.get("id")
+        try:
+            pid_int = int(pid)
+        except Exception:
+            continue
+        pid_str = str(pid_int)
+        if pid_str not in expected or pid_str in successes or pid_str in errors:
+            continue
+        desire_mag = _normalize_tri(_get(entry, "desire_magnitude"))
+        awareness = _normalize_tri(_get(entry, "awareness_level"))
+        competition = _normalize_tri(_get(entry, "competition_level"))
+        desire = _normalize_desire(entry.get("desire"))
+        if desire_mag is None or awareness is None or competition is None:
+            errors[pid_str] = "invalid_fields"
+            continue
+        successes[pid_str] = {
+            "desire": desire,
+            "desire_magnitude": desire_mag,
+            "awareness_level": awareness,
+            "competition_level": competition,
+        }
+    for pid_str in expected:
+        if pid_str not in successes and pid_str not in errors:
+            errors[pid_str] = "missing"
+    return successes, errors
+
+
+def _build_request_payload(items: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "task": "classify",
+        "labels": LABELS_SCHEMA,
+        "items": list(items),
+    }
+
+
+def _resolve_response_format(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"json", "json_object", "json-object"}:
+            return {"type": "json_object"}
+    return {"type": "json_object"}
+
+
+async def _perform_single_request(
+    client: AsyncOpenAI,
+    *,
+    payload_items: List[Dict[str, Any]],
+    item_ids: List[int],
+    model: str,
+    temperature: float,
+    top_p: float,
+    response_format: Dict[str, Any],
+    max_retries: int,
+    rate_limiter: AsyncRateLimiter,
+    stop_event: asyncio.Event,
+) -> Dict[str, Any]:
+    request_payload = _build_request_payload(payload_items)
+    user_content = json.dumps(request_payload, ensure_ascii=False)
+    estimated_in = _estimate_input_tokens(user_content, len(payload_items))
+    estimated_out = _estimate_output_tokens(len(payload_items))
+    last_error = "error"
+    status_code = 0
+    for attempt in range(max_retries + 1):
+        if stop_event.is_set():
+            return {
+                "ok": {},
+                "ko": {str(pid): "cost_cap_reached" for pid in item_ids},
+                "usage": {},
+                "duration": 0.0,
+                "retries": attempt,
+                "status_code": 0,
+                "tokens_in": 0,
+                "tokens_out": 0,
+                "sent": 0,
+                "skipped": True,
+            }
+        await rate_limiter.acquire(estimated_in, 1)
+        try:
+            start = time.perf_counter()
+            response = await client.responses.create(
+                model=model,
+                temperature=temperature,
+                top_p=top_p,
+                response_format=response_format,
+                input=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": user_content},
+                ],
+            )
+            duration = time.perf_counter() - start
+            resp_dict = response.model_dump()
+            usage = resp_dict.get("usage") or {}
+            tokens_in = usage.get("input_tokens") or usage.get("prompt_tokens") or estimated_in
+            tokens_out = usage.get("output_tokens") or usage.get("completion_tokens") or estimated_out
+            raw_text = _extract_response_text(resp_dict)
+            if not raw_text:
+                raise ValueError("empty_response")
+            parsed = json.loads(raw_text)
+            ok_map, ko_map = _parse_batch_response(parsed, item_ids)
+            return {
+                "ok": ok_map,
+                "ko": ko_map,
+                "usage": usage,
+                "duration": duration,
+                "retries": attempt,
+                "status_code": 200,
+                "tokens_in": int(tokens_in),
+                "tokens_out": int(tokens_out),
+                "sent": len(payload_items),
+                "skipped": False,
+            }
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.warning("AI batch parse error: %s", exc)
+            return {
+                "ok": {},
+                "ko": {str(pid): "invalid_json" for pid in item_ids},
+                "usage": {},
+                "duration": 0.0,
+                "retries": attempt,
+                "status_code": 200,
+                "tokens_in": estimated_in,
+                "tokens_out": estimated_out,
+                "sent": len(payload_items),
+                "skipped": False,
+            }
+        except RateLimitError as exc:
+            if attempt < max_retries:
+                delay = min(10.0, 0.6 * (2**attempt)) + random.random() * 0.3
+                await asyncio.sleep(delay)
+                continue
+            last_error = str(exc)
+            status_code = getattr(exc, "status_code", 429) or 429
+        except APIStatusError as exc:
+            status_code = getattr(exc, "status_code", 0) or 0
+            if status_code in {429, 500, 502, 503, 504} and attempt < max_retries:
+                delay = min(10.0, 0.6 * (2**attempt)) + random.random() * 0.3
+                await asyncio.sleep(delay)
+                continue
+            last_error = str(exc)
+        except APIError as exc:
+            last_error = str(exc)
+            status_code = getattr(exc, "status_code", 0) or 0
+        except Exception as exc:
+            logger.exception("AI batch unexpected error", exc_info=True)
+            last_error = str(exc)
+            status_code = 0
+        break
+    else:
+        last_error = "retry_limit"
+        status_code = 0
+
+    return {
+        "ok": {},
+        "ko": {str(pid): last_error or "error" for pid in item_ids},
+        "usage": {},
+        "duration": 0.0,
+        "retries": max_retries,
+        "status_code": status_code,
+        "tokens_in": estimated_in,
+        "tokens_out": estimated_out,
+        "sent": len(payload_items),
+        "skipped": False,
+    }
+
+
+async def _run_batch_task(
+    batch_no: int,
+    candidates: Sequence[Candidate],
+    *,
+    client: AsyncOpenAI,
+    model: str,
+    temperature: float,
+    top_p: float,
+    response_format: Dict[str, Any],
+    max_retries: int,
+    rate_limiter: AsyncRateLimiter,
+    stop_event: asyncio.Event,
+    semaphore: asyncio.Semaphore,
+    results_queue: "asyncio.Queue[Dict[str, Any]]",
+) -> None:
+    item_ids = [cand.id for cand in candidates]
+    payload_items = [cand.payload for cand in candidates]
+    async with semaphore:
+        if stop_event.is_set():
+            await results_queue.put(
+                {
+                    "batch_no": batch_no,
+                    "item_ids": item_ids,
+                    "ok": {},
+                    "ko": {str(pid): "cost_cap_reached" for pid in item_ids},
+                    "usage": {},
+                    "duration": 0.0,
+                    "retries": 0,
+                    "status_code": 0,
+                    "tokens_in": 0,
+                    "tokens_out": 0,
+                    "sent": 0,
+                    "skipped": True,
+                }
+            )
             return
-        delay = (tokens / self.limit) * 60.0
-        with self._lock:
-            now = time.monotonic()
-            start = max(now, self._next_available)
-            self._next_available = start + delay
-            wait = max(0.0, start - now)
-        if wait > 0:
-            time.sleep(wait)
+        try:
+            result = await _perform_single_request(
+                client,
+                payload_items=payload_items,
+                item_ids=item_ids,
+                model=model,
+                temperature=temperature,
+                top_p=top_p,
+                response_format=response_format,
+                max_retries=max_retries,
+                rate_limiter=rate_limiter,
+                stop_event=stop_event,
+            )
+        except Exception:
+            logger.exception("AI batch task failed", exc_info=True)
+            result = {
+                "ok": {},
+                "ko": {str(pid): "error" for pid in item_ids},
+                "usage": {},
+                "duration": 0.0,
+                "retries": 0,
+                "status_code": 0,
+                "tokens_in": 0,
+                "tokens_out": 0,
+                "sent": 0,
+                "skipped": False,
+            }
+        result["batch_no"] = batch_no
+        result["item_ids"] = item_ids
+        await results_queue.put(result)
+
+
+def _run_async(coro: "asyncio.Future[Any]") -> Any:
+    try:
+        return asyncio.run(coro)
+    except RuntimeError as exc:
+        if "running event loop" in str(exc):
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(coro)
+            finally:
+                loop.close()
+        raise
 
 
 def _ensure_conn():
@@ -117,6 +464,7 @@ def _classify_scores(
         "moved_medium": 0,
         "moved_low": 0,
         "moved_high": 0,
+        "skipped": False,
     }
 
     if not pairs:
@@ -137,30 +485,26 @@ def _classify_scores(
     info["q33"] = q33
     info["q67"] = q67
 
-    if n >= 6 and distinct >= 3 and abs(q67 - q33) > 1e-6:
-        for pid, score in pairs:
+    if n < 6 or distinct < 3 or abs(q67 - q33) <= 1e-6:
+        info["skipped"] = True
+        for _, score in pairs:
             if score <= q33:
-                lab = "Low"
+                dist["Low"] += 1
             elif score >= q67:
-                lab = "High"
+                dist["High"] += 1
             else:
-                lab = "Medium"
-            labels[pid] = lab
-            dist[lab] += 1
-    else:
-        info["fallback"] = True
-        sorted_pairs = sorted(pairs, key=lambda x: x[1])
-        cut1 = round(n / 3)
-        cut2 = round(2 * n / 3)
-        for idx, (pid, _) in enumerate(sorted_pairs):
-            if idx < cut1:
-                lab = "Low"
-            elif idx < cut2:
-                lab = "Medium"
-            else:
-                lab = "High"
-            labels[pid] = lab
-            dist[lab] += 1
+                dist["Medium"] += 1
+        return labels, dist, info
+
+    for pid, score in pairs:
+        if score <= q33:
+            lab = "Low"
+        elif score >= q67:
+            lab = "High"
+        else:
+            lab = "Medium"
+        labels[pid] = lab
+        dist[lab] += 1
 
     min_medium = math.ceil(min_medium_pct * n)
     min_low = math.ceil(min_low_pct * n)
@@ -222,51 +566,6 @@ def _quantile(data: List[float], q: float) -> float:
     return s[lo] * (hi - pos) + s[hi] * (pos - lo)
 
 
-def _extract_status_code(exc: Exception) -> int:
-    message = str(exc)
-    for token in message.replace(":", " ").split():
-        if token.isdigit():
-            try:
-                return int(token)
-            except Exception:
-                continue
-    return 0
-
-
-def _call_batch_with_retries(
-    api_key: str,
-    model: str,
-    items: List[Dict[str, Any]],
-    max_retries: int,
-) -> Dict[str, Any]:
-    attempt = 0
-    while True:
-        try:
-            ok, ko, usage, duration = gpt.generate_batch_columns(api_key, model, items)
-            duration = float(duration or 0.0)
-            return {
-                "ok": ok or {},
-                "ko": ko or {},
-                "usage": usage or {},
-                "duration": duration,
-                "retries": attempt,
-            }
-        except gpt.OpenAIError as exc:
-            status = _extract_status_code(exc)
-            if status in {429, 500, 502, 503, 504} and attempt < max_retries:
-                sleep = min(10.0, 0.5 * (2**attempt)) + random.uniform(0.1, 0.5)
-                time.sleep(sleep)
-                attempt += 1
-                continue
-            return {
-                "ok": {},
-                "ko": {str(item["id"]): str(exc) for item in items},
-                "usage": {},
-                "duration": 0.0,
-                "retries": attempt,
-            }
-
-
 def _calculate_cost(usage: Dict[str, Any], price_in: float, price_out: float) -> float:
     prompt = usage.get("prompt_tokens")
     if prompt is None:
@@ -309,19 +608,38 @@ def _apply_ai_updates(conn, updates: Dict[int, Dict[str, Any]]) -> None:
     conn.commit()
 
 
-def _build_payload(row: Any, extra: Dict[str, Any]) -> Dict[str, Any]:
+def _build_payload(row: Any, extra: Dict[str, Any], cfg: Dict[str, Any]) -> Dict[str, Any]:
+    max_title_default = int(config.AI_CFG_DEFAULTS.get("max_title_chars", 120))
+    max_desc_default = int(config.AI_CFG_DEFAULTS.get("max_desc_chars", 220))
+    max_title = int(cfg.get("max_title_chars") or max_title_default)
+    max_desc = int(cfg.get("max_desc_chars") or max_desc_default)
+    title_source = (
+        extra.get("title")
+        or extra.get("name")
+        or row.get("title")
+        or row.get("name")
+    )
+    desc_source = (
+        row.get("description")
+        or extra.get("description")
+        or extra.get("descripcion")
+        or extra.get("short_description")
+        or extra.get("product_description")
+        or extra.get("desc")
+    )
+    brand_source = extra.get("brand") or extra.get("marca") or extra.get("seller")
+    category_source = (
+        row.get("category")
+        or extra.get("category")
+        or extra.get("categoria")
+        or extra.get("cat")
+    )
     return {
         "id": row["id"],
-        "name": row["name"],
-        "category": row["category"],
-        "price": row["price"],
-        "rating": extra.get("rating"),
-        "units_sold": extra.get("units_sold"),
-        "revenue": extra.get("revenue"),
-        "conversion_rate": extra.get("conversion_rate"),
-        "launch_date": extra.get("launch_date"),
-        "date_range": row["date_range"],
-        "image_url": row["image_url"],
+        "title": _clean_text(title_source or row.get("name"), max_title),
+        "desc": _clean_text(desc_source, max_desc),
+        "brand": _clean_text(brand_source, BRAND_MAX_CHARS),
+        "category": _clean_text(category_source, CATEGORY_MAX_CHARS),
     }
 
 
@@ -352,6 +670,7 @@ def _emit_status(
         logger.debug("status callback failed", exc_info=True)
 
 
+
 def run_ai_fill_job(
     job_id: int,
     product_ids: Sequence[int],
@@ -362,7 +681,74 @@ def run_ai_fill_job(
 ) -> Dict[str, Any]:
     start_ts = time.perf_counter()
     conn = _ensure_conn()
+    runtime_cfg = config.get_ai_runtime_config()
+
+    if parallelism is None:
+        parallelism = runtime_cfg.get("parallelism", 8)
+    try:
+        parallelism = int(parallelism)
+    except Exception:
+        parallelism = int(runtime_cfg.get("parallelism", 1) or 1)
+    parallelism = max(1, parallelism)
+
+    micro_default = runtime_cfg.get("microbatch", microbatch)
+    try:
+        microbatch_size = int(microbatch or micro_default or 1)
+    except Exception:
+        microbatch_size = int(micro_default or 1)
+    microbatch_size = max(1, microbatch_size)
+
+    cache_enabled = bool(runtime_cfg.get("cache_enabled", True))
+    cache_version = int(runtime_cfg.get("version", 1) or 1)
+
+    tpm_limit_raw = runtime_cfg.get("tpm_limit")
+    try:
+        tpm_limit = None if tpm_limit_raw in (None, "") else int(tpm_limit_raw)
+    except Exception:
+        tpm_limit = None
+
+    rpm_limit_raw = runtime_cfg.get("rpm_limit")
+    try:
+        rpm_limit = None if rpm_limit_raw in (None, "") else int(rpm_limit_raw)
+    except Exception:
+        rpm_limit = None
+
+    batch_cfg = config.get_ai_batch_config()
+    max_retries = int(batch_cfg.get("MAX_RETRIES", 3) or 3)
+
+    cost_cfg = config.get_ai_cost_config()
+    model = runtime_cfg.get("model") or cost_cfg.get("model") or config.get_model()
+    try:
+        temperature = float(runtime_cfg.get("temperature", 0) or 0.0)
+    except Exception:
+        temperature = 0.0
+    try:
+        top_p = float(runtime_cfg.get("top_p", 0) or 0.0)
+    except Exception:
+        top_p = 0.0
+    response_format = _resolve_response_format(runtime_cfg.get("response_format"))
+
+    cost_cap_val = runtime_cfg.get("costCapUSD")
+    if cost_cap_val is None:
+        cost_cap_val = cost_cfg.get("costCapUSD")
+    if cost_cap_val is not None:
+        try:
+            cost_cap = float(cost_cap_val)
+        except Exception:
+            cost_cap = None
+    else:
+        cost_cap = None
+
+    price_map = cost_cfg.get("prices", {}).get(model, {})
+    price_in = float(price_map.get("input", 0.0))
+    price_out = float(price_map.get("output", 0.0))
+    est_tokens_in = int(cost_cfg.get("estTokensPerItemIn", DEFAULT_EST_TOKENS_PER_ITEM) or DEFAULT_EST_TOKENS_PER_ITEM)
+    est_tokens_out = int(cost_cfg.get("estTokensPerItemOut", DEFAULT_EST_OUTPUT_TOKENS_PER_ITEM) or DEFAULT_EST_OUTPUT_TOKENS_PER_ITEM)
+
+    api_key = config.get_api_key() or os.environ.get("OPENAI_API_KEY")
+
     job_updates_enabled = job_id is not None and int(job_id) > 0
+
     requested_ids: List[int] = []
     seen_ids: set[int] = set()
     for pid in product_ids:
@@ -398,17 +784,17 @@ def run_ai_fill_job(
         if already_done and all(existing.get(field) for field in AI_FIELDS):
             skipped_existing += 1
             continue
-        name = row["name"]
+        name = row.get("name")
         if not name:
             skipped_existing += 1
             continue
         brand = extra.get("brand")
         asin = extra.get("asin")
         product_url = extra.get("product_url")
-        sig_hash = row["sig_hash"] or compute_sig_hash(name, brand, asin, product_url)
-        if sig_hash and not row["sig_hash"]:
+        sig_hash = row.get("sig_hash") or compute_sig_hash(name, brand, asin, product_url)
+        if sig_hash and not row.get("sig_hash"):
             sig_updates.append((sig_hash, pid))
-        payload = _build_payload(row, extra)
+        payload = _build_payload(row, extra, runtime_cfg)
         candidates.append(Candidate(id=pid, sig_hash=sig_hash, payload=payload, extra=extra))
 
     if sig_updates:
@@ -419,39 +805,19 @@ def run_ai_fill_job(
 
     total_items = len(candidates)
 
-    runtime_cfg = config.get_ai_runtime_config()
-    if parallelism is None:
-        parallelism = int(runtime_cfg.get("parallelism", 8) or 8)
-    parallelism = max(1, parallelism)
-
-    microbatch_size = int(microbatch or runtime_cfg.get("microbatch", 32) or 32)
-    if microbatch_size < 24:
-        microbatch_size = 24
-    if microbatch_size > 64:
-        microbatch_size = 64
-
-    cache_enabled = bool(runtime_cfg.get("cache_enabled", True))
-    cache_version = int(runtime_cfg.get("version", 1) or 1)
-    tpm_limit = runtime_cfg.get("tpm_limit")
-    if tpm_limit is not None:
-        try:
-            tpm_limit = int(tpm_limit)
-        except Exception:
-            tpm_limit = None
-
-    batch_cfg = config.get_ai_batch_config()
-    max_retries = int(batch_cfg.get("MAX_RETRIES", 3) or 3)
-
-    cost_cfg = config.get_ai_cost_config()
-    model = cost_cfg.get("model") or config.get_model()
-    cost_cap = cost_cfg.get("costCapUSD")
-    price_map = cost_cfg.get("prices", {}).get(model, {})
-    price_in = float(price_map.get("input", 0.0))
-    price_out = float(price_map.get("output", 0.0))
-    est_tokens_in = int(cost_cfg.get("estTokensPerItemIn", 0) or 0)
-    est_tokens_out = int(cost_cfg.get("estTokensPerItemOut", 0) or 0)
-
-    api_key = config.get_api_key() or os.environ.get("OPENAI_API_KEY")
+    if tpm_limit and tpm_limit > 0:
+        est_per_item = max(DEFAULT_EST_TOKENS_PER_ITEM, est_tokens_in or DEFAULT_EST_TOKENS_PER_ITEM)
+        per_request = est_per_item * microbatch_size
+        if per_request > tpm_limit:
+            microbatch_size = max(1, tpm_limit // max(est_per_item, 1))
+        if microbatch_size <= 0:
+            microbatch_size = 1
+        per_request = est_per_item * microbatch_size
+        if per_request > 0:
+            max_req_per_min = max(1, tpm_limit // per_request)
+            parallelism = max(1, min(parallelism, max_req_per_min))
+    if rpm_limit and rpm_limit > 0:
+        parallelism = max(1, min(parallelism, rpm_limit))
 
     if job_updates_enabled:
         database.start_import_job_ai(conn, int(job_id), total_items)
@@ -535,7 +901,6 @@ def run_ai_fill_job(
             counts["cached"] += 1
         if cached_updates:
             _apply_ai_updates(conn, cached_updates)
-        candidates = remaining
         counts_with_cost = {**counts, "cost_spent_usd": cost_spent}
         done_val = counts["ok"] + counts["cached"]
         if job_updates_enabled:
@@ -560,7 +925,14 @@ def run_ai_fill_job(
         if job_updates_enabled:
             database.set_import_job_ai_counts(conn, int(job_id), counts_with_cost, sorted(pending_set))
             database.set_import_job_ai_error(conn, int(job_id), result_error)
-        _emit_status(status_cb, phase="enrich", counts=counts_with_cost, total=total_items, done=counts["cached"], message="IA pendiente")
+        _emit_status(
+            status_cb,
+            phase="enrich",
+            counts=counts_with_cost,
+            total=total_items,
+            done=counts["cached"],
+            message="IA pendiente",
+        )
         conn.close()
         return {
             "counts": counts_with_cost,
@@ -572,70 +944,64 @@ def run_ai_fill_job(
             "total_requested": len(requested_ids),
         }
 
-    batches: List[Tuple[int, List[Dict[str, Any]]]] = []
-    for idx in range(0, len(remaining), microbatch_size):
-        chunk = remaining[idx : idx + microbatch_size]
-        if not chunk:
-            continue
-        batches.append((len(batches) + 1, [cand.payload for cand in chunk]))
-
-    limiter = _RateLimiter(tpm_limit, est_tokens_in, est_tokens_out)
-    stop_event = threading.Event()
-
+    success_records: Dict[int, Dict[str, Any]] = {}
     desire_scores: List[Tuple[str, float]] = []
     comp_scores: List[Tuple[str, float]] = []
-    success_records: Dict[int, Dict[str, Any]] = {}
 
-    if batches:
-        task_queue: "queue.Queue[Optional[Tuple[int, List[Dict[str, Any]]]]]" = queue.Queue()
-        result_queue: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+    batches: List[List[Candidate]] = []
+    for idx in range(0, len(remaining), microbatch_size):
+        chunk = remaining[idx : idx + microbatch_size]
+        if chunk:
+            batches.append(chunk)
 
-        def worker() -> None:
-            while True:
-                item = task_queue.get()
-                if item is None:
-                    task_queue.task_done()
-                    break
-                batch_no, payload = item
-                if stop_event.is_set():
-                    result_queue.put({"batch_no": batch_no, "items": payload, "skipped": True})
-                    task_queue.task_done()
-                    continue
-                limiter.acquire(len(payload))
-                result = _call_batch_with_retries(api_key, model, payload, max_retries)
-                result["batch_no"] = batch_no
-                result["items"] = payload
-                result_queue.put(result)
-                task_queue.task_done()
+    stop_event = asyncio.Event()
 
-        with ThreadPoolExecutor(max_workers=parallelism) as executor:
-            for _ in range(parallelism):
-                executor.submit(worker)
-            for batch in batches:
-                task_queue.put(batch)
-            for _ in range(parallelism):
-                task_queue.put(None)
-
+    async def _process_batches() -> Tuple[float, bool]:
+        if not batches:
+            return 0.0, False
+        rate_limiter = AsyncRateLimiter(tpm_limit, rpm_limit)
+        semaphore = asyncio.Semaphore(parallelism)
+        results_queue: "asyncio.Queue[Dict[str, Any]]" = asyncio.Queue()
+        local_cost = 0.0
+        async with AsyncOpenAI(api_key=api_key) as client:
+            tasks = [
+                asyncio.create_task(
+                    _run_batch_task(
+                        batch_no,
+                        batch_candidates,
+                        client=client,
+                        model=model,
+                        temperature=temperature,
+                        top_p=top_p,
+                        response_format=response_format,
+                        max_retries=max_retries,
+                        rate_limiter=rate_limiter,
+                        stop_event=stop_event,
+                        semaphore=semaphore,
+                        results_queue=results_queue,
+                    )
+                )
+                for batch_no, batch_candidates in enumerate(batches, start=1)
+            ]
             processed = 0
-            while processed < len(batches):
-                result = result_queue.get()
+            total_batches = len(tasks)
+            while processed < total_batches:
+                result = await results_queue.get()
                 processed += 1
-                batch_items: List[Dict[str, Any]] = result.get("items", [])
-                if result.get("skipped"):
-                    for item in batch_items:
-                        pid = int(item.get("id"))
-                        pending_set.add(pid)
-                        fail_reasons.setdefault(pid, "cost_cap_reached")
-                    continue
-                counts["sent"] += len(batch_items)
-                retries = int(result.get("retries", 0) or 0)
-                counts["retried"] += retries
-                ok_map: Dict[str, Dict[str, Any]] = result.get("ok", {})
-                ko_map: Dict[str, str] = result.get("ko", {})
+                item_ids = result.get("item_ids", [])
+                sent = int(result.get("sent", len(item_ids)))
+                if not result.get("skipped"):
+                    counts["sent"] += sent
+                counts["retried"] += int(result.get("retries", 0) or 0)
+                ok_map: Dict[str, Dict[str, Any]] = result.get("ok", {}) or {}
+                ko_map: Dict[str, str] = result.get("ko", {}) or {}
                 duration = float(result.get("duration", 0.0) or 0.0)
                 usage = result.get("usage", {}) or {}
+                tokens_in = int(result.get("tokens_in", 0) or 0)
+                tokens_out = int(result.get("tokens_out", 0) or 0)
+                status_code = result.get("status_code", 0)
                 if usage:
-                    cost_spent += _calculate_cost(usage, price_in, price_out)
+                    local_cost += _calculate_cost(usage, price_in, price_out)
                 success_updates: Dict[int, Dict[str, Any]] = {}
                 for pid_str, payload in ok_map.items():
                     try:
@@ -644,6 +1010,7 @@ def run_ai_fill_job(
                         continue
                     success_updates[pid] = payload
                     pending_set.discard(pid)
+                    fail_reasons.pop(pid, None)
                 for pid_str, reason in ko_map.items():
                     try:
                         pid = int(pid_str)
@@ -656,62 +1023,64 @@ def run_ai_fill_job(
                     for pid, payload in success_updates.items():
                         candidate = candidate_map.get(pid)
                         sig_hash = candidate.sig_hash if candidate else ""
-                        success_records[pid] = {
-                            "sig_hash": sig_hash,
-                            "updates": payload.copy(),
-                        }
+                        record = {"sig_hash": sig_hash, "updates": payload.copy()}
                         parsed_desire = _parse_score(payload.get("desire_magnitude"))
                         parsed_comp = _parse_score(payload.get("competition_level"))
                         if parsed_desire is not None:
                             desire_scores.append((str(pid), parsed_desire))
-                            success_records[pid]["_desire_score"] = parsed_desire
+                            record["_desire_score"] = parsed_desire
                         if parsed_comp is not None:
                             comp_scores.append((str(pid), parsed_comp))
-                            success_records[pid]["_competition_score"] = parsed_comp
+                            record["_competition_score"] = parsed_comp
+                        success_records[pid] = record
                         applied_outputs[pid] = {k: v for k, v in payload.items() if v is not None}
                 counts["ok"] += len(success_updates)
                 counts["ko"] += len(ko_map)
-                throughput = (len(batch_items) / duration) if duration > 0 else 0.0
-                if job_updates_enabled:
+                if job_updates_enabled and not result.get("skipped"):
+                    throughput = (len(item_ids) / duration) if duration > 0 else 0.0
                     database.append_ai_job_metric(
                         conn,
                         int(job_id),
                         result.get("batch_no", processed),
-                        len(batch_items),
+                        len(item_ids),
                         duration * 1000.0,
                         throughput,
                         cached_hits=0,
                     )
                 done_val = counts["ok"] + counts["cached"]
-                counts_with_cost = {**counts, "cost_spent_usd": cost_spent}
+                counts_with_cost_local = {**counts, "cost_spent_usd": local_cost}
                 if job_updates_enabled:
                     database.update_import_job_ai_progress(conn, int(job_id), done_val)
-                    database.set_import_job_ai_counts(conn, int(job_id), counts_with_cost, sorted(pending_set))
+                    database.set_import_job_ai_counts(conn, int(job_id), counts_with_cost_local, sorted(pending_set))
                 _emit_status(
                     status_cb,
                     phase="enrich",
-                    counts=counts_with_cost,
+                    counts=counts_with_cost_local,
                     total=total_items,
                     done=done_val,
                     message=f"IA columnas {done_val}/{total_items}",
                 )
-                if cost_cap is not None and cost_spent >= float(cost_cap) and not stop_event.is_set():
+                logger.info(
+                    "AI_ENRICH batch k=%s dur_ms=%.0f rps=%.2f tokens_in=%d tokens_out=%d rc=%s",
+                    result.get("batch_no", processed),
+                    duration * 1000.0,
+                    (len(item_ids) / duration) if duration > 0 else 0.0,
+                    tokens_in,
+                    tokens_out,
+                    status_code,
+                )
+                if cost_cap is not None and local_cost >= float(cost_cap) and not stop_event.is_set():
                     stop_event.set()
-            task_queue.join()
-    else:
-        counts_with_cost = {**counts, "cost_spent_usd": cost_spent}
-        if job_updates_enabled:
-            database.set_import_job_ai_counts(conn, int(job_id), counts_with_cost, sorted(pending_set))
-        _emit_status(
-            status_cb,
-            phase="enrich",
-            counts=counts_with_cost,
-            total=total_items,
-            done=counts["ok"] + counts["cached"],
-        )
+            await asyncio.gather(*tasks)
+        return local_cost, stop_event.is_set()
+
+    cost_limit_hit = False
+    if batches:
+        cost_spent, cost_limit_hit = _run_async(_process_batches())
+    counts_with_cost = {**counts, "cost_spent_usd": cost_spent}
 
     result_error: Optional[str] = None
-    if cost_cap is not None and cost_spent >= float(cost_cap):
+    if cost_cap is not None and (cost_limit_hit or cost_spent >= float(cost_cap)):
         result_error = "cost_cap_reached"
 
     cfg_calib = config.get_ai_calibration_config()
@@ -722,6 +1091,8 @@ def run_ai_fill_job(
         min_high = float(cfg_calib.get("min_high_pct", 0.05) or 0.0)
         desire_info: Dict[str, Any] = {}
         comp_info: Dict[str, Any] = {}
+        dist_desire: Dict[str, int] = {}
+        dist_comp: Dict[str, int] = {}
         if desire_scores:
             labels, dist_desire, desire_info = _classify_scores(
                 desire_scores,
@@ -783,7 +1154,6 @@ def run_ai_fill_job(
 
     pending_ids = sorted(pending_set)
     done_val = counts["ok"] + counts["cached"]
-    counts_with_cost = {**counts, "cost_spent_usd": cost_spent}
     if job_updates_enabled:
         database.update_import_job_ai_progress(conn, int(job_id), done_val)
         database.set_import_job_ai_counts(conn, int(job_id), counts_with_cost, pending_ids)
@@ -799,13 +1169,17 @@ def run_ai_fill_job(
     )
 
     logger.info(
-        "run_ai_fill_job: job=%s total=%d ok=%d cached=%d ko=%d cost=%.4f pending=%d error=%s duration=%.2fs",
+        "run_ai_fill_job: job=%s model=%s parallelism=%d micro=%d total=%d ok=%d cached=%d ko=%d cost=%.4f cost_hit=%s pending=%d error=%s duration=%.2fs",
         job_id,
+        model,
+        parallelism,
+        microbatch_size,
         total_items,
         counts["ok"],
         counts["cached"],
         counts["ko"],
         cost_spent,
+        cost_limit_hit,
         len(pending_ids),
         result_error,
         time.perf_counter() - start_ts,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pillow
 openpyxl
 httpx
 pandas
+openai>=1.30.0


### PR DESCRIPTION
## Summary
- add aggressive but safe async defaults for AI runtime config and share them across the app
- upgrade to openai>=1.30.0 to use the async Responses API client
- refactor ai_columns job to trim inputs, batch requests, use AsyncOpenAI with concurrency limits, improved logging, and single-pass calibration

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d03cce0c3483289ee105330fd860af