### PR TITLE
Add AI audit service and live SSE updates

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -135,10 +135,17 @@ def load_config() -> Dict[str, Any]:
 def save_config(config: Dict[str, Any]) -> None:
     """Persist configuration to disk atomically."""
 
+    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = CONFIG_FILE.with_suffix(".tmp")
     with open(tmp_path, "w", encoding="utf-8") as f:
         json.dump(config, f, ensure_ascii=False, indent=2)
-    tmp_path.replace(CONFIG_FILE)
+        f.flush()
+        os.fsync(f.fileno())
+    try:
+        tmp_path.replace(CONFIG_FILE)
+    except FileNotFoundError:
+        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+            json.dump(config, f, ensure_ascii=False, indent=2)
 
 
 def _merge_defaults(dst: Dict[str, Any], src: Dict[str, Any]) -> bool:

--- a/product_research_app/services/ai_audit.py
+++ b/product_research_app/services/ai_audit.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from .. import database
+from . import ai_columns
+from .desire_utils import looks_like_product_desc
+
+logger = logging.getLogger(__name__)
+
+
+REQUIRED_FIELDS: Dict[str, Dict[str, str]] = {
+    "desire": {"via": "DESIRE", "kind": "text", "min_len": 280},
+    "desire_primary": {"via": "DESIRE", "kind": "enum"},
+    "desire_magnitude": {"via": "DESIRE", "kind": "object"},
+    "awareness_level": {"via": "DESIRE", "kind": "enum"},
+    "competition_level": {"via": "DESIRE", "kind": "enum"},
+    "ai_desire_label": {"via": "DERIVED", "kind": "text"},
+}
+
+
+def _normalize_ids(ids: Optional[Sequence[int]]) -> Optional[List[int]]:
+    if ids is None:
+        return None
+    seen: set[int] = set()
+    result: List[int] = []
+    for raw in ids:
+        try:
+            num = int(raw)
+        except Exception:
+            continue
+        if num in seen:
+            continue
+        seen.add(num)
+        result.append(num)
+    result.sort()
+    return result
+
+
+def _coerce_json(value):
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text in {"null", "None"}:
+            return None
+        if text.startswith("{") or text.startswith("["):
+            try:
+                return json.loads(text)
+            except Exception:
+                return value
+    return value
+
+
+def _is_missing(value, kind: str) -> bool:
+    if kind == "text":
+        if value is None:
+            return True
+        if isinstance(value, str):
+            return not value.strip()
+        return False
+    if kind == "enum":
+        if value is None:
+            return True
+        if isinstance(value, str):
+            return not value.strip()
+        return False
+    if kind == "object":
+        if value in (None, "", {}):
+            return True
+        parsed = _coerce_json(value)
+        if parsed in (None, "", {}):
+            return True
+        if isinstance(parsed, dict):
+            if not parsed:
+                return True
+            overall = parsed.get("overall")
+            if isinstance(overall, str):
+                return not overall.strip()
+            return overall in (None, "", {})
+        return False
+    return value is None
+
+
+def needs_fill(row) -> bool:
+    data = dict(row)
+    desire_raw = data.get("desire")
+    desire_txt = (desire_raw or "").strip()
+    if not desire_txt or len(desire_txt) < REQUIRED_FIELDS["desire"]["min_len"]:
+        return True
+    title = (data.get("name") or "").strip()
+    try:
+        if looks_like_product_desc(desire_txt, title):
+            return True
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("looks_like_product_desc failed id=%s", data.get("id"))
+    for key, meta in REQUIRED_FIELDS.items():
+        if key == "desire":
+            continue
+        if _is_missing(data.get(key), meta["kind"]):
+            return True
+    return False
+
+
+def scan_ids(conn, ids: Optional[Sequence[int]] = None) -> List[int]:
+    target_ids = _normalize_ids(ids)
+    missing: List[int] = []
+    for row in database.iter_products(conn, target_ids):
+        try:
+            pid = int(row["id"])
+        except Exception:
+            continue
+        if needs_fill(row):
+            missing.append(pid)
+    return missing
+
+
+def run_fill_for_ids(
+    conn,
+    ids: Sequence[int],
+    *,
+    reason: str = "audit",
+) -> Dict[str, int]:
+    normalized = _normalize_ids(ids) or []
+    metrics = {"queued": len(normalized), "ok": 0, "ko": 0, "retried": 0}
+    if not normalized:
+        return metrics
+    result = ai_columns.run_ai_fill_job(
+        0,
+        normalized,
+        status_cb=None,
+        reason=reason,
+        commit_each=True,
+    )
+    counts = result.get("counts", {}) or {}
+    metrics["queued"] = int(counts.get("queued", len(normalized)))
+    metrics["ok"] = int(counts.get("ok", 0) + counts.get("cached", 0))
+    metrics["ko"] = int(counts.get("ko", 0))
+    metrics["retried"] = int(counts.get("retried", 0))
+    return metrics
+
+
+def _fill_ai_desire_labels(conn, ids: Optional[Iterable[int]]) -> int:
+    target_ids = _normalize_ids(list(ids) if ids is not None else None)
+    updated = 0
+    for row in database.iter_products(conn, target_ids):
+        try:
+            pid = int(row["id"])
+        except Exception:
+            continue
+        label = row.get("ai_desire_label")
+        primary = row.get("desire_primary")
+        if not primary or not str(primary).strip():
+            continue
+        if label and str(label).strip():
+            continue
+        value = str(primary).strip()
+        if not value:
+            continue
+        database.update_product(conn, pid, ai_desire_label=value)
+        try:
+            conn.commit()
+        except Exception:
+            logger.exception("commit failed while setting ai_desire_label pid=%s", pid)
+            continue
+        ai_columns.emit_update(pid, {"ai_desire_label": value}, reason="audit")
+        updated += 1
+    return updated
+
+
+def run_audit(conn, ids: Optional[Sequence[int]] = None) -> Dict[str, int]:
+    target_ids = _normalize_ids(ids)
+    label_updates = _fill_ai_desire_labels(conn, target_ids)
+    missing = scan_ids(conn, target_ids)
+    metrics = {"queued": len(missing), "ok": 0, "ko": 0, "retried": 0}
+    if missing:
+        metrics = run_fill_for_ids(conn, missing, reason="audit")
+        label_updates += _fill_ai_desire_labels(conn, missing)
+    summary = {
+        **metrics,
+        "missing": len(missing),
+        "label_updates": label_updates,
+    }
+    logger.info(
+        "ai_audit: ids=%s missing=%d ok=%d ko=%d retried=%d labels=%d",
+        "*" if target_ids is None else len(target_ids),
+        len(missing),
+        summary["ok"],
+        summary["ko"],
+        summary["retried"],
+        summary["label_updates"],
+    )
+    return summary

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -871,11 +871,13 @@ function renderTable() {
   // Render rows
   products.forEach(item => {
     const tr = document.createElement('tr');
+    tr.setAttribute('data-product-id', item.id);
     if (item.isDuplicate) {
       tr.classList.add('is-duplicate');
     }
     // Selection checkbox
     const tdSel = document.createElement('td');
+    tdSel.setAttribute('data-col', 'select');
     const cb = document.createElement('input');
     cb.type = 'checkbox';
     cb.classList.add('rowCheck');
@@ -895,6 +897,7 @@ function renderTable() {
       const td = document.createElement('td');
       const key = col.key;
       td.setAttribute('data-key', key);
+      td.setAttribute('data-col', key);
       if (col.cellClass) td.className = col.cellClass;
       if (col.dataEcCol) td.setAttribute('data-ec-col', col.dataEcCol);
       if (col.width) td.style.width = col.width + 'px';

--- a/product_research_app/static/js/completar-ia.js
+++ b/product_research_app/static/js/completar-ia.js
@@ -1,6 +1,94 @@
 const EC_BATCH_SIZE = 10;
 const EC_MODEL = "gpt-4o-mini-2024-07-18";
 
+try {
+  const ev = new EventSource('/events');
+  ev.onmessage = (e) => {
+    try {
+      const payload = JSON.parse(e.data || '{}');
+      if (!payload || payload.event !== 'product_update') return;
+      const data = payload.data || {};
+      const id = data.id;
+      const fields = data.fields || {};
+      if (id == null) return;
+      const row = document.querySelector(`[data-product-id="${id}"]`);
+      const list = Array.isArray(window.products) ? window.products : [];
+      const allList = Array.isArray(window.allProducts) ? window.allProducts : [];
+      const product = list.find(p => String(p.id) === String(id));
+      const fullProduct = allList.find(p => String(p.id) === String(id));
+      const updateField = (key, value) => {
+        if (product) {
+          product[key] = value;
+        }
+        if (fullProduct) {
+          fullProduct[key] = value;
+        }
+      };
+      if (fields.desire !== undefined) {
+        updateField('desire', fields.desire);
+        if (row) {
+          const cell = row.querySelector('[data-col="desire"]');
+          if (cell) {
+            const editor = cell.querySelector('textarea.desire-editor');
+            if (editor) editor.value = fields.desire || '';
+            const wrap = cell.querySelector('.desire-text');
+            if (wrap) wrap.textContent = fields.desire || '';
+            else cell.textContent = fields.desire || '';
+          }
+        }
+      }
+      if (fields.desire_primary !== undefined) {
+        updateField('desire_primary', fields.desire_primary);
+        if (row) {
+          const cell = row.querySelector('[data-col="desire_primary"]');
+          if (cell) cell.textContent = fields.desire_primary || '';
+        }
+      }
+      if (fields.awareness_level !== undefined) {
+        updateField('awareness_level', fields.awareness_level);
+        if (row) {
+          const cell = row.querySelector('[data-col="awareness_level"]');
+          const select = cell ? cell.querySelector('select') : null;
+          if (select) select.value = fields.awareness_level || '';
+          else if (cell) cell.textContent = fields.awareness_level || '';
+        }
+      }
+      if (fields.competition_level !== undefined) {
+        updateField('competition_level', fields.competition_level);
+        if (row) {
+          const cell = row.querySelector('[data-col="competition_level"]');
+          const select = cell ? cell.querySelector('select') : null;
+          if (select) select.value = fields.competition_level || '';
+          else if (cell) cell.textContent = fields.competition_level || '';
+        }
+      }
+      if (fields.desire_magnitude !== undefined) {
+        const val = fields.desire_magnitude && typeof fields.desire_magnitude === 'object'
+          ? fields.desire_magnitude.overall ?? fields.desire_magnitude
+          : fields.desire_magnitude;
+        updateField('desire_magnitude', val);
+        if (row) {
+          const cell = row.querySelector('[data-col="desire_magnitude"]');
+          const select = cell ? cell.querySelector('select') : null;
+          if (select) select.value = val || '';
+          else if (cell) cell.textContent = val || '';
+        }
+      }
+      if (fields.ai_desire_label !== undefined) {
+        updateField('ai_desire_label', fields.ai_desire_label);
+        if (row) {
+          const cell = row.querySelector('[data-col="ai_desire_label"]');
+          if (cell) cell.textContent = fields.ai_desire_label || '';
+        }
+      }
+    } catch (err) {
+      console.warn('SSE update error', err);
+    }
+  };
+} catch (err) {
+  console.warn('EventSource unavailable', err);
+}
+
 function getAllFilteredRows() {
   if (typeof window.getAllFilteredRows === 'function') {
     try {


### PR DESCRIPTION
## Summary
- add an AI audit service to scan products for missing AI fields, rerun fills, and backfill AI labels
- wire the audit into database startup and post-import flows while broadcasting product changes over server-sent events
- surface live updates in the UI and harden configuration/database helpers for the expanded AI columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d55f397c20832894792eea2d543634