### PR TITLE
Update IA completion flow to process all products

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -13,6 +13,11 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 
+AI_MICROBATCH_DEFAULT = 8
+AI_MAX_OUTPUT_TOKENS = 3000
+AI_JSON_ENFORCED = True
+
+
 DEFAULT_WINNER_ORDER = [
     "awareness",
     "desire",
@@ -54,7 +59,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     },
     "ai": {
         "parallelism": 8,
-        "microbatch": 12,
+        "microbatch": AI_MICROBATCH_DEFAULT,
         "cache_enabled": True,
         "version": 1,
         "tpm_limit": None,


### PR DESCRIPTION
## Summary
- allow launching IA completion for all products from the UI by batching ids and preserving progress feedback
- expose backend endpoints to list product ids and run AI column jobs while using tolerant micro-batching defaults
- add persistence helpers and configuration defaults to support per-item AI upserts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d697bdd32883289fdaf253c352f92d