### PR TITLE
Improve OpenAI retry handling and rate limit visibility

### DIFF
--- a/product_research_app/config.py
+++ b/product_research_app/config.py
@@ -396,3 +396,8 @@ def get_weights_version() -> int:
         return int(cfg.get("weightsUpdatedAt", 0))
     except Exception:
         return 0
+AI_MAX_PRODUCTS_PER_CALL = int(os.getenv("PRAPP_AI_MAX_PRODUCTS_PER_CALL", "30"))
+AI_MIN_PRODUCTS_PER_CALL = int(os.getenv("PRAPP_AI_MIN_PRODUCTS_PER_CALL", "8"))
+AI_DEGRADE_FACTOR = float(os.getenv("PRAPP_AI_DEGRADE_FACTOR", "0.66"))
+AI_MAX_OUTPUT_TOKENS = int(os.getenv("PRAPP_AI_MAX_OUTPUT_TOKENS", "700"))
+


### PR DESCRIPTION
## Summary
- source AI batch size and degradation limits from environment variables
- lower default OpenAI rate-limit headroom/concurrency and expose a snapshot helper with initialization telemetry
- enhance the chat wrapper with Retry-After parsing, jittered backoff, and usage logging for observability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9429b23a483289c444c3a7780f808