### PR TITLE
Implement unified GPT rate limiting and retries

### DIFF
--- a/product_research_app/gpt.py
+++ b/product_research_app/gpt.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import requests
 
 from . import database, config
-from .ratelimit import decorrelated_jitter_sleep, reserve, snapshot as rl_snapshot
+from .ratelimit import decorrelated_jitter_sleep, reserve
 from .prompts.registry import (
     get_json_schema,
     get_system_prompt,
@@ -245,25 +245,90 @@ def build_messages(
 MAX_429 = int(os.getenv("PRAPP_OPENAI_MAX_RETRIES_429", "6"))
 BACKOFF_CAP = float(os.getenv("PRAPP_OPENAI_BACKOFF_CAP_S", "8"))
 
+# Si no existe en este módulo, definimos un fallback para tipar el except
+try:  # pragma: no cover - protección en tiempo de ejecución
+    OpenAIError  # type: ignore[name-defined]
+except NameError:  # pragma: no cover
+    class OpenAIError(Exception): ...
+
 
 def _estimate_tokens(text: str) -> int:
+    # heurística: 1 token ~ 4 chars aprox. (inglés/español corto)
     return max(1, int(len(text) / 4))
 
 
 def _extract_retry_after_seconds(msg: str) -> float | None:
-    match = re.search(r"in\s+([0-9]+(?:\.[0-9]+)?)\s*s", msg, re.I)
-    if match:
-        try:
-            return float(match.group(1))
-        except Exception:
-            return None
-    match = re.search(r"in\s+([0-9]+)\s*ms", msg, re.I)
-    if match:
-        try:
-            return float(match.group(1)) / 1000.0
-        except Exception:
-            return None
+    # soporta "Please try again in 1.55s" o "in 102ms"
+    m = re.search(r"in\s+([0-9]+(?:\.[0-9]+)?)\s*s", msg, re.I)
+    if m: return float(m.group(1))
+    m = re.search(r"in\s+([0-9]+)\s*ms", msg, re.I)
+    if m: return float(m.group(1)) / 1000.0
     return None
+
+
+def call_gpt(*, messages: List[Dict[str, Any]], **kwargs) -> Dict[str, Any]:
+    """
+    F U N E L  Ú N I C O:
+    - Concurrencia acotada + RPM/TPM por token bucket (reserve).
+    - Reintentos 429 con Retry-After / parseo del mensaje y backoff con jitter.
+    Mantiene la API pública existente.
+    """
+    # Estimación simple de tokens del prompt (si no hay otra función ya en uso)
+    try:
+        prompt_text = "\n".join(
+            m.get("content", "") for m in (messages or []) if isinstance(m, dict)
+        )
+    except Exception:
+        prompt_text = ""
+    tokens_est = _estimate_tokens(prompt_text)
+    extra_est = kwargs.get("tokens_estimate")
+    if extra_est is not None:
+        try:
+            tokens_est = max(tokens_est, int(extra_est))
+        except Exception:
+            pass
+
+    attempt = 0
+    sleep_prev = 0.0
+
+    while True:
+        attempt += 1
+        # Embudo global: RPM/TPM + concurrencia
+        with reserve(tokens_est):
+            try:
+                raw = call_openai_chat(messages=messages, **kwargs)
+                if attempt > 1:
+                    log.info("gpt.call_gpt.recovered status=OK_RECOVERED attempts=%s", attempt)
+                return raw
+            except OpenAIError as e:
+                msg = str(e)
+                low = msg.lower()
+                # Si no es 429, relanza
+                if "status 429" not in low and "rate limit" not in low:
+                    raise
+                if attempt >= MAX_429:
+                    log.error("gpt.call_gpt.gave_up_429 attempts=%s", attempt)
+                    raise
+                # 1) Intenta Retry-After de cabeceras (si el cliente lo expone)
+                retry_after = None
+                try:
+                    resp = getattr(e, "response", None)
+                    headers = getattr(resp, "headers", None) if resp is not None else None
+                    if headers:
+                        ra = headers.get("Retry-After") or headers.get("retry-after")
+                        if ra:
+                            try:
+                                retry_after = float(ra)
+                            except Exception:
+                                retry_after = None  # si es un HTTP-date, ignoramos
+                except Exception:
+                    retry_after = None
+                # 2) Si no, parsea "Please try again in …"
+                wait_s = retry_after if retry_after is not None else _extract_retry_after_seconds(msg) or sleep_prev
+                # 3) Decorrelated jitter backoff
+                sleep_prev = decorrelated_jitter_sleep(wait_s, BACKOFF_CAP)
+                log.warning("gpt.call_gpt.retry_429 attempt=%s sleep=%.2fs", attempt, sleep_prev)
+                continue
 
 
 def _message_text(messages: List[Dict[str, Any]]) -> str:
@@ -285,7 +350,7 @@ def _message_text(messages: List[Dict[str, Any]]) -> str:
     return "\n".join(parts)
 
 
-def call_gpt(
+def call_prompt_task(
     task: str,
     context_json: Optional[Dict[str, Any]] = None,
     aggregates: Optional[Dict[str, Any]] = None,
@@ -333,59 +398,16 @@ def call_gpt(
         except Exception:
             prompt_tokens_est += 0
 
-    attempt = 0
-    sleep_prev = 0.0
-    response_format_enabled = response_format is not None
-
-    while True:
-        attempt += 1
-        try:
-            with reserve(prompt_tokens_est):
-                raw = call_openai_chat(
-                    api_key,
-                    model,
-                    messages,
-                    temperature=temperature,
-                    response_format=response_format if response_format_enabled else None,
-                    max_tokens=call_max_tokens,
-                    stop=stop,
-                    tokens_estimate=prompt_tokens_est,
-                )
-        except OpenAIError as exc:
-            message = str(exc)
-            lowered = message.lower()
-            if (
-                response_format_enabled
-                and response_format
-                and _looks_like_response_format_error(message)
-                and "status 429" not in lowered
-            ):
-                response_format_enabled = False
-                attempt -= 1
-                continue
-            if "status 429" not in lowered:
-                raise
-            if attempt >= MAX_429:
-                log.error("gpt.call_gpt.gave_up_429 attempts=%s", attempt)
-                raise
-            retry_after = getattr(exc, "retry_after", None)
-            wait_s: float | None = None
-            if isinstance(retry_after, (int, float)):
-                wait_s = float(retry_after)
-            if wait_s is None:
-                wait_s = _extract_retry_after_seconds(message)
-            if wait_s is None:
-                wait_s = sleep_prev
-            sleep_prev = decorrelated_jitter_sleep(wait_s or sleep_prev, BACKOFF_CAP)
-            log.warning(
-                "gpt.call_gpt.retry_429 attempt=%s sleep=%.2fs",
-                attempt,
-                sleep_prev,
-            )
-            continue
-        if attempt > 1:
-            log.info("gpt.call_gpt.recovered status=OK_RECOVERED attempts=%s", attempt)
-        break
+    raw = call_gpt(
+        messages=messages,
+        api_key=api_key,
+        model=model,
+        temperature=temperature,
+        response_format=response_format,
+        max_tokens=call_max_tokens,
+        stop=stop,
+        tokens_estimate=prompt_tokens_est,
+    )
 
     parsed_json, text_content = _parse_message_content(raw)
     if is_json_only(canonical):
@@ -581,108 +603,56 @@ def call_openai_chat(
         payload["stop"] = stop
     if response_format is not None:
         payload["response_format"] = response_format
-    est_tokens = int(tokens_estimate or 0)
-
-    rl_info_cache: Optional[Dict[str, Any]] = None
-
-    def _get_rl_info(*, force: bool = False) -> Dict[str, Any]:
-        nonlocal rl_info_cache
-        if rl_info_cache is None and (force or AI_API_VERBOSE):
-            try:
-                rl_info_cache = rl_snapshot() or {}
-            except Exception:
-                rl_info_cache = {}
-        return rl_info_cache or {}
-
-    def _warn_if_limit_near(token_count: int) -> None:
-        if token_count <= 0 or LIMIT_NEAR_FRAC <= 0:
-            return
-        rl_info = _get_rl_info(force=True)
-        eff_tpm = int(rl_info.get("eff_tpm") or 0)
-        if eff_tpm <= 0:
-            return
-        frac_tpm = float(token_count) / max(1, eff_tpm)
-        if frac_tpm >= LIMIT_NEAR_FRAC:
-            logger.warning(
-                "gpt.limit.near tpm_frac=%.2f tokens=%d",
-                frac_tpm,
-                token_count,
-            )
 
     if AI_API_VERBOSE >= 2:
-        rl = _get_rl_info()
         logger.debug(
-            "gpt.pre model=%s est_tokens=%d eff_tpm=%d eff_rpm=%d headroom=%.2f conc=%d",
+            "gpt.pre model=%s est_tokens=%s",
             model,
-            est_tokens,
-            int(rl.get("eff_tpm", 0)),
-            int(rl.get("eff_rpm", 0)),
-            float(rl.get("headroom", 0.0)),
-            int(rl.get("max_conc", 0)),
+            str(tokens_estimate or ""),
         )
-    attempt = 0
-    while True:
-        attempt += 1
-        t0 = time.perf_counter()
+
+    try:
+        response = requests.post(
+            url,
+            headers=headers,
+            data=json.dumps(payload),
+            timeout=60,
+        )
+    except requests.RequestException as exc:
+        raise OpenAIError(f"Failed to connect to OpenAI API: {exc}") from exc
+
+    if response.status_code == 200:
         try:
-            response = requests.post(
-                url,
-                headers=headers,
-                data=json.dumps(payload),
-                timeout=60,
-            )
-        except requests.RequestException as exc:
-            raise OpenAIError(f"Failed to connect to OpenAI API: {exc}") from exc
-        latency_ms = int(round((time.perf_counter() - t0) * 1000))
-        if response.status_code == 200:
-            try:
-                data = response.json()
-            except Exception as exc:
-                raise OpenAIError(f"Invalid JSON response from OpenAI: {exc}") from exc
+            data = response.json()
+        except Exception as exc:
+            raise OpenAIError(f"Invalid JSON response from OpenAI: {exc}") from exc
+        if AI_API_VERBOSE >= 2:
             usage = data.get("usage") if isinstance(data, dict) else None
-            if isinstance(usage, dict) and usage:
-                prompt_tokens = int(usage.get("prompt_tokens") or 0)
-                completion_tokens = int(usage.get("completion_tokens") or 0)
-                total_tokens = int(usage.get("total_tokens") or prompt_tokens + completion_tokens)
-                if AI_API_VERBOSE >= 2:
-                    logger.debug(
-                        "gpt.post model=%s prompt_tokens=%d completion_tokens=%d total_tokens=%d latency_ms=%d",
-                        model,
-                        prompt_tokens,
-                        completion_tokens,
-                        total_tokens,
-                        latency_ms,
-                    )
-                observed_tokens = total_tokens or (prompt_tokens + completion_tokens)
-                if observed_tokens:
-                    _warn_if_limit_near(int(observed_tokens))
-            elif est_tokens:
-                _warn_if_limit_near(est_tokens)
-            return data
+            if isinstance(usage, dict):
+                logger.debug(
+                    "gpt.post model=%s prompt_tokens=%s completion_tokens=%s total_tokens=%s",
+                    model,
+                    usage.get("prompt_tokens"),
+                    usage.get("completion_tokens"),
+                    usage.get("total_tokens"),
+                )
+        return data
 
-        try:
-            err = response.json()
-            msg = err.get("error", {}).get("message", response.text)
-        except Exception:
-            msg = response.text
-        message = f"OpenAI API returned status {response.status_code}: {msg}"
-        if response.status_code != 429:
-            logger.error("gpt.error status=%s detail=%s", response.status_code, msg)
-            raise OpenAIError(message)
-
+    try:
+        err = response.json()
+        msg = err.get("error", {}).get("message", response.text)
+    except Exception:
+        msg = response.text
+    message = f"OpenAI API returned status {response.status_code}: {msg}"
+    error = OpenAIError(message)
+    setattr(error, "response", response)
+    if response.status_code == 429:
         retry_hint = _parse_retry_after_seconds(response, msg)
-        base = retry_hint
-        if base is None:
-            base = min(10.0, 0.5 * (2 ** (attempt - 1)))
-        jitter = random.uniform(-0.2, 0.2)
-        delay = max(0.25, min(10.0, (base or 0.0)) + jitter)
-        logger.warning("gpt.429 retry_in=%.2fs attempt=%d", delay, attempt)
-        time.sleep(delay)
-        if attempt >= 2:
-            error = RateLimitWouldDegrade(message)
-            if retry_hint is not None:
-                setattr(error, "retry_after", retry_hint)
-            raise error
+        if retry_hint is not None:
+            setattr(error, "retry_after", retry_hint)
+    else:
+        logger.error("gpt.error status=%s detail=%s", response.status_code, msg)
+    raise error
 
 
 def build_evaluation_prompt(product: Dict[str, Any]) -> str:
@@ -787,7 +757,7 @@ def evaluate_product(
         {"role": "system", "content": "Eres un asistente inteligente que responde en español."},
         {"role": "user", "content": prompt},
     ]
-    resp_json = call_openai_chat(api_key, model, messages)
+    resp_json = call_gpt(messages=messages, api_key=api_key, model=model)
     try:
         content = resp_json["choices"][0]["message"]["content"].strip()
     except Exception as exc:
@@ -1032,10 +1002,10 @@ def generate_ba_insights(api_key: str, model: str, product: Dict[str, Any]) -> T
     ]
 
     start = time.time()
-    resp = call_openai_chat(
-        api_key,
-        model,
-        messages,
+    resp = call_gpt(
+        messages=messages,
+        api_key=api_key,
+        model=model,
         temperature=0.2,
         response_format={"type": "json_object"},
     )
@@ -1132,10 +1102,10 @@ def generate_batch_columns(api_key: str, model: str, items: List[Dict[str, Any]]
     ]
 
     start = time.time()
-    resp = call_openai_chat(
-        api_key,
-        model,
-        messages,
+    resp = call_gpt(
+        messages=messages,
+        api_key=api_key,
+        model=model,
         temperature=0.2,
         response_format={"type": "json_object"},
     )
@@ -1379,7 +1349,7 @@ def evaluate_winner_score(
         },
         {"role": "user", "content": user_content},
     ]
-    resp_json = call_openai_chat(api_key, model, messages)
+    resp_json = call_gpt(messages=messages, api_key=api_key, model=model)
     try:
         content = resp_json["choices"][0]["message"]["content"].strip()
         raw = json.loads(content)
@@ -1450,7 +1420,12 @@ def simplify_product_names(api_key: str, model: str, names: List[str], *, temper
         {"role": "user", "content": prompt},
     ]
     try:
-        resp = call_openai_chat(api_key, model, messages, temperature=temperature)
+        resp = call_gpt(
+            messages=messages,
+            api_key=api_key,
+            model=model,
+            temperature=temperature,
+        )
         # We expect a JSON response in the assistant's content
         content = resp['choices'][0]['message']['content']
         simplified = json.loads(content)
@@ -1562,7 +1537,7 @@ def recommend_winner_weights(
 
     parsed = {}
     try:
-        resp = call_openai_chat(api_key, model, messages)
+        resp = call_gpt(messages=messages, api_key=api_key, model=model)
         content = resp["choices"][0]["message"]["content"].strip()
         parsed = _extract_json_block(content)
     except Exception:
@@ -1648,7 +1623,7 @@ def summarize_top_products(api_key: str, model: str, products: List[Dict[str, An
         },
         {"role": "user", "content": prompt},
     ]
-    resp = call_openai_chat(api_key, model, messages)
+    resp = call_gpt(messages=messages, api_key=api_key, model=model)
     try:
         return resp["choices"][0]["message"]["content"].strip()
     except Exception as exc:

--- a/product_research_app/ratelimit.py
+++ b/product_research_app/ratelimit.py
@@ -1,196 +1,83 @@
-import asyncio
-import logging
-import os
-import random
-import threading
-import time
-from collections import deque
+from __future__ import annotations
+import os, time, threading, random
 from contextlib import contextmanager
-from typing import Deque, Tuple
 
+def _env_int(name, default):
+    try: return int(os.getenv(name, default))
+    except: return default
+def _env_float(name, default):
+    try: return float(os.getenv(name, default))
+    except: return default
 
-def _env_int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, default))
-    except Exception:
-        return default
+_TPM = _env_int("PRAPP_OPENAI_TPM", 30000)
+_RPM = _env_int("PRAPP_OPENAI_RPM", 3000)
+_HEADROOM = _env_float("PRAPP_OPENAI_HEADROOM", 0.85)
+_MAX_CONC = _env_int("PRAPP_OPENAI_MAX_CONCURRENCY", 2)
 
+# Efectivo tras aplicar headroom
+_EFF_TPM = max(1, int(_TPM * _HEADROOM))
+_EFF_RPM = max(1, int(_RPM * _HEADROOM))
 
-def _resolve_headroom() -> float:
-    raw = os.getenv("AI_RL_HEADROOM")
-    if raw is None:
-        raw = os.getenv("PRAPP_OPENAI_HEADROOM", "0.75")
-    try:
-        return float(raw)
-    except Exception:
-        return 0.75
-
-
-HEADROOM = _resolve_headroom()
-RAW_TPM = _env_int("PRAPP_OPENAI_TPM", 30000)
-RAW_RPM = _env_int("PRAPP_OPENAI_RPM", 3000)
-
-if RAW_TPM <= 0:
-    EFFECTIVE_TPM = 0
-else:
-    EFFECTIVE_TPM = max(1, int(RAW_TPM * HEADROOM))
-
-if RAW_RPM <= 0:
-    EFFECTIVE_RPM = 0
-else:
-    EFFECTIVE_RPM = max(1, int(RAW_RPM * HEADROOM))
-
-logger = logging.getLogger(__name__)
-
-
-class _RollingLimiter:
-    def __init__(self, eff_rpm: int, eff_tpm: int) -> None:
-        self.eff_rpm = max(0, eff_rpm)
-        self.eff_tpm = max(0, eff_tpm)
+class _TokenBucket:
+    def __init__(self, capacity_per_min: int):
+        self.capacity = max(1, capacity_per_min)
+        self.tokens = float(self.capacity)
         self.lock = threading.Lock()
-        self.request_events: Deque[float] = deque()
-        self.token_events: Deque[Tuple[float, int]] = deque()
-        self.token_total = 0
-
-    def _cleanup(self, now: float) -> None:
-        horizon = now - 60.0
-        while self.request_events and self.request_events[0] <= horizon:
-            self.request_events.popleft()
-        while self.token_events and self.token_events[0][0] <= horizon:
-            _, amount = self.token_events.popleft()
-            self.token_total -= amount
-        if self.token_total < 0:
-            self.token_total = 0
-
-    def _record_locked(self, now: float, amount: int) -> None:
-        self.request_events.append(now)
-        self.token_events.append((now, amount))
-        self.token_total += amount
-
-    def preflight(self, amount: int) -> Tuple[float, int, int, int, int, bool]:
+        self.last = time.monotonic()
+    def acquire(self, amount: int):
+        amount = max(1, int(amount))
         with self.lock:
-            now = time.monotonic()
-            self._cleanup(now)
-            req_count = len(self.request_events)
-            token_total = self.token_total
+            while True:
+                now = time.monotonic()
+                # recarga lineal por segundo
+                refill = (now - self.last) * (self.capacity / 60.0)
+                if refill > 0:
+                    self.tokens = min(self.capacity, self.tokens + refill)
+                    self.last = now
+                if self.tokens >= amount:
+                    self.tokens -= amount
+                    return
+                # esperar lo justo para acumular lo que falta
+                deficit = amount - self.tokens
+                rate_per_s = (self.capacity / 60.0)
+                sleep_s = max(deficit / rate_per_s, 0.01)
+                # liberar el lock para no bloquear a quienes vengan a recargar/consultar
+                self.lock.release()
+                try:
+                    time.sleep(sleep_s)
+                finally:
+                    self.lock.acquire()
 
-            rpm_wait = 0.0
-            if self.eff_rpm > 0 and req_count >= self.eff_rpm:
-                earliest = self.request_events[0]
-                rpm_wait = max(0.0, (earliest + 60.0) - now)
+# buckets globales
+_tokens_bucket = _TokenBucket(_EFF_TPM)
+_requests_bucket = _TokenBucket(_EFF_RPM)
 
-            tpm_wait = 0.0
-            if self.eff_tpm > 0 and token_total + amount > self.eff_tpm:
-                excess = token_total + amount - self.eff_tpm
-                acc = 0
-                wait_until: float | None = None
-                for ts, used in self.token_events:
-                    acc += used
-                    if acc >= excess:
-                        wait_until = ts + 60.0
-                        break
-                if wait_until is not None:
-                    tpm_wait = max(0.0, wait_until - now)
-
-            delay = max(rpm_wait, tpm_wait)
-            if delay <= 0:
-                self._record_locked(now, amount)
-                return 0.0, req_count + 1, token_total + amount, self.eff_rpm, self.eff_tpm, True
-
-            return delay, req_count, token_total, self.eff_rpm, self.eff_tpm, False
-
-    def commit(self, amount: int) -> Tuple[int, int]:
-        with self.lock:
-            now = time.monotonic()
-            self._cleanup(now)
-            self._record_locked(now, amount)
-            return len(self.request_events), self.token_total
-
-
-_limiter = _RollingLimiter(EFFECTIVE_RPM, EFFECTIVE_TPM)
-
-
-def _normalize_amount(tokens_in: int, tokens_out: int) -> int:
-    try:
-        in_val = int(tokens_in or 0)
-    except Exception:
-        in_val = 0
-    try:
-        out_val = int(tokens_out or 0)
-    except Exception:
-        out_val = 0
-    total = max(0, in_val) + max(0, out_val)
-    return max(1, total)
-
-
-def snapshot() -> dict[str, int | float | None]:
-    return {
-        "eff_tpm": EFFECTIVE_TPM,
-        "eff_rpm": EFFECTIVE_RPM,
-        "headroom": HEADROOM,
-        "max_conc": None,
-    }
-
-
-async def acquire(tokens_in: int, tokens_out: int = 0) -> float:
-    amount = _normalize_amount(tokens_in, tokens_out)
-    delay, req_usage, token_usage, eff_rpm, eff_tpm, committed = _limiter.preflight(amount)
-    waited = 0.0
-    if delay > 0:
-        if delay > 1.0:
-            logger.info(
-                "rate_limit_wait waited=%.2fs rpm=%d/%s tpm=%d/%s",
-                delay,
-                req_usage,
-                str(eff_rpm or "∞"),
-                token_usage,
-                str(eff_tpm or "∞"),
-            )
-        await asyncio.sleep(delay)
-        _limiter.commit(amount)
-        waited = delay
-    elif not committed:
-        _limiter.commit(amount)
-    return waited
-
+# semáforo global para capar concurrencia
+_conc_sem = threading.BoundedSemaphore(_MAX_CONC)
 
 @contextmanager
 def reserve(tokens_estimate: int):
-    amount = _normalize_amount(tokens_estimate, 0)
-    delay, req_usage, token_usage, eff_rpm, eff_tpm, committed = _limiter.preflight(amount)
+    """
+    Embudo global de RPM/TPM + concurrencia.
+    Debe envolver TODA llamada real al proveedor (batch y refine).
+    """
+    _conc_sem.acquire()
     try:
-        if delay > 0:
-            if delay > 1.0:
-                logger.info(
-                    "rate_limit_wait waited=%.2fs rpm=%d/%s tpm=%d/%s",
-                    delay,
-                    req_usage,
-                    str(eff_rpm or "∞"),
-                    token_usage,
-                    str(eff_tpm or "∞"),
-                )
-            time.sleep(delay)
-            _limiter.commit(amount)
-        elif not committed:
-            _limiter.commit(amount)
+        # 1) limita RPM (una unidad por request)
+        _requests_bucket.acquire(1)
+        # 2) limita TPM (tokens estimados)
+        _tokens_bucket.acquire(max(1, int(tokens_estimate)))
         yield
     finally:
-        # No release step required; limiter tracks rolling windows only.
-        pass
-
-
-def log_throttled(req_id: str | None, retry_after: float | None, waited: float) -> None:
-    logger.warning(
-        "rate_limit_throttled req_id=%s retry_after=%.2f waited=%.2f",
-        req_id or "",
-        float(retry_after) if retry_after is not None else -1.0,
-        float(waited or 0.0),
-    )
-
+        _conc_sem.release()
 
 def decorrelated_jitter_sleep(prev: float, cap: float) -> float:
+    """
+    Backoff con "decorrelated jitter" (AWS). Devuelve el sleep usado.
+    """
     base = 0.3
+    prev = max(0.0, float(prev or 0.0))
+    cap = max(base, float(cap or base))
     next_sleep = min(cap, random.uniform(base, prev * 3 if prev > 0 else 1.0))
     time.sleep(next_sleep)
     return next_sleep
-

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -2612,10 +2612,14 @@ class RequestHandler(BaseHTTPRequestHandler):
             self.wfile.write(json.dumps({"error": "No API key configured"}).encode('utf-8'))
             return
         try:
-            resp = gpt.call_openai_chat(api_key, model, [
-                {"role": "system", "content": "Eres un asistente útil."},
-                {"role": "user", "content": prompt},
-            ])
+            resp = gpt.call_gpt(
+                messages=[
+                    {"role": "system", "content": "Eres un asistente útil."},
+                    {"role": "user", "content": prompt},
+                ],
+                api_key=api_key,
+                model=model,
+            )
             content = resp['choices'][0]['message']['content']
             self._set_json()
             self.wfile.write(json.dumps({"response": content}).encode('utf-8'))
@@ -2652,7 +2656,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         data = payload.get("data")
 
         try:
-            result = gpt.call_gpt(
+            result = gpt.call_prompt_task(
                 canonical,
                 context_json=context_json,
                 aggregates=aggregates,
@@ -2838,10 +2842,14 @@ class RequestHandler(BaseHTTPRequestHandler):
                         "propón pesos (de 0 a 2) para cada métrica en formato JSON con las claves exactas: "
                         "momentum, saturation, differentiation, social_proof, margin, logistics."
                     )
-                    resp = gpt.call_openai_chat(api_key, model, [
-                        {"role": "system", "content": "Eres un asistente experto en scoring de productos."},
-                        {"role": "user", "content": prompt},
-                    ])
+                    resp = gpt.call_gpt(
+                        messages=[
+                            {"role": "system", "content": "Eres un asistente experto en scoring de productos."},
+                            {"role": "user", "content": prompt},
+                        ],
+                        api_key=api_key,
+                        model=model,
+                    )
                     content = resp['choices'][0]['message']['content']
                     # Attempt to parse JSON from content
                     try:


### PR DESCRIPTION
## Summary
- add a global semaphore and token-bucket limiter with jitter backoff for GPT usage
- refactor gpt.call_gpt into a single funnel and route all GPT callers through it, including ai_columns and web endpoints
- simplify AI batch handling, remove legacy degradation paths, and add a stubbed smoke test for 429 recovery

## Testing
- python -m product_research_app.dev_test_ratelimit

------
https://chatgpt.com/codex/tasks/task_e_68d970e112d08328bd38f63505a4d05b