### PR TITLE
Replace macOS launcher script

### DIFF
--- a/mac_run_app.command
+++ b/mac_run_app.command
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# ===== Config base (proyecto puede estar en USB solo-lectura) =====
+# ====== Config (proyecto puede estar en USB solo-lectura) ======
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
@@ -14,18 +14,36 @@ HASH_FILE="$VENV_DIR/.req.sha256"
 PY_PATH_FILE="$VENV_DIR/.py.path"
 mkdir -p "$STATE_DIR" "$LOG_DIR"
 
-# Quitar cuarentena si viene de Descargas
+# Quitar cuarentena si vino de Descargas
 xattr -d com.apple.quarantine "$0" 2>/dev/null || true
 
-# ===== Utilidades =====
+# ====== Utilidades ======
 bold() { printf "\033[1m%s\033[0m" "$*"; }
 msg()  { printf "\033[1;34m[mac_run]\033[0m %s\n" "$*"; }
 err()  { printf "\033[1;31m[mac_run ERROR]\033[0m %s\n" "$*" >&2; }
 
+# Spinner/heartbeat para evitar apariencia de cuelgue
+run_with_spinner() {
+  local -a cmd=("$@")
+  "${cmd[@]}" &
+  local pid=$!
+  local spin='-\|/'
+  local i=0
+  while kill -0 "$pid" 2>/dev/null; do
+    i=$(( (i+1) % 4 ))
+    printf "\r\033[1;34m[mac_run]\033[0m %s trabajando..." "${spin:$i:1}"
+    sleep 0.3
+  done
+  printf "\r"
+  wait "$pid"
+}
+
 require_clt() {
+  # CLT instaladas si xcode-select devuelve ruta válida
   if xcode-select -p >/dev/null 2>&1; then return 0; fi
   err "Faltan las Command Line Tools de Xcode."
-  printf "%s\n" "Ejecuta en una terminal aparte: $(bold "xcode-select --install") y cuando finalice, vuelve a lanzar este script."
+  printf "%s\n" "Ejecuta en una terminal aparte: $(bold "xcode-select --install")"
+  printf "%s\n" "Cuando termine la instalación, vuelve a lanzar este script."
   exit 1
 }
 
@@ -38,8 +56,7 @@ ensure_brew() {
     eval "$(brew shellenv)"
     return 0
   fi
-
-  msg "Instalando Homebrew (esto puede abrir prompts del sistema)..."
+  msg "Instalando Homebrew (puede requerir confirmación del sistema)..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
   if command -v brew >/dev/null 2>&1; then
@@ -61,8 +78,7 @@ persist_path_line() {
   grep -Fqs "$line" "$file" || printf "%s\n" "$line" >> "$file"
 }
 
-ensure_py311() {
-  # Intentar un Python >=3.10 ya disponible
+detect_py_ge310() {
   local cand
   for cand in \
     "${PYTHON_BIN:-}" \
@@ -84,45 +100,54 @@ ensure_py311() {
       fi
     fi
   done
+  return 1
+}
 
-  # No hay >=3.10 → Brew python@3.11
+ensure_py311() {
+  local py
+  if py="$(detect_py_ge310)"; then
+    echo "$py"; return 0
+  fi
   ensure_brew
-  msg "Instalando python@3.11 con Homebrew..."
-  brew list python@3.11 >/dev/null 2>&1 || brew install python@3.11
-
-  local prefix py
+  msg "Instalando python@3.11 con Homebrew (esto puede tardar, mostrando progreso)..."
+  # Usamos spinner para feedback visual mientras brew trabaja
+  run_with_spinner brew install python@3.11
+  local prefix pybin
   prefix="$(brew --prefix)"
-  # Priorizar en ESTA sesión y persistir para las siguientes
   eval "$(brew shellenv)"
-  persist_path_line "eval \"\$(brew shellenv)\""
+  persist_path_line "eval \"$(brew shellenv)\""
   persist_path_line "export PATH=\"$prefix/opt/python@3.11/bin:\$PATH\""
   export PATH="$prefix/opt/python@3.11/bin:$PATH"
-
-  if [[ -x "$prefix/opt/python@3.11/bin/python3.11" ]]; then
-    py="$prefix/opt/python@3.11/bin/python3.11"
-  else
-    py="$(command -v python3.11 || true)"
+  pybin="$prefix/opt/python@3.11/bin/python3.11"
+  if [[ ! -x "$pybin" ]]; then
+    pybin="$(command -v python3.11 || true)"
   fi
-  [[ -x "$py" ]] || { err "python3.11 no encontrado tras brew."; exit 1; }
-  echo "$py"
+  [[ -x "$pybin" ]] || { err "python3.11 no encontrado tras brew."; exit 1; }
+  echo "$pybin"
 }
 
 wait_for_url() {
   local url="${1:-http://127.0.0.1:8000}"
-  local max="${2:-30}"
+  local max="${2:-40}"
+  local code="000"
   for ((i=1; i<=max; i++)); do
-    if curl -fsS "$url" >/dev/null 2>&1; then return 0; fi
+    code="$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo 000)"
+    # Considera 2xx, 3xx y 4xx como “arriba” (al menos hay servidor)
+    if [[ "$code" != "000" && "$code" != "000" && "$code" -ge 200 && "$code" -lt 500 ]]; then
+      return 0
+    fi
     sleep 1
   done
   return 1
 }
 
-# ===== Flujo =====
+# ====== Flujo principal ======
 require_clt
+
 PY_BIN="$(ensure_py311)"
 msg "Usando Python: $PY_BIN ($("$PY_BIN" -V 2>/dev/null || true))"
 
-# Venv: recrear si no existe, cambió intérprete o es <3.10
+# Rehacer venv si no existe, si cambió intérprete o si es <3.10
 needs_rebuild=0
 if [[ ! -x "$VENV_DIR/bin/python" ]]; then
   needs_rebuild=1
@@ -134,6 +159,7 @@ import sys
 raise SystemExit(0 if sys.version_info[:2] >= (3,10) else 1)
 PY
 fi
+
 if [[ "$needs_rebuild" -eq 1 ]]; then
   msg "Creando venv con $PY_BIN ..."
   rm -rf "$VENV_DIR"
@@ -145,7 +171,7 @@ fi
 source "$VENV_DIR/bin/activate"
 printf "%s" "$PY_BIN" > "$PY_PATH_FILE"
 
-# Deps: solo si cambia requirements o se reconstruye venv
+# Instalar deps solo si cambia requirements o se rehace venv
 calc_hash() { [[ -f "$REQ_FILE" ]] && shasum -a 256 "$REQ_FILE" | awk '{print $1}'; }
 old="$(cat "$HASH_FILE" 2>/dev/null || true)"
 new="$(calc_hash || true)"
@@ -160,11 +186,11 @@ fi
 
 export PYTHONUNBUFFERED=1
 
-# URL destino (variable para personalizar, por defecto 8000)
+# URL a abrir (cámbiala exportando APP_URL si tu servidor no usa 8000)
 APP_URL="${APP_URL:-http://127.0.0.1:8000}"
 
-# Abrir navegador cuando esté arriba
-( wait_for_url "$APP_URL" 40 && open -g "$APP_URL" ) >/dev/null 2>&1 &
+# Abrir navegador solo cuando responda el servidor (2xx–4xx)
+( msg "Esperando a $APP_URL ..."; if wait_for_url "$APP_URL" 60; then open -g "$APP_URL"; else msg "No se pudo verificar $APP_URL; puedes abrirlo manualmente."; fi ) >/dev/null 2>&1 &
 
 msg "Lanzando product_research_app..."
 python -u -m product_research_app 2>&1 | tee "$LOG_DIR/session.log"


### PR DESCRIPTION
## Summary
- replace the macOS launcher with the new script that checks Command Line Tools, installs python@3.11 via Homebrew with spinner feedback, and persists PATH updates
- ensure the launcher rebuilds the app virtual environment only when necessary and reuses dependency hashes before starting the app server

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d486f0b0b4832888fa3c1980d4236d