### PR TITLE
Chunk AI column requests into configurable batches

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -13,6 +13,9 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 
+AI_MAX_PRODUCTS_PER_CALL = int(os.getenv("PRAPP_AI_MAX_PRODUCTS_PER_CALL", "30"))
+
+
 DEFAULT_WINNER_ORDER = [
     "awareness",
     "desire",


### PR DESCRIPTION
## Summary
- add an environment-driven AI_MAX_PRODUCTS_PER_CALL constant to configure batch sizing
- chunk ai column completion requests and missing-entry retries to respect the batch limit while logging per sub-batch usage

## Testing
- python -m compileall product_research_app/services/ai_columns.py

------
https://chatgpt.com/codex/tasks/task_e_68d9372b96d883289e6aab1ee51ca973