### PR TITLE
Improve GPT rate limiting and add telemetry logs

### DIFF
--- a/product_research_app/main.py
+++ b/product_research_app/main.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import logging
 import os
 import sys
 from pathlib import Path
@@ -31,6 +32,14 @@ from . import scraper
 from .utils.db import row_to_dict, rget
 
 import sqlite3
+
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logging.getLogger("gpt.api").setLevel(logging.INFO)
+logging.getLogger("gpt.ratelimit").setLevel(logging.INFO)
 
 
 APP_DIR = Path(__file__).resolve().parent

--- a/product_research_app/ratelimit.py
+++ b/product_research_app/ratelimit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import random
 import threading
@@ -23,11 +24,36 @@ def _env_float(name, default):
 
 _TPM = _env_int("PRAPP_OPENAI_TPM", 30000)
 _RPM = _env_int("PRAPP_OPENAI_RPM", 3000)
-_HEADROOM = _env_float("PRAPP_OPENAI_HEADROOM", 0.85)
-_MAX_CONC = _env_int("PRAPP_OPENAI_MAX_CONCURRENCY", 2)
+_HEADROOM = _env_float("PRAPP_OPENAI_HEADROOM", 0.75)  # más conservador
+_MAX_CONC = _env_int("PRAPP_OPENAI_MAX_CONCURRENCY", 1)
 
 _EFF_TPM = max(1, int(_TPM * _HEADROOM))
 _EFF_RPM = max(1, int(_RPM * _HEADROOM))
+
+
+logger = logging.getLogger("gpt.ratelimit")
+_last_log_ts = 0.0
+_last_log_key = None
+
+
+def _maybe_log_reserve(tokens_estimate: int) -> None:
+    """Log anti-spam: máx cada ~3s o si cambia de tramo de uso (5%)."""
+
+    global _last_log_ts, _last_log_key
+    now = time.monotonic()
+    approx_pct = min(99, int(100 * max(1, tokens_estimate) / max(1, _EFF_TPM)))
+    key = approx_pct // 5
+    if (now - _last_log_ts) >= 3.0 or key != _last_log_key:
+        _last_log_ts, _last_log_key = now, key
+        logger.info(
+            "reserve tokens_est=%d eff_tpm=%d eff_rpm=%d headroom=%.2f max_conc=%d approx_used_pct=%d",
+            tokens_estimate,
+            _EFF_TPM,
+            _EFF_RPM,
+            _HEADROOM,
+            _MAX_CONC,
+            approx_pct,
+        )
 
 
 class _TokenBucket:
@@ -67,11 +93,23 @@ _conc_sem = threading.BoundedSemaphore(_MAX_CONC)
 def reserve(tokens_estimate: int):
     _conc_sem.acquire()
     try:
+        _maybe_log_reserve(max(1, tokens_estimate))
         _requests_bucket.acquire(1)
         _tokens_bucket.acquire(max(1, tokens_estimate))
         yield
     finally:
         _conc_sem.release()
+
+
+logger.info(
+    "init tpm=%d rpm=%d headroom=%.2f eff_tpm=%d eff_rpm=%d max_conc=%d",
+    _TPM,
+    _RPM,
+    _HEADROOM,
+    _EFF_TPM,
+    _EFF_RPM,
+    _MAX_CONC,
+)
 
 
 def decorrelated_jitter_sleep(prev: float, cap: float) -> float:


### PR DESCRIPTION
## Summary
- lower default rate-limit headroom/concurrency and add structured logging in the OpenAI reserver
- instrument GPT enrichment calls with start/finish/429 telemetry and periodic summaries
- initialize INFO-level logging so new GPT loggers are visible at runtime

## Testing
- pytest -q product_research_app/tests/test_winner_score.py

------
https://chatgpt.com/codex/tasks/task_e_68d933ccc17c8328bb6907281fa34950