### PR TITLE
Optimize AI enrichment throughput and caching

### DIFF
--- a/product_research_app/config.json
+++ b/product_research_app/config.json
@@ -1,0 +1,71 @@
+{
+  "autoFillIAOnImport": true,
+  "aiBatch": {
+    "BATCH_SIZE": 10,
+    "MAX_CONCURRENCY": 2,
+    "MAX_RETRIES": 3,
+    "TIME_LIMIT_SECONDS": 300
+  },
+  "aiCost": {
+    "model": "gpt-4o-mini",
+    "useBatchWhenCountGte": 300,
+    "costCapUSD": null,
+    "estTokensPerItemIn": 120,
+    "estTokensPerItemOut": 40
+  },
+  "aiCalibration": {
+    "enabled": true,
+    "mode": "terciles",
+    "winsorize_pct": 0.05,
+    "min_low_pct": 0.05,
+    "min_medium_pct": 0.05,
+    "min_high_pct": 0.05
+  },
+  "ai": {
+    "model": "gpt-4o-mini",
+    "temperature": 0.0,
+    "top_p": 0.1,
+    "topP": 0.1,
+    "response_format": "json",
+    "parallelism": 32,
+    "microbatch": 128,
+    "max_desc_chars": 240,
+    "max_title_chars": 120,
+    "tpm_limit": null,
+    "rpm_limit": null,
+    "costCapUSD": null,
+    "cache_enabled": true,
+    "enableCache": true,
+    "maxOutputTokensPerItem": 8,
+    "truncate": {
+      "title": 120,
+      "description": 240
+    },
+    "version": 2
+  },
+  "includeImageInAI": true,
+  "aiImageCostMaxUSD": 0.02,
+  "weightsVersion": 0,
+  "weightsUpdatedAt": 0,
+  "oldness_preference": "newer",
+  "winner_order": [
+    "awareness",
+    "desire",
+    "revenue",
+    "competition",
+    "units_sold",
+    "price",
+    "oldness",
+    "rating"
+  ],
+  "weights_order": [
+    "awareness",
+    "desire",
+    "revenue",
+    "competition",
+    "units_sold",
+    "price",
+    "oldness",
+    "rating"
+  ]
+}


### PR DESCRIPTION
## Summary
- raise the AI default parallelism/microbatch settings while enforcing deterministic sampling, truncation, caching, and token limits in the config helpers and bundled config.json
- add digest-based caching, payload truncation, max-output token caps, and single-batch scheduling with exception-tolerant gathers to the AI column enrichment service, persisting hits in SQLite
- reduce high-volume logging by moving per-product winner-score messages to DEBUG and provide concise INFO summaries and safe config merging in the web app

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d0497bad2083288384774c03141f1c