### PR TITLE
Handle missing ai_desire_label column when updating AI fields

### DIFF
--- a/product_research_app/db.py
+++ b/product_research_app/db.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from typing import Optional, Union
 
 
+def _table_has_column(conn, table: str, column: str) -> bool:
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cur.fetchall())
+
+
 logger = logging.getLogger(__name__)
 
 _DB: Optional[sqlite3.Connection] = None
@@ -116,3 +121,82 @@ def close_db():
                 pass
         _DB = None
         _DB_PATH = None
+
+
+def upsert_ai_columns(conn, rows):
+    """
+    rows: [{"product_id": int,
+            "ai_desire_label": Optional[str],   # puede no venir
+            "desire": Optional[str],            # texto corto/etiqueta fallback
+            "desire_magnitude": Optional[float|int],
+            "awareness_level": Optional[float|int],
+            "competition_level": Optional[float|int]}]
+    Actualiza ÚNICAMENTE columnas IA del producto existente. Tolerante si
+    'ai_desire_label' no existe en el esquema: usará 'desire' en su lugar.
+    """
+    if not rows:
+        return 0
+
+    has_ai_label = _table_has_column(conn, "products", "ai_desire_label")
+
+    # columnas numéricas siempre presentes en este fix
+    set_cols = []
+    if has_ai_label:
+        set_cols.append("ai_desire_label")
+    else:
+        set_cols.append("desire")
+    set_cols += ["desire_magnitude", "awareness_level", "competition_level"]
+
+    set_sql = ", ".join([f"{c} = COALESCE(?, {c})" for c in set_cols])
+    sql = f"UPDATE products SET {set_sql} WHERE id = ?"
+
+    payload = []
+    for r in rows:
+        pid = int(r["product_id"])
+        # label: preferimos 'ai_desire_label', luego 'desire'
+        label = (r.get("ai_desire_label") or r.get("desire") or "").strip()
+        mag = r.get("desire_magnitude")
+        aware = r.get("awareness_level")
+        comp = r.get("competition_level")
+        vals = [label, mag, aware, comp]
+        vals.append(pid)
+        payload.append(vals)
+
+    cur = conn.cursor()
+    try:
+        cur.executemany(sql, payload)
+        conn.commit()
+        updated = cur.rowcount if cur.rowcount is not None else 0
+        logging.info("upsert_ai_columns: updated=%s has_ai_label=%s", updated, has_ai_label)
+        return updated
+    except Exception as e:
+        logging.exception("upsert_ai_columns failed: %s", e)
+        conn.rollback()
+        return 0
+    finally:
+        cur.close()
+
+
+def filter_missing_ai_columns(conn, ids):
+    if not ids:
+        return []
+    has_ai_label = _table_has_column(conn, "products", "ai_desire_label")
+    qmarks = ",".join(["?"] * len(ids))
+
+    # Columna de texto a verificar: ai_desire_label (si existe) o desire
+    txt_col = "ai_desire_label" if has_ai_label else "desire"
+
+    sql = f"""
+      SELECT id FROM products
+       WHERE id IN ({qmarks})
+         AND (
+              ({txt_col} IS NULL OR TRIM({txt_col}) = '')
+           OR desire_magnitude IS NULL
+           OR awareness_level IS NULL
+           OR competition_level IS NULL
+         )
+    """
+    cur = conn.execute(sql, ids)
+    out = [r[0] for r in cur.fetchall()]
+    logging.info("filter_missing_ai_columns: need=%d using=%s", len(out), txt_col)
+    return out


### PR DESCRIPTION
## Summary
- add a helper to detect whether the products table exposes ai_desire_label
- make AI column updates fall back to the desire column and add logging when ai_desire_label is absent
- filter missing AI columns against the appropriate schema column to avoid OperationalError

## Testing
- python -m compileall product_research_app/db.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f25de5c883288c0c12f055cdb765