### PR TITLE
Add front-end orchestrator for import and AI progress

### DIFF
--- a/product_research_app/static/css/loading.css
+++ b/product_research_app/static/css/loading.css
@@ -4,6 +4,60 @@
 /* Slot genérico: colapsado por defecto para NO ocupar espacio */
 .progress-slot { height: 0; overflow: clip; transition: height 160ms ease; }
 
+.progress-orchestrator-shell,
+[data-progress-shell] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  margin: 4px auto 0 auto;
+  min-height: 22px;
+  border-radius: 999px;
+  background: rgba(24, 34, 54, 0.78);
+  color: #f5f7ff;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: opacity .25s ease, transform .25s ease;
+}
+
+[data-progress-shell].is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.progress-orchestrator-bar {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 120px;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-orchestrator-fill,
+[data-progress-bar] {
+  width: 0%;
+  height: 100%;
+  background: linear-gradient(90deg, #8b5cf6, #6366f1);
+  transition: width 140ms linear;
+}
+
+.progress-orchestrator-text,
+[data-progress-text] {
+  flex: 0 0 auto;
+  font-weight: 600;
+}
+
+.progress-done [data-progress-shell] {
+  opacity: 0;
+  transform: translateY(-6px);
+  pointer-events: none;
+}
+
 /* Cuando hay progreso, el slot se expande y empuja el contenido (sin solapar) */
 .progress-slot.active { height: 18px; }
 

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -418,6 +418,58 @@ function mapServerFraction(serverPct) {
   return Math.min(IMPORT_POLL_MAX_FRAC, frac);
 }
 
+function pickFiniteNumber(...values) {
+  for (const value of values) {
+    const num = Number(value);
+    if (Number.isFinite(num)) return num;
+  }
+  return null;
+}
+
+function extractAiProgress(payload = {}) {
+  if (!payload || typeof payload !== 'object') return { total: null, done: null };
+  const counts = (payload.ai_counts && typeof payload.ai_counts === 'object') ? payload.ai_counts : {};
+  const total = pickFiniteNumber(
+    payload.ai_total,
+    counts.total,
+    counts.total_items,
+    counts.total_rows,
+    counts.expected_total,
+    counts.target,
+    counts.total_requested,
+    counts.requested,
+    Number.isFinite(Number(counts.queued)) && (Number.isFinite(Number(counts.ok)) || Number.isFinite(Number(counts.cached)))
+      ? Number(counts.queued) + (Number.isFinite(Number(counts.ok)) ? Number(counts.ok) : 0) + (Number.isFinite(Number(counts.cached)) ? Number(counts.cached) : 0)
+      : null
+  );
+  let done = pickFiniteNumber(
+    payload.ai_done,
+    counts.done,
+    counts.completed,
+    counts.processed,
+    counts.rows_completed,
+    counts.finished,
+    counts.success,
+    counts.n_procesados
+  );
+  if (!Number.isFinite(done)) {
+    const ok = Number(counts.ok);
+    const cached = Number(counts.cached);
+    if (Number.isFinite(ok) || Number.isFinite(cached)) {
+      done = (Number.isFinite(ok) ? ok : 0) + (Number.isFinite(cached) ? cached : 0);
+    }
+  }
+  return { total, done };
+}
+
+function syncProgressFromStatus(payload) {
+  if (!window._progress) return { total: null, done: null };
+  const { total, done } = extractAiProgress(payload);
+  if (Number.isFinite(total) && total > 0) window._progress.setAiTotal(total);
+  if (Number.isFinite(done)) window._progress.setAiProgress(done, total);
+  return { total, done };
+}
+
 async function followImportTask(taskId, tracker, { statusUrl = IMPORT_STATUS_URL, host = getGlobalProgressHost() } = {}) {
   const id = typeof taskId === 'string' ? taskId : String(taskId || '');
   if (!id) return null;
@@ -440,6 +492,10 @@ async function followImportTask(taskId, tracker, { statusUrl = IMPORT_STATUS_URL
     serverPct = Math.max(0, Math.min(100, serverPct));
     const stage = (data.message || data.stage || data.state || '').toString() || 'Procesando…';
     tracker?.step(mapServerFraction(serverPct), stage);
+    if (window._progress) {
+      window._progress.setImportPercent(serverPct);
+    }
+    const aiSnapshot = syncProgressFromStatus(data);
 
     const statusVal = String(data.state || data.status || '').toLowerCase();
     if (statusVal === 'error' || data.error) {
@@ -451,6 +507,11 @@ async function followImportTask(taskId, tracker, { statusUrl = IMPORT_STATUS_URL
     if (serverPct >= 100 || statusVal === 'done' || statusVal === 'completed' || statusVal === 'finished') {
       await reloadTable({ skipProgress: true });
       hideImportBanner();
+      const aiTotal = aiSnapshot.total;
+      const aiDone = aiSnapshot.done;
+      if (!Number.isFinite(aiTotal) || aiTotal <= 0 || (Number.isFinite(aiDone) && aiDone >= aiTotal)) {
+        window._progress?.finish();
+      }
       return data;
     }
     await sleep(450);
@@ -462,6 +523,8 @@ async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IM
   const host = getGlobalProgressHost();
   const tracker = LoadingHelpers.start('Importando catálogo', { host });
   tracker.setStage('Subiendo archivo…');
+  window._progress?.reset();
+  window._progress?.setUploadProgress(0);
   let lastResult = null;
   try {
     const fd = new FormData();
@@ -476,6 +539,9 @@ async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IM
         if (!event.lengthComputable) return;
         const frac = Math.min(IMPORT_UPLOAD_FRAC, (event.loaded / event.total) * IMPORT_UPLOAD_FRAC);
         tracker.step(frac, 'Subiendo archivo…');
+        if (window._progress) {
+          window._progress.setUploadProgress(event.total ? event.loaded / event.total : 0);
+        }
       };
       xhr.onerror = () => reject(new Error('Error de red subiendo archivo'));
       xhr.onload = () => {
@@ -501,6 +567,10 @@ async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IM
 
     if (startResult.kind === 'sync') {
       tracker.step(1, 'Completado');
+      window._progress?.setUploadProgress(1);
+      window._progress?.setImportPercent(100);
+      syncProgressFromStatus(startResult.data);
+      window._progress?.finish();
       await reloadTable({ skipProgress: true });
       const importedCount = startResult.data?.imported ?? startResult.data?.rows_imported;
       if (Number.isFinite(importedCount) && importedCount > 0) {
@@ -512,9 +582,14 @@ async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IM
     const taskId = startResult.taskId;
     const idStr = typeof taskId === 'string' ? taskId : String(taskId);
     tracker.step(IMPORT_UPLOAD_FRAC, 'Archivo subido');
+    window._progress?.setUploadProgress(1);
     localStorage.setItem(IMPORT_TASK_LS_KEY, idStr);
 
     lastResult = await followImportTask(idStr, tracker, { statusUrl, host });
+    const finalSnapshot = syncProgressFromStatus(lastResult);
+    if (!Number.isFinite(finalSnapshot.total) || finalSnapshot.total <= 0 || (Number.isFinite(finalSnapshot.done) && finalSnapshot.done >= finalSnapshot.total)) {
+      window._progress?.finish();
+    }
 
     const importedCount = lastResult?.imported ?? lastResult?.rows_imported;
     if (Number.isFinite(importedCount) && importedCount > 0) {
@@ -524,6 +599,7 @@ async function importCatalog(file, { startUrl = IMPORT_START_URL, statusUrl = IM
     return lastResult;
   } catch (err) {
     tracker.step(1, 'Error');
+    window._progress?.reset();
     toast.error(err?.message || 'Error al importar catálogo');
     throw err;
   } finally {
@@ -1147,6 +1223,7 @@ window.onload = async () => {
     const host = getGlobalProgressHost();
     const tracker = LoadingHelpers.start('Importando catálogo', { host });
     tracker.step(IMPORT_UPLOAD_FRAC, 'Reanudando…');
+    window._progress?.reset();
     try {
       const result = await followImportTask(tid, tracker, { host });
       const importedCount = result?.imported ?? result?.rows_imported;

--- a/product_research_app/static/js/completar-ia.js
+++ b/product_research_app/static/js/completar-ia.js
@@ -51,6 +51,9 @@ function applyUpdates(product, updates) {
       body: JSON.stringify(applied)
     }).catch(() => {});
     if (window.ecAutoFitColumns && window.gridRoot) ecAutoFitColumns(gridRoot);
+    if (window._progress) {
+      window._progress.noteAiRowCompleted(product.id);
+    }
   }
   return applied;
 }
@@ -135,6 +138,12 @@ window.handleCompletarIA = async function(opts = {}) {
   if (all.length === 0) {
     if (!opts.silent) toast.info('No hay productos');
     return;
+  }
+  if (window._progress) {
+    window._progress.reset();
+    window._progress.setUploadProgress(1);
+    window._progress.setImportPercent(100);
+    window._progress.setAiTotal(all.length);
   }
   let okTotal = 0;
   const chunks = chunkArray(all, EC_BATCH_SIZE);


### PR DESCRIPTION
## Summary
- add a front-end progress orchestrator in `loading.js` and expose a shared instance on `window._progress`
- style the orchestrator container/animation and wire import polling plus manual AI workflows to update it
- smooth out the upload/import/AI transitions so the bar advances across phases and hides when finished

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d905c9ba18832890816c838e745453