### PR TITLE
Refine DESIRE batch handling and prompts

### DIFF
--- a/product_research_app/metrics.py
+++ b/product_research_app/metrics.py
@@ -1,0 +1,38 @@
+"""Lightweight helpers to accumulate usage metrics for AI calls."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Union
+
+logger = logging.getLogger(__name__)
+
+_Number = Union[int, float]
+
+_usage_totals = {"prompt_tokens": 0, "completion_tokens": 0}
+
+
+def add_usage(prompt_tokens: Optional[_Number], completion_tokens: Optional[_Number]) -> None:
+    """Accumulate token usage for observability dashboards."""
+
+    try:
+        if prompt_tokens is not None:
+            _usage_totals["prompt_tokens"] += max(0, int(prompt_tokens))
+        if completion_tokens is not None:
+            _usage_totals["completion_tokens"] += max(0, int(completion_tokens))
+    except Exception:  # pragma: no cover - defensive logging only
+        logger.debug("metrics.add_usage failed", exc_info=True)
+        return
+
+    logger.debug(
+        "metrics.add_usage: prompt=%s completion=%s totals=%s",
+        prompt_tokens,
+        completion_tokens,
+        dict(_usage_totals),
+    )
+
+
+def get_totals() -> dict:
+    """Return the current aggregated usage totals."""
+
+    return dict(_usage_totals)

--- a/product_research_app/services/batch_parser.py
+++ b/product_research_app/services/batch_parser.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict, List, Tuple
+
+
+def _norm_id(value: Any):
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return None
+
+
+def map_desire_results(
+    obj: Any, expected_ids: List[int]
+) -> Tuple[Dict[int, dict], List[int], List[int]]:
+    """
+    Acepta:
+      A) {"items":[{"id":123,...}, ...]}
+      B) [{"id":123,...}, ...]
+      C) {"123": {...}, "124": {...}}   # dict por id
+    Acepta claves: "desire_statement" | "desire" | "s"
+    """
+
+    rows: List[dict] = []
+    if isinstance(obj, dict) and isinstance(obj.get("items"), list):
+        rows = obj["items"]
+    elif isinstance(obj, list):
+        rows = obj
+    elif isinstance(obj, dict):
+        rows = [{"id": key, **(value or {})} for key, value in obj.items()]
+
+    mapping: Dict[int, dict] = {}
+    seen: set[int] = set()
+
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        pid = _norm_id(row.get("id"))
+        if pid is None:
+            continue
+        statement = row.get("desire_statement") or row.get("desire") or row.get("s") or ""
+        row["desire_statement"] = statement
+        mapping[pid] = row
+        seen.add(pid)
+
+    expected = set(expected_ids)
+    missing = sorted(list(expected - seen))
+    extras = sorted([pid for pid in seen if pid not in expected])
+    return mapping, missing, extras

--- a/product_research_app/services/json_utils.py
+++ b/product_research_app/services/json_utils.py
@@ -1,45 +1,97 @@
 import json, re
 
 JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", re.IGNORECASE)
+PAIR_RE = re.compile(r'"(?P<id>\d+)"\s*:\s*\{(?P<body>[^{}]*?)\}\s*,?', re.DOTALL)
 
-def extract_json_object(text: str):
+
+def fix_newlines_in_strings(text: str) -> str:
+    """Reemplaza saltos de línea crudos dentro de strings JSON por \n."""
+
+    out = []
+    in_str = False
+    esc = False
+    for ch in text:
+        if esc:
+            out.append(ch)
+            esc = False
+            continue
+        if ch == "\\":
+            out.append(ch)
+            esc = True
+            continue
+        if ch == '"':
+            in_str = not in_str
+            out.append(ch)
+            continue
+        if ch in ('\r', '\n') and in_str:
+            out.append('\\n')
+            continue
+        out.append(ch)
+    return ''.join(out)
+
+
+def try_load(s: str):
+    try:
+        return json.loads(s), None
+    except Exception as e:
+        return None, str(e)
+
+
+def extract_json_object_loose(text: str):
     """
-    Devuelve (obj, err). Intenta:
-      1) Bloque ```json ... ```
-      2) Primer objeto { ... } balanceando llaves
+    1) Si hay fence ```json ... ```, cargar.
+    2) Si no, buscar primer '{' e intentar balancear.
+    3) Reparar newlines en strings y reintentar.
+    4) Si sigue fallando, salvar pares "id": {...} sueltos.
+    Retorna (obj, err). obj puede ser dict por id.
     """
+
     if not text:
         return None, "empty"
 
     m = JSON_BLOCK_RE.search(text)
     if m:
-        s = m.group(1)
-        try:
-            return json.loads(s), None
-        except Exception as e:
-            last_err = f"fenced_load:{e}"
-    else:
-        last_err = "no_fence"
+        raw = m.group(1)
+        obj, err = try_load(raw)
+        if obj is not None:
+            return obj, None
+        raw2 = fix_newlines_in_strings(raw)
+        obj, err2 = try_load(raw2)
+        if obj is not None:
+            return obj, None
+        return None, f"fenced:{err2 or err}"
 
     start = text.find("{")
-    if start == -1:
-        return None, last_err or "no_left_brace"
+    if start != -1:
+        depth = 0
+        end = -1
+        for i, ch in enumerate(text[start:], start):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        if end != -1:
+            cand = text[start : end + 1]
+            obj, err = try_load(cand)
+            if obj is not None:
+                return obj, None
+            cand2 = fix_newlines_in_strings(cand)
+            obj, err2 = try_load(cand2)
+            if obj is not None:
+                return obj, None
 
-    depth = 0; end = -1
-    for i, ch in enumerate(text[start:], start):
-        if ch == "{": depth += 1
-        elif ch == "}":
-            depth -= 1
-            if depth == 0: end = i; break
-    if end != -1:
-        candidate = text[start:end+1]
-        try:
-            return json.loads(candidate), None
-        except Exception as e:
-            return None, f"balanced_load:{e}"
+    salvage = {}
+    fixed = fix_newlines_in_strings(text)
+    for match in PAIR_RE.finditer(fixed):
+        pid = match.group("id")
+        body = "{" + (match.group("body") or "") + "}"
+        item, _ = try_load(body)
+        if isinstance(item, dict):
+            salvage[pid] = item
+    if salvage:
+        return salvage, None
 
-    return None, last_err or "unbalanced"
-
-def coerce_bounds(s: str, mn: int, mx: int) -> str:
-    s = (s or "").strip()
-    return s[:mx] if len(s) >= mn else s
+    return None, "no_json"


### PR DESCRIPTION
## Summary
- add robust JSON utilities and batch mapping so DESIRE responses tolerate truncated or fence-less objects
- make the DESIRE prompt and GPT client aware of the compact contract when only desire text is missing and track usage metrics
- rework the DESIRE batch processor to choose the compact contract per batch, parse loosely, and stream SSE updates while the audit flow requests the lighter mode when eligible

## Testing
- PYTHONPATH=. pytest product_research_app/tests/test_gpt_messages.py product_research_app/tests/test_prompts_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68d573b7ce6483288486efd7536f0cb7