### PR TITLE
Automate AI enrichment after imports and harden GPT usage

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -13,6 +13,13 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 
+AUTO_AI_ON_IMPORT = True
+AI_MICROBATCH_DEFAULT = 8
+AI_REFINE_CONCURRENCY = 2
+OPENAI_TPM_LIMIT = 30000
+OPENAI_SAFETY_TPM = 0.90
+
+
 DEFAULT_WINNER_ORDER = [
     "awareness",
     "desire",


### PR DESCRIPTION
## Summary
- add global configuration defaults for AI import behaviour and OpenAI throttling
- update database helpers and AI column writer to perform UPDATE-only writes and reuse a shared upsert utility
- return newly inserted product IDs from the fast importer, launch background AI jobs for those IDs after import, and add OpenAI backoff plus TPM protection

## Testing
- pytest product_research_app/tests/test_app_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68d6afaa9f4c8328876b56da5be5c5af