### PR TITLE
Add one-time dependency bootstrap batch scripts

### DIFF
--- a/docs/dependency_setup_troubleshooting.md
+++ b/docs/dependency_setup_troubleshooting.md
@@ -1,0 +1,31 @@
+# Dependency Bootstrap Troubleshooting
+
+The one-time dependency bootstrap flow stores state using either a marker file or a registry value. If application startup slows down or setup runs on every launch, review the following scenarios.
+
+## Permission issues
+- **Symptom:** The first run fails when creating the virtual environment or writing the setup marker.
+- **Resolution:**
+  - Run the script from an elevated command prompt if the installation paths require administrator access.
+  - Confirm that the user has write access to the application directory (`logs`, `config`, and `.venv`).
+  - Check `logs\setup_flag.log` or `logs\setup_registry.log` for the specific command that failed.
+
+## Corrupted or deleted markers
+- **Symptom:** Dependencies reinstall every time even though the initial setup succeeded.
+- **Resolution:**
+  - For the **flag file** workflow, ensure `config\setup_complete.flag` still exists and contains the timestamp and python path entries.
+  - For the **registry** workflow, verify `HKCU\Software\EcomTestingApp` has the `SetupComplete` value. Remove any partially written or empty values before rerunning the script.
+  - Re-run the script after restoring the marker; it will skip the heavy bootstrap when the marker is intact.
+
+## Manual reset
+- **Symptom:** You intentionally need to rerun the dependency bootstrap (e.g., upgrading Python or dependencies).
+- **Resolution:**
+  - Delete `config\setup_complete.flag` for the file-based approach or run `reg delete "HKCU\Software\EcomTestingApp" /v "SetupComplete" /f` for the registry approach.
+  - On the next launch, the script will perform the dependency verification and recreate the markers upon success.
+
+## Network or download failures
+- **Symptom:** Python or dependency downloads fail during the first run.
+- **Resolution:**
+  - Verify network connectivity and proxy settings used by `Invoke-WebRequest`.
+  - Inspect the setup log for the HTTP status code or PowerShell error. Retry after the connection is restored.
+
+Maintain the log files (`logs\setup_flag.log` and `logs\setup_registry.log`) for auditing. They capture every bootstrap attempt and highlight the commands to retry manually when necessary.

--- a/scripts/run_app_flag_marker.bat
+++ b/scripts/run_app_flag_marker.bat
@@ -1,0 +1,182 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+chcp 65001 >nul
+
+:: ============================================================
+:: Ecom Testing App — run_app_flag_marker.bat
+:: One-time dependency bootstrap using a marker file
+:: ============================================================
+
+:: ---------- Paths and constants ----------
+set "ROOT=%~dp0"
+set "LOG_DIR=%ROOT%logs"
+set "LOG_FILE=%LOG_DIR%\setup_flag.log"
+set "FLAG_FILE=%ROOT%config\setup_complete.flag"
+set "PY_EXPECTED_MIN=3.11"
+set "APP_DEFAULT_PORT=8000"
+
+if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
+if not exist "%ROOT%config" mkdir "%ROOT%config"
+
+echo ============================================================>>"%LOG_FILE%"
+echo %DATE% %TIME% — run_app_flag_marker bootstrap >>"%LOG_FILE%"
+
+:: ---------- Fast-path: skip dependency setup when marker exists ----------
+if exist "%FLAG_FILE%" (
+  echo [INFO] Marker found. Skipping dependency validation.>>"%LOG_FILE%"
+  goto :run_application
+)
+
+:: ---------- Initial dependency check & installation ----------
+call :ensure_python
+if errorlevel 1 goto :setup_failed
+
+call :ensure_virtualenv
+if errorlevel 1 goto :setup_failed
+
+call :install_requirements
+if errorlevel 1 goto :setup_failed
+
+:: ---------- Flag creation after successful setup ----------
+(
+  echo setup completed on %DATE% %TIME%
+  echo python=%PYEXE%
+) > "%FLAG_FILE%"
+echo [INFO] Setup marker created at %FLAG_FILE%>>"%LOG_FILE%"
+
+goto :run_application
+
+:: ============================================================
+:: Function: ensure_python — validates Python installation
+:: Downloads embedded distribution if nothing suitable exists
+:: ============================================================
+:ensure_python
+set "PYEXE="
+
+for /f "delims=" %%P in ('py -3 -c "import sys;print(sys.executable)" 2^>nul') do set "PYEXE=%%P"
+if defined PYEXE goto :check_version
+
+for /f "delims=" %%P in ('where python 2^>nul') do set "PYEXE=%%P"
+if defined PYEXE goto :check_version
+
+echo [WARN] Python not detected. Attempting to use embedded build...>>"%LOG_FILE%"
+set "EMBED_DIR=%ROOT%python_embed"
+set "PYEXE=%EMBED_DIR%\python.exe"
+if not exist "%PYEXE%" (
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "try{Invoke-WebRequest -UseBasicParsing -Uri 'https://www.python.org/ftp/python/3.12.6/python-3.12.6-embed-amd64.zip' -OutFile '%TEMP%\python-embed.zip';exit 0}catch{exit 1}" >>"%LOG_FILE%" 2>&1
+  if errorlevel 1 (
+    echo [ERROR] Unable to download embedded Python.>>"%LOG_FILE%"
+    echo [ERROR] Download failed. Verify your internet connection.
+    exit /b 1
+  )
+  mkdir "%EMBED_DIR%" >nul 2>&1
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "Expand-Archive -Force '%TEMP%\python-embed.zip' '%EMBED_DIR%'" >>"%LOG_FILE%" 2>&1
+  del "%TEMP%\python-embed.zip" >nul 2>&1
+  for %%F in ("%EMBED_DIR%\python3*._pth") do (
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "$p='%%~fF';$t=Get-Content -Raw $p; if($t -notmatch 'import\s+site'){ $t=$t + \"`r`nimport site`r`n\"}; $t=$t -replace '^\s*#\s*import\s+site','import site'; Set-Content -NoNewline $p $t -Encoding ASCII" >>'%LOG_FILE%' 2>&1
+  )
+  if not exist "%PYEXE%" (
+    echo [ERROR] Embedded Python extraction failed.>>"%LOG_FILE%"
+    exit /b 1
+  )
+)
+
+echo [INFO] Using Python executable: %PYEXE%>>"%LOG_FILE%"
+goto :verify_python_ready
+
+:check_version
+for /f "delims=" %%V in ('"%PYEXE%" -c "import sys;print('.'.join(map(str,sys.version_info[:2])))" 2^>nul') do set "PY_VERSION=%%V"
+if not defined PY_VERSION (
+  echo [WARN] Unable to read Python version.>>"%LOG_FILE%"
+  set "PYEXE="
+  goto :ensure_python
+)
+for /f "tokens=1,2 delims=." %%a in ("%PY_VERSION%") do set "_MAJOR=%%a"&set "_MINOR=%%b"
+for /f "tokens=1,2 delims=." %%a in ("%PY_EXPECTED_MIN%") do set "_REQ_MAJOR=%%a"&set "_REQ_MINOR=%%b"
+if not "%_MAJOR%"=="%_REQ_MAJOR%" goto :verify_python_ready
+if %_MINOR% LSS %_REQ_MINOR% (
+  echo [WARN] Python version %PY_VERSION% below required %PY_EXPECTED_MIN%.>>"%LOG_FILE%"
+  set "PYEXE="
+  goto :ensure_python
+)
+
+echo [INFO] System Python %PY_VERSION% accepted.>>"%LOG_FILE%"
+
+:verify_python_ready
+if not defined PYEXE (
+  echo [ERROR] Python could not be prepared.>>"%LOG_FILE%"
+  exit /b 1
+)
+exit /b 0
+
+:: ============================================================
+:: Function: ensure_virtualenv — create dedicated venv when using system python
+:: ============================================================
+:ensure_virtualenv
+echo %PYEXE% | find /I "%ROOT%python_embed\" >nul
+if not errorlevel 1 (
+  echo [INFO] Embedded Python detected. Skipping venv creation.>>"%LOG_FILE%"
+  exit /b 0
+)
+
+if not exist "%ROOT%.venv\Scripts\python.exe" (
+  echo [INFO] Creating local virtual environment...>>"%LOG_FILE%"
+  "%PYEXE%" -m venv "%ROOT%.venv" >>"%LOG_FILE%" 2>&1
+  if errorlevel 1 (
+    echo [ERROR] Virtual environment creation failed.>>"%LOG_FILE%"
+    exit /b 1
+  )
+)
+set "PYEXE=%ROOT%.venv\Scripts\python.exe"
+exit /b 0
+
+:: ============================================================
+:: Function: install_requirements — upgrade tooling & install packages once
+:: ============================================================
+:install_requirements
+echo [INFO] Upgrading pip tooling...>>"%LOG_FILE%"
+"%PYEXE%" -m pip install --upgrade pip setuptools wheel >>"%LOG_FILE%" 2>&1
+if errorlevel 1 (
+  echo [ERROR] Failed to upgrade pip.>>"%LOG_FILE%"
+  exit /b 1
+)
+
+if exist "%ROOT%requirements.txt" (
+  echo [INFO] Installing requirements...>>"%LOG_FILE%"
+  "%PYEXE%" -m pip install -r "%ROOT%requirements.txt" >>"%LOG_FILE%" 2>&1
+  if errorlevel 1 (
+    echo [ERROR] Dependency installation failed.>>"%LOG_FILE%"
+    exit /b 1
+  )
+) else (
+  echo [WARN] requirements.txt not found.>>"%LOG_FILE%"
+)
+exit /b 0
+
+:: ============================================================
+:: Runtime section — execute the application after setup
+:: ============================================================
+:run_application
+echo [INFO] Launching application...>>"%LOG_FILE%"
+set "APP_PYEXE=%PYEXE%"
+if not defined APP_PYEXE set "APP_PYEXE=%ROOT%.venv\Scripts\python.exe"
+if not exist "%APP_PYEXE%" set "APP_PYEXE=%ROOT%python_embed\python.exe"
+
+if not exist "%APP_PYEXE%" (
+  echo [ERROR] Runtime Python not found.>>"%LOG_FILE%"
+  echo Application launch aborted.
+  exit /b 1
+)
+
+start "" cmd /c ^
+  "for /l %%i in (1,1,60) do (curl -I -s http://127.0.0.1:%APP_DEFAULT_PORT% >nul 2>&1 && start "" http://127.0.0.1:%APP_DEFAULT_PORT% & exit) & timeout /t 1 >nul"
+"%APP_PYEXE%" -m product_research_app.web_app
+set "RC=%ERRORLEVEL%"
+echo [INFO] Application exited with code %RC%>>"%LOG_FILE%"
+exit /b %RC%
+
+:setup_failed
+echo [ERROR] Initial setup failed. Dependencies remain unchecked.>>"%LOG_FILE%"
+if exist "%FLAG_FILE%" del "%FLAG_FILE%" >nul 2>&1
+echo Setup failed. Review %LOG_FILE% for details.
+exit /b 1

--- a/scripts/run_app_registry_marker.bat
+++ b/scripts/run_app_registry_marker.bat
@@ -1,0 +1,184 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+chcp 65001 >nul
+
+:: ============================================================
+:: Ecom Testing App — run_app_registry_marker.bat
+:: One-time dependency bootstrap using the Windows registry
+:: ============================================================
+
+:: ---------- Paths, constants, and registry settings ----------
+set "ROOT=%~dp0"
+set "LOG_DIR=%ROOT%logs"
+set "LOG_FILE=%LOG_DIR%\setup_registry.log"
+set "REG_KEY=HKCU\Software\EcomTestingApp"
+set "REG_VALUE=SetupComplete"
+set "PY_EXPECTED_MIN=3.11"
+set "APP_DEFAULT_PORT=8000"
+
+if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
+
+echo ============================================================>>"%LOG_FILE%"
+echo %DATE% %TIME% — run_app_registry_marker bootstrap >>"%LOG_FILE%"
+
+:: ---------- Fast-path: skip dependency setup when registry value exists ----------
+for /f "tokens=1*" %%A in ('reg query "%REG_KEY%" /v "%REG_VALUE%" 2^>nul ^| findstr /I "%REG_VALUE%"') do (
+  set "REG_STATUS=%%B"
+)
+if defined REG_STATUS (
+  echo [INFO] Registry flag detected (%REG_STATUS%).>>"%LOG_FILE%"
+  goto :run_application
+)
+
+:: ---------- Initial dependency check & installation ----------
+call :ensure_python
+if errorlevel 1 goto :setup_failed
+
+call :ensure_virtualenv
+if errorlevel 1 goto :setup_failed
+
+call :install_requirements
+if errorlevel 1 goto :setup_failed
+
+:: ---------- Registry flag creation after successful setup ----------
+reg add "%REG_KEY%" /v "%REG_VALUE%" /t REG_SZ /d "%DATE% %TIME%" /f >>"%LOG_FILE%" 2>&1
+if errorlevel 1 (
+  echo [WARN] Unable to store registry marker. Dependencies are still ready, but the next run will repeat checks.>>"%LOG_FILE%"
+) else (
+  echo [INFO] Registry marker stored under %REG_KEY%\%REG_VALUE%.>>"%LOG_FILE%"
+)
+
+goto :run_application
+
+:: ============================================================
+:: Function: ensure_python — validates Python installation, falls back to embedded build
+:: ============================================================
+:ensure_python
+set "PYEXE="
+
+for /f "delims=" %%P in ('py -3 -c "import sys;print(sys.executable)" 2^>nul') do set "PYEXE=%%P"
+if defined PYEXE goto :check_version
+
+for /f "delims=" %%P in ('where python 2^>nul') do set "PYEXE=%%P"
+if defined PYEXE goto :check_version
+
+echo [WARN] Python not detected. Attempting embedded download...>>"%LOG_FILE%"
+set "EMBED_DIR=%ROOT%python_embed"
+set "PYEXE=%EMBED_DIR%\python.exe"
+if not exist "%PYEXE%" (
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "try{Invoke-WebRequest -UseBasicParsing -Uri 'https://www.python.org/ftp/python/3.12.6/python-3.12.6-embed-amd64.zip' -OutFile '%TEMP%\python-embed.zip';exit 0}catch{exit 1}" >>"%LOG_FILE%" 2>&1
+  if errorlevel 1 (
+    echo [ERROR] Embedded Python download failed.>>"%LOG_FILE%"
+    exit /b 1
+  )
+  mkdir "%EMBED_DIR%" >nul 2>&1
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "Expand-Archive -Force '%TEMP%\python-embed.zip' '%EMBED_DIR%'" >>"%LOG_FILE%" 2>&1
+  del "%TEMP%\python-embed.zip" >nul 2>&1
+  for %%F in ("%EMBED_DIR%\python3*._pth") do (
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "$p='%%~fF';$t=Get-Content -Raw $p; if($t -notmatch 'import\s+site'){ $t=$t + \"`r`nimport site`r`n\"}; $t=$t -replace '^\s*#\s*import\s+site','import site'; Set-Content -NoNewline $p $t -Encoding ASCII" >>"%LOG_FILE%" 2>&1
+  )
+  if not exist "%PYEXE%" (
+    echo [ERROR] Embedded Python extraction failed.>>"%LOG_FILE%"
+    exit /b 1
+  )
+)
+
+echo [INFO] Using Python executable: %PYEXE%>>"%LOG_FILE%"
+goto :verify_python_ready
+
+:check_version
+for /f "delims=" %%V in ('"%PYEXE%" -c "import sys;print('.'.join(map(str,sys.version_info[:2])))" 2^>nul') do set "PY_VERSION=%%V"
+if not defined PY_VERSION (
+  echo [WARN] Could not detect Python version.>>"%LOG_FILE%"
+  set "PYEXE="
+  goto :ensure_python
+)
+for /f "tokens=1,2 delims=." %%a in ("%PY_VERSION%") do set "_MAJOR=%%a"&set "_MINOR=%%b"
+for /f "tokens=1,2 delims=." %%a in ("%PY_EXPECTED_MIN%") do set "_REQ_MAJOR=%%a"&set "_REQ_MINOR=%%b"
+if not "%_MAJOR%"=="%_REQ_MAJOR%" goto :verify_python_ready
+if %_MINOR% LSS %_REQ_MINOR% (
+  echo [WARN] Python version %PY_VERSION% below required %PY_EXPECTED_MIN%.>>"%LOG_FILE%"
+  set "PYEXE="
+  goto :ensure_python
+)
+
+echo [INFO] System Python %PY_VERSION% accepted.>>"%LOG_FILE%"
+
+:verify_python_ready
+if not defined PYEXE (
+  echo [ERROR] Python preparation failed.>>"%LOG_FILE%"
+  exit /b 1
+)
+exit /b 0
+
+:: ============================================================
+:: Function: ensure_virtualenv — create venv when using system python
+:: ============================================================
+:ensure_virtualenv
+echo %PYEXE% | find /I "%ROOT%python_embed\" >nul
+if not errorlevel 1 (
+  echo [INFO] Embedded Python detected. Skipping venv creation.>>"%LOG_FILE%"
+  exit /b 0
+)
+
+if not exist "%ROOT%.venv\Scripts\python.exe" (
+  echo [INFO] Creating .venv environment...>>"%LOG_FILE%"
+  "%PYEXE%" -m venv "%ROOT%.venv" >>"%LOG_FILE%" 2>&1
+  if errorlevel 1 (
+    echo [ERROR] Virtual environment creation failed.>>"%LOG_FILE%"
+    exit /b 1
+  )
+)
+set "PYEXE=%ROOT%.venv\Scripts\python.exe"
+exit /b 0
+
+:: ============================================================
+:: Function: install_requirements — upgrade pip tooling & install packages
+:: ============================================================
+:install_requirements
+echo [INFO] Upgrading pip tooling...>>"%LOG_FILE%"
+"%PYEXE%" -m pip install --upgrade pip setuptools wheel >>"%LOG_FILE%" 2>&1
+if errorlevel 1 (
+  echo [ERROR] Failed to upgrade pip.>>"%LOG_FILE%"
+  exit /b 1
+)
+
+if exist "%ROOT%requirements.txt" (
+  echo [INFO] Installing requirements...>>"%LOG_FILE%"
+  "%PYEXE%" -m pip install -r "%ROOT%requirements.txt" >>"%LOG_FILE%" 2>&1
+  if errorlevel 1 (
+    echo [ERROR] Dependency installation failed.>>"%LOG_FILE%"
+    exit /b 1
+  )
+) else (
+  echo [WARN] requirements.txt not found.>>"%LOG_FILE%"
+)
+exit /b 0
+
+:: ============================================================
+:: Runtime section — start the app
+:: ============================================================
+:run_application
+echo [INFO] Launching application...>>"%LOG_FILE%"
+set "APP_PYEXE=%PYEXE%"
+if not defined APP_PYEXE set "APP_PYEXE=%ROOT%.venv\Scripts\python.exe"
+if not exist "%APP_PYEXE%" set "APP_PYEXE=%ROOT%python_embed\python.exe"
+
+if not exist "%APP_PYEXE%" (
+  echo [ERROR] Runtime Python not found.>>"%LOG_FILE%"
+  echo Application launch aborted.
+  exit /b 1
+)
+
+start "" cmd /c ^
+  "for /l %%i in (1,1,60) do (curl -I -s http://127.0.0.1:%APP_DEFAULT_PORT% >nul 2>&1 && start "" http://127.0.0.1:%APP_DEFAULT_PORT% & exit) & timeout /t 1 >nul"
+"%APP_PYEXE%" -m product_research_app.web_app
+set "RC=%ERRORLEVEL%"
+echo [INFO] Application exited with code %RC%>>"%LOG_FILE%"
+exit /b %RC%
+
+:setup_failed
+echo [ERROR] Initial setup failed.>>"%LOG_FILE%"
+reg delete "%REG_KEY%" /v "%REG_VALUE%" /f >nul 2>&1
+echo Setup failed. Review %LOG_FILE% for details.
+exit /b 1


### PR DESCRIPTION
## Summary
- add a flag-based batch script that stores a marker file after installing dependencies and skips later checks
- add a registry-based batch script that records setup state in HKCU and bypasses repeated bootstrapping
- document troubleshooting guidance for marker corruption, permission issues, and manual resets

## Testing
- not run (documentation and scripts only)


------
https://chatgpt.com/codex/tasks/task_e_68d434b760bc8328932313ce28acd02b