### PR TITLE
Adjust progress tracking and rate limit telemetry

### DIFF
--- a/product_research_app/ratelimit.py
+++ b/product_research_app/ratelimit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import random
 import threading
@@ -23,11 +24,34 @@ def _env_float(name, default):
 
 _TPM = _env_int("PRAPP_OPENAI_TPM", 30000)
 _RPM = _env_int("PRAPP_OPENAI_RPM", 3000)
-_HEADROOM = _env_float("PRAPP_OPENAI_HEADROOM", 0.85)
-_MAX_CONC = _env_int("PRAPP_OPENAI_MAX_CONCURRENCY", 2)
+_HEADROOM = _env_float("PRAPP_OPENAI_HEADROOM", 0.75)  # más conservador
+_MAX_CONC = _env_int("PRAPP_OPENAI_MAX_CONCURRENCY", 1)  # evitar picos de 429
 
 _EFF_TPM = max(1, int(_TPM * _HEADROOM))
 _EFF_RPM = max(1, int(_RPM * _HEADROOM))
+
+
+logger = logging.getLogger(__name__)
+_last_log_ts = 0.0
+_last_log_key: int | None = None
+
+
+def _maybe_log(tokens_estimate: int) -> None:
+    global _last_log_ts, _last_log_key
+    now = time.monotonic()
+    pct = min(99, int(100 * tokens_estimate / max(1, _EFF_TPM)))
+    key = pct // 5
+    if (now - _last_log_ts) >= 3.0 or key != _last_log_key:
+        _last_log_ts, _last_log_key = now, key
+        logger.info(
+            "ratelimit reserve tokens_est=%d eff_tpm=%d eff_rpm=%d headroom=%.2f max_conc=%d approx_used_pct=%d",
+            tokens_estimate,
+            _EFF_TPM,
+            _EFF_RPM,
+            _HEADROOM,
+            _MAX_CONC,
+            pct,
+        )
 
 
 class _TokenBucket:
@@ -67,6 +91,7 @@ _conc_sem = threading.BoundedSemaphore(_MAX_CONC)
 def reserve(tokens_estimate: int):
     _conc_sem.acquire()
     try:
+        _maybe_log(max(1, tokens_estimate))
         _requests_bucket.acquire(1)
         _tokens_bucket.acquire(max(1, tokens_estimate))
         yield
@@ -79,4 +104,15 @@ def decorrelated_jitter_sleep(prev: float, cap: float) -> float:
     next_sleep = min(cap, random.uniform(base, prev * 3 if prev > 0 else 1.0))
     time.sleep(next_sleep)
     return next_sleep
+
+
+logger.info(
+    "ratelimit init tpm=%d rpm=%d headroom=%.2f eff_tpm=%d eff_rpm=%d max_conc=%d",
+    _TPM,
+    _RPM,
+    _HEADROOM,
+    _EFF_TPM,
+    _EFF_RPM,
+    _MAX_CONC,
+)
 

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -373,9 +373,9 @@ const saveIfDirty = window.saveIfDirty;
 window.fetchJson = fetchJson;
 window.groupsService = groupsService;
 const IMPORT_TASK_LS_KEY = 'last_import_task';
-// Tramos: 0–0.20 subida | 0.20–0.70 importación | 0.70–1.00 IA
-const PROG_UPLOAD_FRAC = 0.20;
-const PROG_IMPORT_END = 0.70;
+// Tramos: 0–0.10 subida | 0.10–0.40 servidor | 0.40–1.00 IA
+const PROG_UPLOAD_FRAC = 0.10;
+const PROG_IMPORT_END = 0.40;
 const IMPORT_STATUS_URL = '/_import_status';
 const IMPORT_START_URL = '/upload';
 let savedApiKeyHash = null;
@@ -414,7 +414,7 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 function mapServerFraction(serverPct){
   const clamped = Math.max(0, Math.min(100, Number(serverPct)||0));
-  const span = PROG_IMPORT_END - PROG_UPLOAD_FRAC; // 0.50
+  const span = PROG_IMPORT_END - PROG_UPLOAD_FRAC; // 0.30
   return Math.min(PROG_IMPORT_END, PROG_UPLOAD_FRAC + (clamped/100)*span);
 }
 
@@ -437,9 +437,9 @@ function iaCountComplete(targetIds){
   return done;
 }
 
-// Tween lineal acotado para evitar saltos (máx ~2.5% por tick)
+// Tween lineal acotado para evitar saltos (máx ~1.5% por tick)
 async function animateTowards(tracker, cur, target){
-  const maxStep = 0.025; // 2.5%
+  const maxStep = 0.015; // 1.5% para que suba "a poquitos"
   return new Promise(res=>{
     function step(){
       const delta = target - cur;
@@ -454,51 +454,79 @@ async function animateTowards(tracker, cur, target){
 }
 
 // Fase IA: progresa de PROG_IMPORT_END → 1.0 leyendo productos
-async function trackIaPhase(tracker, targetIds, {pollMs=1600, maxIdle=120000} = {}){
-  if(!Array.isArray(targetIds) || targetIds.length===0){
-    // Si no pudimos aislar IDs nuevos, intenta con todos los visibles
-    targetIds = (Array.isArray(window.allProducts) ? window.allProducts : []).map(p => String(p.id));
+async function trackIaPhase(tracker, targetIds, {pollMs=1200, maxIdle=120000} = {}){
+  if (window.__iaTrackerActive) {
+    return false;
   }
-  window.__iaTailPending = true; // evita cerrar la barra en finally
-  let cur = PROG_IMPORT_END;
-  tracker.step(cur, 'Columnas IA…');
+  window.__iaTrackerActive = true;
+  try {
+    if(!Array.isArray(targetIds) || targetIds.length===0){
+      // Si no pudimos aislar IDs nuevos, intenta con todos los visibles
+      targetIds = (Array.isArray(window.allProducts) ? window.allProducts : []).map(p => String(p.id));
+    }
+    const total = Array.isArray(targetIds) ? targetIds.length : 0;
+    window.__iaTailPending = true; // evita cerrar la barra en finally
+    const start = PROG_IMPORT_END;
+    let cur = start;
+    tracker.step(cur, 'Columnas IA…');
 
-  let lastDone = -1;
-  let sinceChange = 0;
-  const startTs = Date.now();
-
-  while(true){
-    // Refresca datos con poca frecuencia para no spamear
-    try { await reloadTable({ skipProgress: true }); } catch {}
-
-    const done = iaCountComplete(targetIds);
-    const frac = done / Math.max(1, targetIds.length);
-    const target = PROG_IMPORT_END + frac * (1 - PROG_IMPORT_END);
-
-    await animateTowards(tracker, cur, target);
-    cur = target;
-
-    if(done === targetIds.length){
+    if (total === 0) {
+      await animateTowards(tracker, cur, 1);
       tracker.step(1, 'Completado');
+      tracker.done();
       window.__iaTailPending = false;
       return true;
     }
 
-    // Control de inactividad para evitar ciclos infinitos
-    if(done === lastDone){ sinceChange += pollMs; } else { sinceChange = 0; lastDone = done; }
-    if(sinceChange >= maxIdle || (Date.now()-startTs) > 10*60*1000){ // 2 min sin cambios o 10 min total
-      // Cierra igualmente, pero deja nota visual de “Completado (parcial)”
-      tracker.step(Math.max(cur, 0.98), 'Completado (parcial)');
-      window.__iaTailPending = false;
-      return false;
-    }
+    let lastDone = -1;
+    let idleFor = 0;
+    const startTs = Date.now();
 
-    await new Promise(r => setTimeout(r, pollMs));
+    while(true){
+      // Refresca datos con poca frecuencia para no spamear
+      try { await reloadTable({ skipProgress: true }); } catch {}
+
+      const done = iaCountComplete(targetIds);
+      if (done !== lastDone) {
+        lastDone = done;
+        const target = start + (done / total) * (1 - start);
+        const clamped = Math.min(1, target);
+        await animateTowards(tracker, cur, clamped);
+        cur = clamped;
+        if(done >= total){
+          tracker.step(1, 'Completado');
+          tracker.done();
+          window.__iaTailPending = false;
+          return true;
+        }
+        idleFor = 0;
+      } else {
+        idleFor += pollMs;
+      }
+
+      if((idleFor >= maxIdle && maxIdle > 0) || (Date.now()-startTs) > 10*60*1000){
+        const fallback = Math.max(cur, 0.98);
+        await animateTowards(tracker, cur, fallback);
+        cur = fallback;
+        tracker.step(cur, 'Completado (parcial)');
+        tracker.done();
+        window.__iaTailPending = false;
+        return false;
+      }
+
+      await sleep(pollMs);
+    }
+  } finally {
+    window.__iaTrackerActive = false;
   }
 }
 
 if (typeof window.__iaTailPending !== 'boolean') {
   window.__iaTailPending = false;
+}
+
+if (typeof window.__iaTrackerActive !== 'boolean') {
+  window.__iaTrackerActive = false;
 }
 
 async function followImportTask(taskId, tracker, { statusUrl = IMPORT_STATUS_URL, host = getGlobalProgressHost() } = {}) {


### PR DESCRIPTION
## Summary
- rebalance the upload/server/IA fractions in the existing global progress tracker and smooth IA animation updates
- guard IA polling against overlapping runs and advance only when new rows complete to avoid noisy logging
- lower the OpenAI rate-limit headroom/concurrency defaults and add throttled telemetry logs for reserve calls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d927a092bc832883ba25ffb6ae225a