### PR TITLE
Allow running the app on Python 3.9

### DIFF
--- a/product_research_app/api/config.py
+++ b/product_research_app/api/config.py
@@ -1,5 +1,6 @@
 from flask import request, jsonify, current_app
 import time
+from typing import Optional
 
 from . import app
 
@@ -17,7 +18,7 @@ from product_research_app.services.config import (
 from product_research_app.config import DEFAULT_WINNER_ORDER
 
 
-def _coerce_weights(raw: dict | None) -> dict[str, int]:
+def _coerce_weights(raw: Optional[dict]) -> dict[str, int]:
     out: dict[str, int] = {}
     for k, v in (raw or {}).items():
         if k not in ALLOWED_FIELDS:
@@ -30,7 +31,7 @@ def _coerce_weights(raw: dict | None) -> dict[str, int]:
     return out
 
 
-def _merge_winner_weights(current: dict | None, incoming: dict | None) -> dict:
+def _merge_winner_weights(current: Optional[dict], incoming: Optional[dict]) -> dict:
     cur = dict(current or {})
     cur.update(incoming or {})
     return cur
@@ -59,7 +60,7 @@ def _sanitize_enabled(raw_enabled, keys: list[str]) -> dict[str, bool]:
         return {k: True for k in keys}
     return {k: bool(raw_enabled.get(k, True)) for k in keys}
 
-def _apply_reset(settings: dict | None = None) -> dict:
+def _apply_reset(settings: Optional[dict] = None) -> dict:
     cfg = dict(settings or load_settings() or {})
     default_weights = get_default_winner_weights()
     cfg["winner_weights"] = dict(default_weights)

--- a/product_research_app/database.py
+++ b/product_research_app/database.py
@@ -834,7 +834,7 @@ def delete_list(
     conn: sqlite3.Connection,
     list_id: int,
     mode: str = "remove",
-    target_list_id: int | None = None,
+    target_list_id: Optional[int] = None,
 ) -> dict:
     """Delete a list with options to detach or move products.
 

--- a/product_research_app/gpt.py
+++ b/product_research_app/gpt.py
@@ -81,7 +81,7 @@ class InvalidJSONError(OpenAIError):
     pass
 
 
-def _dumps_payload(payload: Any | None) -> str:
+def _dumps_payload(payload: Optional[Any]) -> str:
     data = {} if payload is None else payload
     return json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)
 

--- a/product_research_app/prompts/registry.py
+++ b/product_research_app/prompts/registry.py
@@ -6,7 +6,7 @@ prompt_version = "prompt-maestro-v3".
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 PROMPT_VERSION = "prompt-maestro-v3"
 PROMPT_RELEASE_DATE = "2024-09-15"
@@ -174,7 +174,7 @@ def is_json_only(task: str) -> bool:
     return JSON_ONLY.get(canonical, False)
 
 
-def get_json_schema(task: str) -> Dict[str, Any] | None:
+def get_json_schema(task: str) -> Optional[Dict[str, Any]]:
     """Return the JSON schema associated with a task, if any."""
     canonical = _normalize_task(task)
     return JSON_SCHEMAS.get(canonical)

--- a/product_research_app/routes_export_minimal.py
+++ b/product_research_app/routes_export_minimal.py
@@ -13,7 +13,7 @@ import threading
 import time
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
 
 import pandas as pd
 import requests
@@ -77,7 +77,7 @@ def next_export_id() -> int:
         return current
 
 
-def build_export_filename(base_dir: os.PathLike[str] | str) -> Path:
+def build_export_filename(base_dir: Union[os.PathLike[str], str]) -> Path:
     base_path = Path(base_dir)
     try:
         base_path.mkdir(parents=True, exist_ok=True)

--- a/product_research_app/services/config.py
+++ b/product_research_app/services/config.py
@@ -1,6 +1,6 @@
 import time
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from ..config import load_config, save_config, DEFAULT_WINNER_ORDER
 
@@ -29,7 +29,7 @@ def get_default_winner_weights() -> Dict[str, int]:
 DB_PATH = Path(__file__).resolve().parents[1] / "data.sqlite3"
 
 
-def _coerce_weights(raw: Dict[str, object] | None) -> Dict[str, int]:
+def _coerce_weights(raw: Optional[Dict[str, object]]) -> Dict[str, int]:
     out: Dict[str, int] = {}
     for k, v in (raw or {}).items():
         try:
@@ -216,7 +216,9 @@ def set_weights_enabled_raw(enabled: Dict[str, object]) -> Dict[str, bool]:
 
 
 # Útil para logs/cálculo: pesos efectivos enteros 0..100 considerando prioridad
-def compute_effective_int(weights_raw: Dict[str, int], order: List[str] | None = None) -> Dict[str, int]:
+def compute_effective_int(
+    weights_raw: Dict[str, int], order: Optional[List[str]] = None
+) -> Dict[str, int]:
     from . import winner_score  # lazy to avoid circular import
 
     eff = winner_score.compute_effective_weights(weights_raw, order or list(weights_raw.keys()))

--- a/product_research_app/services/trends_service.py
+++ b/product_research_app/services/trends_service.py
@@ -3,7 +3,7 @@ import logging
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from .. import database
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 DB_PATH = Path(__file__).resolve().parents[1] / "data.sqlite3"
 
 
-def _parse_extra(extra: str | bytes | None) -> Dict[str, Any]:
+def _parse_extra(extra: Optional[Union[str, bytes]]) -> Dict[str, Any]:
     if not extra:
         return {}
     try:

--- a/product_research_app/services/winner_weights_from_aggregates.py
+++ b/product_research_app/services/winner_weights_from_aggregates.py
@@ -26,7 +26,7 @@ additional transformations.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from . import winner_score as winner_calc
 
@@ -63,7 +63,7 @@ COVERAGE_THRESHOLD = 0.35
 LOW_COVERAGE_MAX_WEIGHT = 15
 
 
-def _to_float(value: Any) -> float | None:
+def _to_float(value: Any) -> Optional[float]:
     try:
         if value is None:
             return None
@@ -76,7 +76,7 @@ def _clamp(value: float, low: float, high: float) -> float:
     return max(low, min(high, value))
 
 
-def _extract_metrics(payload: Dict[str, Any] | None) -> Dict[str, Dict[str, Any]]:
+def _extract_metrics(payload: Optional[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
     """Return the metrics block from an aggregates payload."""
 
     if not isinstance(payload, dict):
@@ -99,7 +99,7 @@ def _extract_metrics(payload: Dict[str, Any] | None) -> Dict[str, Dict[str, Any]
     return filtered
 
 
-def _distribution_position(stats: Dict[str, Any]) -> float | None:
+def _distribution_position(stats: Dict[str, Any]) -> Optional[float]:
     min_v = _to_float(stats.get("min"))
     max_v = _to_float(stats.get("max"))
     if min_v is None or max_v is None or max_v <= min_v:
@@ -167,7 +167,7 @@ def _zero_result(note: str) -> Dict[str, Any]:
     }
 
 
-def calculate_weights_from_aggregates(payload: Dict[str, Any] | None) -> Dict[str, Any]:
+def calculate_weights_from_aggregates(payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Derive Winner Score weights from aggregate statistics."""
 
     metrics = _extract_metrics(payload)

--- a/product_research_app/utils/__init__.py
+++ b/product_research_app/utils/__init__.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import re
+from typing import Optional
 
 FLAME = "\U0001F525"
 _FLAMES_RE = re.compile(rf"{FLAME}+$")
 
 
-def sanitize_product_name(name: str | None):
+def sanitize_product_name(name: Optional[str]):
     """Remove trailing flame emojis from product names."""
 
     if not isinstance(name, str):


### PR DESCRIPTION
## Summary
- replace PEP 604 union type hints with typing.Optional/Union so the codebase imports under Python 3.9
- update helper signatures across services, API, and utilities without changing runtime behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4786c228c8328b8ea5dfd87cb03a1