### PR TITLE
Update DESIRE prompt to v6.2 and widen length

### DIFF
--- a/product_research_app/prompts/registry.py
+++ b/product_research_app/prompts/registry.py
@@ -25,6 +25,43 @@ PROMPT_E = """TAREA E — Resumen ejecutivo para decisión\nObjetivo: condensar 
 
 PROMPT_E_AUTO = """TAREA E_auto — Decisión automática sobre lotes de productos\nObjetivo: clasificar cada elemento del lote y generar acciones siguientes.\n\nInstrucciones:\n1. Lee la matriz en "### DATA" (cada elemento con métricas agregadas).\n2. Para cada elemento, determina estado ("aprobado", "revisar", "descartar") según señales.\n3. Calcula un "score" 0-100 y asigna un "confidence" 0-100.\n4. Resume en una frase el motivo y propone el "next_step" (texto o null si no aplica).\n5. Añade "signals" como lista de palabras clave que respaldan la decisión.\n\nSalida obligatoria: objeto JSON con\n{\n  "prompt_version": "prompt-maestro-v3",\n  "items": [\n    {\n      "id": <string|number>,\n      "status": "aprobado"|"revisar"|"descartar",\n      "score": <0-100>,\n      "confidence": <0-100>,\n      "summary": <string>,\n      "reason": <string|null>,\n      "next_step": <string|null>,\n      "signals": [<string>, ...]\n    }, ...\n  ]\n}\n\nReglas:\n- Respeta exactamente los nombres de las claves.\n- Mantén "signals" como lista (puede ir vacía).\n- No añadas campos adicionales ni texto fuera del JSON.\n\nFallbacks específicos:\n- Si "### DATA" está vacío, devuelve items como lista vacía y reason="SIN DATOS" en cada registro generado."""
 
+PROMPT_DESIRE = """TAREA DESIRE — Mass-Desire Triad (v6.2 • 3–4 líneas)
+Objetivo: redactar el DESEO HUMANO subyacente (no la cosa). Usa ###CONTEXT_JSON/###DATA y, si hay navegación disponible, puedes consultar hasta 5 fuentes para extraer señales (foros/reseñas/comentarios). Si no hay navegador, continúa con el input.
+
+Fundamento Evolve (compacto):
+- instincts: health|sex|status|belonging|control|comfort   # elige 1
+- tech_problems (0–1): complexity|overwhelm|fragility|maintenance|incompatibility|obsolescence
+- forces (opcional): style_trends|mass_education
+- overall = round((scope+urgency+staying_power)/3)
+
+DESIRE STATEMENT — reglas duras:
+- Longitud: 280–420 caracteres (≈3–4 líneas en UI). 2–4 frases o cláusulas “;”.
+- Estructura: resultado funcional + beneficio emocional + micro-escena de uso + fricción neutralizada (p. ej., sin tiempo extra/desorden) + matiz social/temporal si eleva el deseo.
+- Voz centrada en la persona: “quien busca… / personas que desean…”.
+- PROHIBIDO: marcas/modelos; nombres de producto o categoría (“crema”, “aspiradora”, “cuchillos”…); packs/cantidades; medidas (ml/W/cm); materiales; hype; claims médicos. Si aparecen, reescribe hasta eliminarlas.
+- Si el borrador queda <280 caracteres, añade cláusulas breves separadas por “;” hasta cumplir la longitud.
+
+Estacionalidad (calendario de deseo):
+- seasonality_hint.window ∈ {jan,feb,mar_apr,may,jun,jul_aug,sep,oct,nov,dec}; elige la ventana que mejor eleve el deseo según señales internas/externas.
+
+SALIDA JSON (estricta, sin texto extra):
+{
+  "prompt_version":"prompt-maestro-v4",
+  "desire_primary":"<health|sex|status|belonging|control|comfort>",
+  "desire_statement":"<=420, >=280",
+  "desire_magnitude":{"scope":0-100,"urgency":0-100,"staying_power":0-100,"overall":0-100},
+  "awareness_level":"<problem|solution|product|most>",
+  "competition_level":"<low|mid|high>",
+  "competition_reason":"<=140",
+  "seasonality_hint":{"window":"<jan|feb|mar_apr|may|jun|jul_aug|sep|oct|nov|dec>","confidence":0-100},
+  "elevation_strategy":"<=140",
+  "signals":["t1","t2","t3"]   // 1–3 tokens (pains/beneficios/evidencia: p.ej., “reddit-skin”, “amz-reviews”)
+}
+
+Reglas finales:
+- No añadas campos ni comentarios.
+- Sin navegador → incluye “no-browse” en signals cuando corresponda."""
+
 _TASK_PROMPTS: Dict[str, str] = {
     "A": PROMPT_A,
     "B": PROMPT_B,
@@ -32,6 +69,7 @@ _TASK_PROMPTS: Dict[str, str] = {
     "D": PROMPT_D,
     "E": PROMPT_E,
     "E_auto": PROMPT_E_AUTO,
+    "DESIRE": PROMPT_DESIRE,
 }
 
 JSON_ONLY: Dict[str, bool] = {
@@ -41,6 +79,7 @@ JSON_ONLY: Dict[str, bool] = {
     "D": False,
     "E": False,
     "E_auto": True,
+    "DESIRE": True,
 }
 
 _TASK_B_METRICS = [
@@ -133,6 +172,110 @@ JSON_SCHEMAS: Dict[str, Dict[str, Any]] = {
             },
         },
     },
+    "DESIRE": {
+        "name": "prompt_maestro_v4_task_desire",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": [
+                "prompt_version",
+                "desire_primary",
+                "desire_statement",
+                "desire_magnitude",
+                "awareness_level",
+                "competition_level",
+                "competition_reason",
+                "seasonality_hint",
+                "elevation_strategy",
+                "signals",
+            ],
+            "properties": {
+                "prompt_version": {"type": "string", "enum": ["prompt-maestro-v4"]},
+                "desire_primary": {
+                    "type": "string",
+                    "enum": [
+                        "health",
+                        "sex",
+                        "status",
+                        "belonging",
+                        "control",
+                        "comfort",
+                    ],
+                },
+                "desire_statement": {
+                    "type": "string",
+                    "minLength": 280,
+                    "maxLength": 420,
+                },
+                "desire_magnitude": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": [
+                        "scope",
+                        "urgency",
+                        "staying_power",
+                        "overall",
+                    ],
+                    "properties": {
+                        "scope": {"type": "number", "minimum": 0, "maximum": 100},
+                        "urgency": {"type": "number", "minimum": 0, "maximum": 100},
+                        "staying_power": {"type": "number", "minimum": 0, "maximum": 100},
+                        "overall": {"type": "number", "minimum": 0, "maximum": 100},
+                    },
+                },
+                "awareness_level": {
+                    "type": "string",
+                    "enum": ["problem", "solution", "product", "most"],
+                },
+                "competition_level": {
+                    "type": "string",
+                    "enum": ["low", "mid", "high"],
+                },
+                "competition_reason": {
+                    "type": "string",
+                    "maxLength": 140,
+                },
+                "seasonality_hint": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["window", "confidence"],
+                    "properties": {
+                        "window": {
+                            "type": "string",
+                            "enum": [
+                                "jan",
+                                "feb",
+                                "mar_apr",
+                                "may",
+                                "jun",
+                                "jul_aug",
+                                "sep",
+                                "oct",
+                                "nov",
+                                "dec",
+                            ],
+                        },
+                        "confidence": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 100,
+                        },
+                    },
+                },
+                "elevation_strategy": {
+                    "type": "string",
+                    "maxLength": 140,
+                },
+                "signals": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 0,
+                    "maxItems": 3,
+                },
+            },
+        },
+    },
 }
 
 
@@ -146,7 +289,7 @@ def _normalize_task(task: str) -> str:
     upper = normalized.upper()
     if upper == "E_AUTO" or upper == "EAUTO":
         return "E_auto"
-    if upper in {"A", "B", "C", "D", "E"}:
+    if upper in {"A", "B", "C", "D", "E", "DESIRE"}:
         return upper
     raise KeyError(f"Unknown task: {task}")
 
@@ -188,6 +331,7 @@ __all__ = [
     "PROMPT_D",
     "PROMPT_E",
     "PROMPT_E_AUTO",
+    "PROMPT_DESIRE",
     "PROMPT_VERSION",
     "PROMPT_RELEASE_DATE",
     "JSON_ONLY",


### PR DESCRIPTION
## Summary
- update the DESIRE task prompt to Mass-Desire Triad v6.2 with 3–4 line guidance
- increase the DESIRE schema length bounds to 280–420 characters

## Testing
- python - <<'PY'
from product_research_app.prompts.registry import get_task_prompt, get_json_schema, PROMPT_DESIRE
print(get_task_prompt('DESIRE') == PROMPT_DESIRE)
print(get_task_prompt('desire')[:120])
schema = get_json_schema('DESIRE')
print(schema['schema']['properties']['desire_statement'])
PY

------
https://chatgpt.com/codex/tasks/task_e_68d533916858832890d24ceefadd78ca