### PR TITLE
Add post-import audit workflow for critical product fields

### DIFF
--- a/product_research_app/services/audit_config.py
+++ b/product_research_app/services/audit_config.py
@@ -1,0 +1,33 @@
+"""Configuration for post-import audit of critical product fields."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+REQUIRED_FIELDS: dict[str, dict[str, Any]] = {
+    "desire": {"via": "DESIRE", "type": "text", "min_len": 280},
+    "desire_primary": {"via": "DESIRE", "type": "enum"},
+    "desire_magnitude": {"via": "DESIRE", "type": "object"},
+    "awareness_level": {"via": "DESIRE", "type": "enum"},
+    "competition_level": {"via": "DESIRE", "type": "enum"},
+    "ai_desire_label": {"via": "DERIVED", "type": "text", "from": "desire_primary"},
+}
+
+
+def should_fill(field: str, row: Mapping[str, Any]) -> bool:
+    """Return ``True`` if the audit should attempt to fill ``field``."""
+
+    value = row.get(field)
+    if field == "desire":
+        text = str(value or "").strip()
+        if not text:
+            return True
+        return len(text) < REQUIRED_FIELDS[field].get("min_len", 0)
+    if field == "ai_desire_label":
+        return value in (None, "")
+    if REQUIRED_FIELDS.get(field, {}).get("type") in {"enum", "object"}:
+        return value in (None, "")
+    return value in (None, "")
+
+
+__all__ = ["REQUIRED_FIELDS", "should_fill"]

--- a/product_research_app/services/post_import_audit.py
+++ b/product_research_app/services/post_import_audit.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from .. import database
+from . import ai_columns, audit_config
+from .desire_utils import cleanse, looks_like_product_desc
+
+logger = logging.getLogger(__name__)
+
+APP_DIR = Path(__file__).resolve().parent.parent
+DEFAULT_DB_PATH = APP_DIR / "data.sqlite3"
+
+
+def _coerce_conn(db: Any) -> Tuple[sqlite3.Connection, bool]:
+    if db is None:
+        return database.get_connection(DEFAULT_DB_PATH), True
+    if isinstance(db, (str, Path)):
+        return database.get_connection(Path(db)), True
+    if hasattr(db, "cursor"):
+        return db, False  # type: ignore[return-value]
+    candidate = getattr(db, "connection", None)
+    if candidate is not None and hasattr(candidate, "cursor"):
+        return candidate, False  # type: ignore[return-value]
+    raise TypeError("db must be a sqlite3.Connection, path or wrapper with .connection")
+
+
+def _get_product_columns(conn: sqlite3.Connection) -> set[str]:
+    cur = conn.execute("PRAGMA table_info(products)")
+    return {str(row[1]) for row in cur.fetchall()}
+
+
+def _count_products(conn: sqlite3.Connection, ids: Optional[Sequence[int]] = None) -> int:
+    cur = conn.cursor()
+    if ids:
+        uniq = sorted({int(pid) for pid in ids})
+        if not uniq:
+            return 0
+        placeholders = ",".join(["?"] * len(uniq))
+        cur.execute(f"SELECT COUNT(*) FROM products WHERE id IN ({placeholders})", tuple(uniq))
+    else:
+        cur.execute("SELECT COUNT(*) FROM products")
+    row = cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+def scan_missing(db: Any, ids: Optional[Sequence[int]] = None) -> Dict[int, List[str]]:
+    conn, should_close = _coerce_conn(db)
+    missing: Dict[int, List[str]] = {}
+    try:
+        for row in database.iter_products(conn, ids=ids):
+            data = {k: row[k] for k in row.keys()}  # type: ignore[attr-defined]
+            try:
+                pid = int(data.get("id"))
+            except Exception:
+                continue
+            to_fill: List[str] = []
+            for field in audit_config.REQUIRED_FIELDS.keys():
+                if audit_config.should_fill(field, data):
+                    to_fill.append(field)
+            if to_fill:
+                missing[pid] = to_fill
+    finally:
+        if should_close:
+            conn.close()
+    return missing
+
+
+def _prepare_desire_payload(
+    pid: int,
+    payload: Mapping[str, Any],
+    product_row: Mapping[str, Any],
+    columns: set[str],
+) -> Optional[Dict[str, Any]]:
+    title = str(product_row.get("name") or product_row.get("title") or "")
+    desire_txt = str(payload.get("desire") or "").strip()
+    if desire_txt:
+        cleaned = cleanse(desire_txt).strip()
+        if cleaned:
+            desire_txt = cleaned
+    if not desire_txt:
+        return None
+    if len(desire_txt) < 280 or len(desire_txt) > 420:
+        logger.info("audit: fail product=%s reason=desire_length", pid)
+        return None
+    if looks_like_product_desc(desire_txt, title):
+        logger.info("audit: fail product=%s reason=looks_like_product", pid)
+        return None
+
+    update: Dict[str, Any] = {}
+    if "desire" in columns:
+        update["desire"] = desire_txt
+
+    desire_primary = payload.get("desire_primary")
+    if desire_primary in ("", None):
+        desire_primary = None
+    if desire_primary and "desire_primary" in columns:
+        update["desire_primary"] = desire_primary
+
+    raw_magnitude = payload.get("desire_magnitude")
+    magnitude_obj: Optional[Dict[str, Any]] = None
+    if isinstance(raw_magnitude, Mapping):
+        magnitude_obj = {
+            "scope": raw_magnitude.get("scope"),
+            "urgency": raw_magnitude.get("urgency"),
+            "staying_power": raw_magnitude.get("staying_power"),
+            "overall": raw_magnitude.get("overall"),
+        }
+    elif isinstance(raw_magnitude, str):
+        try:
+            parsed = json.loads(raw_magnitude)
+            if isinstance(parsed, Mapping):
+                magnitude_obj = {
+                    "scope": parsed.get("scope"),
+                    "urgency": parsed.get("urgency"),
+                    "staying_power": parsed.get("staying_power"),
+                    "overall": parsed.get("overall"),
+                }
+        except json.JSONDecodeError:
+            magnitude_obj = None
+    if magnitude_obj and "desire_magnitude" in columns:
+        update["desire_magnitude"] = json.dumps(magnitude_obj)
+
+    awareness = payload.get("awareness_level")
+    if awareness and "awareness_level" in columns:
+        update["awareness_level"] = awareness
+
+    competition = payload.get("competition_level")
+    if competition and "competition_level" in columns:
+        update["competition_level"] = competition
+
+    ai_label = payload.get("ai_desire_label") or None
+    if not ai_label and desire_primary:
+        ai_label = str(desire_primary)
+    if not ai_label:
+        ai_label = " ".join(desire_txt.split()[:8]).strip()
+    if ai_label and "ai_desire_label" in columns:
+        update["ai_desire_label"] = ai_label
+
+    return update if update else None
+
+
+def fill_batch_desire(
+    db: Any,
+    ids: List[int],
+    *,
+    batch_size: int = 32,
+    parallel: int = 3,
+) -> None:
+    if not ids:
+        return
+    conn, should_close = _coerce_conn(db)
+    try:
+        columns = _get_product_columns(conn)
+        unique_ids = []
+        seen: set[int] = set()
+        for raw in ids:
+            try:
+                pid = int(raw)
+            except Exception:
+                continue
+            if pid in seen:
+                continue
+            unique_ids.append(pid)
+            seen.add(pid)
+        total = len(unique_ids)
+        for start in range(0, total, batch_size):
+            chunk = unique_ids[start : start + batch_size]
+            if not chunk:
+                continue
+            logger.info(
+                "audit: batch start %d..%d / total %d",
+                start + 1,
+                start + len(chunk),
+                total,
+            )
+            result = ai_columns.run_ai_fill_job(
+                0,
+                chunk,
+                microbatch=batch_size,
+                parallelism=parallel,
+                status_cb=None,
+            )
+            ok_map: Dict[str, Mapping[str, Any]] = result.get("ok", {}) or {}
+            ko_map: Dict[str, Any] = result.get("ko", {}) or {}
+            if ko_map:
+                for pid_str, reason in ko_map.items():
+                    try:
+                        pid = int(pid_str)
+                    except Exception:
+                        continue
+                    logger.info("audit: fail product=%s reason=%s", pid, reason or "error")
+            if not ok_map:
+                continue
+            product_rows = {
+                int(row["id"]): {k: row[k] for k in row.keys()}  # type: ignore[attr-defined]
+                for row in database.get_products_by_ids(conn, [int(pid) for pid in ok_map.keys()])
+            }
+            assignments: Dict[int, Dict[str, Any]] = {}
+            for pid_str, payload in ok_map.items():
+                try:
+                    pid = int(pid_str)
+                except Exception:
+                    continue
+                row = product_rows.get(pid)
+                if not row:
+                    continue
+                update_payload = _prepare_desire_payload(pid, payload, row, columns)
+                if update_payload:
+                    assignments[pid] = update_payload
+            if assignments:
+                cur = conn.cursor()
+                for pid, data in assignments.items():
+                    sets = ",".join(f"{key}=?" for key in data.keys())
+                    params = list(data.values())
+                    params.append(pid)
+                    cur.execute(f"UPDATE products SET {sets} WHERE id=?", params)
+                conn.commit()
+    finally:
+        if should_close:
+            conn.close()
+
+
+def derive_missing_locally(row: Dict[str, Any]) -> None:
+    current = str(row.get("ai_desire_label") or "").strip()
+    if current:
+        return
+    primary = row.get("desire_primary")
+    if not primary:
+        return
+    row["ai_desire_label"] = str(primary)
+
+
+def run_audit(
+    db: Any,
+    ids: Optional[Sequence[int]] = None,
+    batch_size: int = 32,
+    parallel: int = 3,
+    max_passes: int = 2,
+    logger_obj: Optional[Any] = None,
+) -> Dict[str, int]:
+    conn, should_close = _coerce_conn(db)
+    summary = {"checked": 0, "updated": 0, "skipped": 0, "failed": 0}
+    try:
+        total = _count_products(conn, ids)
+        summary["checked"] = total
+        initial_missing = scan_missing(conn, ids=ids)
+        summary["skipped"] = max(0, total - len(initial_missing))
+        current_missing = initial_missing
+        for attempt in range(max_passes):
+            if not current_missing:
+                break
+            desire_ids: List[int] = []
+            derived_ids: List[int] = []
+            for pid, fields in current_missing.items():
+                via_types = {audit_config.REQUIRED_FIELDS[f]["via"] for f in fields if f in audit_config.REQUIRED_FIELDS}
+                if "DESIRE" in via_types:
+                    desire_ids.append(pid)
+                elif via_types == {"DERIVED"}:
+                    derived_ids.append(pid)
+            if desire_ids:
+                for start in range(0, len(desire_ids), batch_size):
+                    chunk = desire_ids[start : start + batch_size]
+                    fill_batch_desire(
+                        conn,
+                        chunk,
+                        batch_size=min(batch_size, 32),
+                        parallel=parallel,
+                    )
+            if derived_ids:
+                rows = database.get_products_by_ids(conn, derived_ids)
+                cur = conn.cursor()
+                for row in rows:
+                    data = {k: row[k] for k in row.keys()}  # type: ignore[attr-defined]
+                    before = data.get("ai_desire_label")
+                    derive_missing_locally(data)
+                    after = data.get("ai_desire_label")
+                    if after and after != before:
+                        cur.execute(
+                            "UPDATE products SET ai_desire_label=? WHERE id=?",
+                            (after, int(data.get("id"))),
+                        )
+                conn.commit()
+            current_missing = scan_missing(conn, ids=ids)
+        final_missing = current_missing
+        summary["failed"] = len(final_missing)
+        summary["updated"] = max(0, len(initial_missing) - len(final_missing))
+        target_logger = logger_obj if logger_obj is not None else logger
+        try:
+            target_logger.info(
+                "audit: done checked=%s updated=%s failed=%s",
+                summary["checked"],
+                summary["updated"],
+                summary["failed"],
+            )
+        except Exception:
+            try:
+                globals()["logger"].info(
+                    "audit: done checked=%s updated=%s failed=%s",
+                    summary["checked"],
+                    summary["updated"],
+                    summary["failed"],
+                )
+            except Exception:
+                pass
+        return summary
+    finally:
+        if should_close:
+            conn.close()

--- a/product_research_app/static/js/completar-ia.js
+++ b/product_research_app/static/js/completar-ia.js
@@ -224,6 +224,76 @@ async function launchDesireBackfill(opts = {}) {
 
 window.launchDesireBackfill = launchDesireBackfill;
 
+async function launchAudit(opts = {}) {
+  const payload = {};
+  if (Array.isArray(opts.ids) && opts.ids.length) payload.ids = opts.ids;
+
+  let resp;
+  try {
+    resp = await fetch('/api/audit/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+  } catch (err) {
+    if (!opts.silent) toast.error(`Auditoría: ${err.message}`);
+    return null;
+  }
+  if (!resp.ok) {
+    let msg = resp.statusText || 'Error';
+    try {
+      const error = await resp.json();
+      if (error && error.error) msg = error.error;
+    } catch {}
+    if (!opts.silent) toast.error(`Auditoría: ${msg}`);
+    return null;
+  }
+  let data;
+  try { data = await resp.json(); } catch { data = {}; }
+  const taskId = data && data.task_id;
+  if (!taskId) {
+    if (!opts.silent) toast.error('Auditoría: sin task_id');
+    return null;
+  }
+  if (!opts.silent) toast.info('Auditoría iniciada');
+
+  const pollInterval = opts.pollInterval || 1500;
+  let finalStatus = null;
+
+  while (true) {
+    await new Promise(resolve => setTimeout(resolve, pollInterval));
+    let statusResp;
+    try {
+      statusResp = await fetch(`/_audit_status?task_id=${encodeURIComponent(taskId)}`);
+    } catch {
+      continue;
+    }
+    if (!statusResp.ok) continue;
+    let status;
+    try { status = await statusResp.json(); } catch { continue; }
+    if (!status) continue;
+    finalStatus = status;
+    if (status.status === 'error') {
+      if (!opts.silent) {
+        const msg = status.message || 'Error';
+        toast.error(`Auditoría: ${msg}`);
+      }
+      break;
+    }
+    if (status.status === 'done') {
+      break;
+    }
+  }
+
+  if (finalStatus && finalStatus.status === 'done') {
+    if (!opts.silent) toast.success('Auditoría completada');
+    if (typeof updateMasterState === 'function') updateMasterState();
+  }
+  return finalStatus;
+}
+
+window.launchAudit = launchAudit;
+
 window.handleCompletarIA = async function(opts = {}) {
   const ids = opts.ids;
   let all;


### PR DESCRIPTION
## Summary
- add an audit configuration module that lists required fields and a helper to detect missing values
- implement the post import audit service to scan products, call the existing DESIRE pipeline, and derive missing labels
- schedule the audit after imports, expose API endpoints to trigger and monitor it, and add a frontend helper to launch the process

## Testing
- python -m compileall product_research_app/services/post_import_audit.py product_research_app/services/audit_config.py product_research_app/services/importer_fast.py product_research_app/web_app.py product_research_app/static/js/completar-ia.js

------
https://chatgpt.com/codex/tasks/task_e_68d5530e00ec8328bed835d6dcb8152e