### PR TITLE
Update desire pipeline to support long-form statements

### DIFF
--- a/product_research_app/prompts/registry.py
+++ b/product_research_app/prompts/registry.py
@@ -32,27 +32,27 @@ Fallbacks globales:
 - No puedes garantizar estructura: "ERROR: formato"
 """
 
-PROMPT_DESIRE = """TAREA DESIRE — Extracción de Deseo (v4.1, micro-párrafo)
-Objetivo: inferir el deseo dominante y su fuerza a partir de ### CONTEXT_JSON y/o ### DATA.
+PROMPT_DESIRE = """TAREA DESIRE — Extracción de Deseo (v4.2-L)
+Objetivo: inferir el deseo dominante y su fuerza a partir de ### CONTEXT_JSON y/o ### DATA. Usa SOLO el material provisto.
 
-Marco de instintos (elige 1): health | sex | status | belonging | control | comfort
-Magnitud = media de 3 dimensiones (0–100): scope, urgency, staying_power
+Instinto (elige 1): health | sex | status | belonging | control | comfort
+Magnitud: media de {scope, urgency, staying_power} (0–100)
 Awareness: problem | solution | product | most
 Competencia: low | mid | high
-Estacionalidad (heurística): window ∈ {jan, feb, mar_apr, may, jun, jul_aug, sep, oct, nov, dec}
+Estacionalidad: window ∈ {jan, feb, mar_apr, may, jun, jul_aug, sep, oct, nov, dec}
 
-Desire statement — reglas de redacción:
-- Extensión: 220–320 caracteres, 2–4 frases cortas (o cláusulas con “;”).
-- Contenido: resultado funcional + beneficio emocional + micro-escena de uso + mini-objeción neutralizada/diferenciador.
-- Estilo telegráfico, sin hype ni claims médicos/ilegales; evita marca y tecnicismos innecesarios.
+DESIRE STATEMENT — reglas:
+- EXTENSIÓN OBLIGATORIA: entre 220 y 360 caracteres. Si quedas corto, añade cláusulas concisas separadas por “;”.
+- Forma: 2–4 frases cortas que incluyan: resultado funcional + beneficio emocional + micro-escena de uso + diferenciador/objeción neutralizada.
+- Estilo telegráfico, sin hype, sin claims médicos/ilegales, sin marcas.
 
-signals: 3–8 tokens o rasgos del input que respalden el deseo (palabras/atributos/beneficios).
+signals: 3–8 tokens/rasgos del input que respalden el deseo.
 
-Salida JSON estricta:
+SALIDA JSON estricta:
 {
   "prompt_version": "prompt-maestro-v4",
   "desire_primary": "<health|sex|status|belonging|control|comfort>",
-  "desire_statement": "<=320 chars",
+  "desire_statement": "<=360 chars, >=220 chars",
   "desire_magnitude": {
     "scope": <0-100>, "urgency": <0-100>, "staying_power": <0-100>, "overall": <0-100>
   },
@@ -63,11 +63,10 @@ Salida JSON estricta:
   "elevation_strategy": "<=140 chars",
   "signals": ["<token>", "..."]
 }
-
 Reglas:
 - "overall" = round((scope+urgency+staying_power)/3).
-- Si faltan señales → signals=[], y usa "SIN DATOS" en statement y reason.
-- No añadas campos. No navegues; usa SOLO el material provisto."""
+- Sin señales → signals=[], y usa "SIN DATOS" en statement y reason.
+- No añadas campos ni comentarios."""
 
 PROMPT_A = """TAREA A — Radiografía del mercado\nObjetivo: sintetizar oportunidades y riesgos clave del dataset recibido.\nUsa exclusivamente ### CONTEXT_JSON.\n\nLímites:\n- Diagnóstico: 2–3 frases (≤80 palabras)\n- Oportunidades: hasta 3 viñetas\n- Riesgos: ≥1 viñeta\n- Próximos pasos: 2–3 acciones\n\nFormato:\nDiagnóstico\nHallazgos\nRiesgos\nPróximos pasos\nprompt_version: prompt-maestro-v4\n\nFallbacks:\n- <1 producto válido: “SIN DATOS” y listas vacías.\n- JSON ilegible: “ERROR: entrada inválida”."""
 
@@ -224,7 +223,8 @@ JSON_SCHEMAS: Dict[str, Dict[str, Any]] = {
                 },
                 "desire_statement": {
                     "type": "string",
-                    "maxLength": 320,
+                    "minLength": 220,
+                    "maxLength": 360,
                 },
                 "desire_magnitude": {
                     "type": "object",

--- a/product_research_app/services/ai_columns.py
+++ b/product_research_app/services/ai_columns.py
@@ -11,7 +11,7 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
 import httpx
 
@@ -24,7 +24,14 @@ APP_DIR = Path(__file__).resolve().parent.parent
 DB_PATH = APP_DIR / "data.sqlite3"
 CALIBRATION_CACHE_FILE = APP_DIR / "ai_calibration_cache.json"
 
-AI_FIELDS = ("desire", "desire_magnitude", "awareness_level", "competition_level")
+AI_FIELDS = (
+    "desire",
+    "desire_primary",
+    "ai_desire_label",
+    "desire_magnitude",
+    "awareness_level",
+    "competition_level",
+)
 StatusCallback = Callable[..., None]
 
 
@@ -89,13 +96,15 @@ class _AsyncRateLimiter:
 
 SYSTEM_PROMPT = (
     "Eres un analista de marketing. Devuelve únicamente un JSON con claves de producto. "
-    "Cada valor debe incluir desire (string corta), desire_magnitude (Low|Medium|High), "
+    "Cada valor debe incluir desire_statement (micro-párrafo 220-360 caracteres), desire_primary "
+    "(health|sex|status|belonging|control|comfort), desire_magnitude (Low|Medium|High), "
     "awareness_level (Unaware|Problem-Aware|Solution-Aware|Product-Aware|Most Aware) y "
     "competition_level (Low|Medium|High)."
 )
 USER_INSTRUCTION = (
     "Analiza los siguientes productos y responde solo con un JSON cuyas claves sean los IDs. "
-    "Cada entrada debe incluir desire, desire_magnitude, awareness_level y competition_level."
+    "Cada entrada debe incluir desire_statement, desire_primary, desire_magnitude, "
+    "awareness_level y competition_level. Usa únicamente la información proporcionada."
 )
 
 
@@ -631,8 +640,49 @@ async def _call_batch_with_retries(
                     if not isinstance(entry, dict):
                         ko[pid] = "missing"
                         continue
+                    desire_statement_raw = entry.get("desire_statement")
+                    desire_statement = (
+                        str(desire_statement_raw).strip()
+                        if isinstance(desire_statement_raw, str)
+                        else None
+                    )
+                    desire_raw = entry.get("desire")
+                    desire_text = (
+                        str(desire_raw).strip()
+                        if isinstance(desire_raw, str)
+                        else None
+                    )
+                    desire_value = desire_statement or desire_text or ""
+                    if isinstance(desire_value, str):
+                        desire_value = desire_value.strip()
+                    desire_primary_raw = entry.get("desire_primary")
+                    desire_primary = (
+                        str(desire_primary_raw).strip()
+                        if isinstance(desire_primary_raw, str)
+                        else None
+                    )
+                    if desire_primary == "":
+                        desire_primary = None
+                    ai_label_raw = entry.get("ai_desire_label")
+                    ai_label = (
+                        str(ai_label_raw).strip()
+                        if isinstance(ai_label_raw, str)
+                        else None
+                    )
+                    if ai_label == "":
+                        ai_label = None
+                    if not ai_label:
+                        if desire_primary:
+                            ai_label = desire_primary
+                        else:
+                            label_source = desire_statement or desire_text or ""
+                            label = " ".join(str(label_source).split()[:8]).strip()
+                            ai_label = label or None
                     ok[pid] = {
-                        "desire": entry.get("desire"),
+                        "desire": desire_value,
+                        "desire_statement": desire_statement,
+                        "desire_primary": desire_primary,
+                        "ai_desire_label": ai_label,
                         "desire_magnitude": gpt._norm_tri(entry.get("desire_magnitude")),
                         "awareness_level": gpt._norm_awareness(entry.get("awareness_level")),
                         "competition_level": gpt._norm_tri(entry.get("competition_level")),
@@ -974,12 +1024,23 @@ def run_ai_fill_job(
             if not cache_row:
                 remaining.append(cand)
                 continue
+            cache_dict = dict(cache_row)
             update_payload = {
-                "desire": cache_row["desire"],
-                "desire_magnitude": cache_row["desire_magnitude"],
-                "awareness_level": cache_row["awareness_level"],
-                "competition_level": cache_row["competition_level"],
+                "desire": (cache_dict.get("desire") or ""),
+                "desire_statement": (cache_dict.get("desire") or ""),
+                "desire_primary": cache_dict.get("desire_primary"),
+                "ai_desire_label": cache_dict.get("ai_desire_label"),
+                "desire_magnitude": cache_dict.get("desire_magnitude"),
+                "awareness_level": cache_dict.get("awareness_level"),
+                "competition_level": cache_dict.get("competition_level"),
             }
+            if not update_payload.get("ai_desire_label"):
+                primary = update_payload.get("desire_primary")
+                if primary:
+                    update_payload["ai_desire_label"] = primary
+                else:
+                    label = " ".join(str(update_payload.get("desire", "")).split()[:8]).strip()
+                    update_payload["ai_desire_label"] = label or None
             cached_updates[cand.id] = update_payload
             applied_outputs[cand.id] = {k: v for k, v in update_payload.items() if v is not None}
             if cand.sig_hash:
@@ -989,6 +1050,8 @@ def run_ai_fill_job(
                     model=model,
                     version=cache_version,
                     desire=update_payload.get("desire"),
+                    desire_primary=update_payload.get("desire_primary"),
+                    ai_desire_label=update_payload.get("ai_desire_label"),
                     desire_magnitude=update_payload.get("desire_magnitude"),
                     awareness_level=update_payload.get("awareness_level"),
                     competition_level=update_payload.get("competition_level"),
@@ -1410,6 +1473,8 @@ def run_ai_fill_job(
                 model=model,
                 version=cache_version,
                 desire=updates.get("desire"),
+                desire_primary=updates.get("desire_primary"),
+                ai_desire_label=updates.get("ai_desire_label"),
                 desire_magnitude=updates.get("desire_magnitude"),
                 awareness_level=updates.get("awareness_level"),
                 competition_level=updates.get("competition_level"),
@@ -1462,6 +1527,61 @@ def run_ai_fill_job(
         "skipped_existing": skipped_existing,
         "total_requested": len(requested_ids),
     }
+
+
+def backfill_desire_long(
+    rows: Sequence[Mapping[str, Any]], *, job_id: Optional[int] = None
+) -> Dict[str, Any]:
+    """Re-run DESIRE task for items lacking a long-form statement."""
+
+    def _normalize_text(value: Any) -> Optional[str]:
+        if isinstance(value, str):
+            text = value.strip()
+            return text or None
+        return None
+
+    missing_ids: List[int] = []
+    seen: set[int] = set()
+    for item in rows:
+        if not isinstance(item, Mapping):
+            continue
+        pid = item.get("id") or item.get("product_id")
+        try:
+            pid_int = int(pid)
+        except Exception:
+            continue
+        if pid_int in seen:
+            continue
+        seen.add(pid_int)
+        desire_statement = _normalize_text(item.get("desire_statement"))
+        desire_text = _normalize_text(item.get("desire"))
+        if desire_statement and len(desire_statement) >= 220:
+            continue
+        if desire_text and len(desire_text) >= 220:
+            continue
+        missing_ids.append(pid_int)
+
+    if not missing_ids:
+        empty_counts: Dict[str, Any] = {
+            "queued": 0,
+            "sent": 0,
+            "ok": 0,
+            "ko": 0,
+            "cached": 0,
+            "retried": 0,
+            "cost_spent_usd": 0.0,
+        }
+        return {
+            "counts": empty_counts,
+            "pending_ids": [],
+            "error": None,
+            "ok": {},
+            "ko": {},
+            "skipped_existing": 0,
+            "total_requested": 0,
+        }
+
+    return run_ai_fill_job(job_id or 0, missing_ids)
 
 
 def fill_ai_columns(

--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -1048,6 +1048,13 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
   word-break: break-word;
   line-height: 1.25;
 }
+.desire-cell {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  white-space: normal;
+}
 /* Editor multi-línea para Desire */
 .desire-editor {
   width: 100%;

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -901,6 +901,7 @@ function renderTable() {
       if (col.minWidth) td.style.minWidth = col.minWidth + 'px';
       if (col.maxWidth) td.style.maxWidth = col.maxWidth + 'px';
       if (col.align) td.style.textAlign = col.align;
+      if (key === 'desire') td.classList.add('desire-cell');
       let value = '';
       if (key === 'desire') {
         // La columna textual "Desire" NUNCA debe tratarse como métrica
@@ -969,9 +970,9 @@ function renderTable() {
         }
       } else if (key === 'desire') {
         let current = value || '';
-        td.title = current;
         const render = () => {
           td.innerHTML = '';
+          td.title = current;
           const wrap = document.createElement('div');
           wrap.className = 'desire-wrap';
           wrap.textContent = current;

--- a/product_research_app/static/js/completar-ia.js
+++ b/product_research_app/static/js/completar-ia.js
@@ -44,6 +44,31 @@ function applyUpdates(product, updates) {
     }
     applied[k] = nv;
   });
+  if ('desire_statement' in updates) {
+    product.desire_statement = updates.desire_statement;
+    if (!('desire' in applied) && typeof updates.desire_statement === 'string') {
+      product.desire = updates.desire_statement;
+    }
+  }
+  if ('desire_primary' in updates) {
+    product.desire_primary = updates.desire_primary;
+  }
+  if ('ai_desire_label' in updates) {
+    product.ai_desire_label = updates.ai_desire_label;
+  }
+  if (row) {
+    const nextText =
+      ('desire' in applied ? applied.desire : null) ??
+      (typeof updates.desire_statement === 'string' ? updates.desire_statement : null);
+    if (typeof nextText === 'string') {
+      const cell = row.querySelector('td.ec-col-desire');
+      if (cell) {
+        cell.title = nextText;
+        const wrap = cell.querySelector('.desire-wrap');
+        if (wrap) wrap.textContent = nextText;
+      }
+    }
+  }
   if (Object.keys(applied).length) {
     fetch(`/products/${product.id}`, {
       method: 'PUT',

--- a/product_research_app/tests/test_prompts_registry.py
+++ b/product_research_app/tests/test_prompts_registry.py
@@ -51,6 +51,9 @@ def test_json_schema_task_e_auto() -> None:
 def test_json_schema_task_desire() -> None:
     schema = registry.get_json_schema("DESIRE")
     assert schema is not None
+    statement = schema["schema"]["properties"]["desire_statement"]
+    assert statement["minLength"] == 220
+    assert statement["maxLength"] == 360
     magnitude = schema["schema"]["properties"]["desire_magnitude"]
     for key in ["scope", "urgency", "staying_power", "overall"]:
         bounds = magnitude["properties"][key]

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -1239,6 +1239,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                     "price": price_val,
                     "image_url": rget(p, "image_url"),
                     "desire": desire_val,
+                    "desire_primary": rget(p, "desire_primary"),
+                    "ai_desire_label": rget(p, "ai_desire_label"),
                     "desire_magnitude": rget(p, "desire_magnitude"),
                     "awareness_level": rget(p, "awareness_level"),
                     "competition_level": rget(p, "competition_level"),
@@ -1376,6 +1378,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                         "price": p["price"],
                         "image_url": p["image_url"],
                         "desire": desire_val,
+                        "desire_primary": rget(p_dict, "desire_primary"),
+                        "ai_desire_label": rget(p_dict, "ai_desire_label"),
                         "desire_magnitude": rget(p_dict, "desire_magnitude"),
                         "extras": extra_dict,
                     }


### PR DESCRIPTION
## Summary
- update the DESIRE prompt template and schema to require 220–360 character statements
- extend persistence and AI processing to prefer desire_statement text, including new desire_primary/ai_desire_label storage and a backfill helper
- clamp the Desire column to four lines with tooltips while propagating the richer desire data through the API and UI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d517fcd08c8328a3fb3721c11a03fe