### PR TITLE
Implement OpenAI rate limiting and 429 backoff

### DIFF
--- a/product_research_app/dev_test_ratelimit.py
+++ b/product_research_app/dev_test_ratelimit.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import itertools
+import os
+from typing import Any, Dict
+
+from product_research_app.gpt import OpenAIError, call_gpt, call_openai_chat
+
+
+class Stub:
+    """Simula una secuencia de respuestas con errores 429 antes de recuperarse."""
+
+    def __init__(self, fails: int = 3):
+        self.counter = itertools.count()
+        self.fails = fails
+        self.last_index = -1
+
+    def run(self) -> Dict[str, Any]:
+        index = next(self.counter)
+        self.last_index = index
+        if index < self.fails:
+            raise OpenAIError(
+                "OpenAI API returned status 429: Please try again in 500ms."
+            )
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": "{\"desire_statement\": \"texto\", \"desire_magnitude\": 5}"
+                    }
+                }
+            ]
+        }
+
+
+def main() -> None:
+    os.environ.setdefault("OPENAI_API_KEY", "test-key")
+    stub = Stub()
+    original = call_openai_chat
+
+    def _fake_call(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return stub.run()
+
+    try:
+        # Monkeypatch temporal para simular reintentos.
+        import product_research_app.gpt as gpt_module
+
+        gpt_module.call_openai_chat = _fake_call  # type: ignore[assignment]
+        result = call_gpt("DESIRE", context_json={"product": {"id": 1}})
+        print({"result_ok": result.get("ok"), "attempts": stub.last_index + 1})
+    except OpenAIError as exc:
+        print({"error": str(exc)})
+    finally:
+        # Restaurar la función original.
+        import product_research_app.gpt as gpt_module
+
+        gpt_module.call_openai_chat = original  # type: ignore[assignment]
+
+
+if __name__ == "__main__":
+    main()
+

--- a/product_research_app/ratelimit.py
+++ b/product_research_app/ratelimit.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import random
+import threading
+import time
+from contextlib import contextmanager
+
+
+def _env_int(name, default):
+    try:
+        return int(os.getenv(name, default))
+    except Exception:
+        return default
+
+
+def _env_float(name, default):
+    try:
+        return float(os.getenv(name, default))
+    except Exception:
+        return default
+
+
+_TPM = _env_int("PRAPP_OPENAI_TPM", 30000)
+_RPM = _env_int("PRAPP_OPENAI_RPM", 3000)
+_HEADROOM = _env_float("PRAPP_OPENAI_HEADROOM", 0.85)
+_MAX_CONC = _env_int("PRAPP_OPENAI_MAX_CONCURRENCY", 2)
+
+_EFF_TPM = max(1, int(_TPM * _HEADROOM))
+_EFF_RPM = max(1, int(_RPM * _HEADROOM))
+
+
+class _TokenBucket:
+    def __init__(self, capacity_per_min: int):
+        self.capacity = max(1, capacity_per_min)
+        self.tokens = self.capacity
+        self.lock = threading.Lock()
+        self.last = time.monotonic()
+
+    def acquire(self, amount: int):
+        with self.lock:
+            while True:
+                now = time.monotonic()
+                refill = (now - self.last) * (self.capacity / 60.0)
+                if refill > 0:
+                    self.tokens = min(self.capacity, self.tokens + refill)
+                    self.last = now
+                if self.tokens >= amount:
+                    self.tokens -= amount
+                    return
+                deficit = amount - self.tokens
+                sleep_s = max(deficit / (self.capacity / 60.0), 0.01)
+                self.lock.release()
+                try:
+                    time.sleep(sleep_s)
+                finally:
+                    self.lock.acquire()
+
+
+_tokens_bucket = _TokenBucket(_EFF_TPM)
+_requests_bucket = _TokenBucket(_EFF_RPM)
+
+_conc_sem = threading.BoundedSemaphore(_MAX_CONC)
+
+
+@contextmanager
+def reserve(tokens_estimate: int):
+    _conc_sem.acquire()
+    try:
+        _requests_bucket.acquire(1)
+        _tokens_bucket.acquire(max(1, tokens_estimate))
+        yield
+    finally:
+        _conc_sem.release()
+
+
+def decorrelated_jitter_sleep(prev: float, cap: float) -> float:
+    base = 0.3
+    next_sleep = min(cap, random.uniform(base, prev * 3 if prev > 0 else 1.0))
+    time.sleep(next_sleep)
+    return next_sleep
+


### PR DESCRIPTION
## Summary
- add a global token bucket rate limiter and concurrency semaphore for OpenAI calls
- wrap call_gpt with retry/backoff logic for 429 responses and respect Retry-After hints
- adjust desire refine logging to avoid noisy errors and add a smoke test harness for rate limiting

## Testing
- python -m product_research_app.dev_test_ratelimit

------
https://chatgpt.com/codex/tasks/task_e_68d826346e9c8328a9daf1944f69a011