### PR TITLE
Refine global progress bar layout

### DIFF
--- a/product_research_app/static/css/loading.css
+++ b/product_research_app/static/css/loading.css
@@ -38,17 +38,56 @@
 /* Kill switch por si aparece legacy UI */
 #top-progress, .loading-overlay { display: none !important; }
 
-/* === Cancelar en barra global === */
-#global-progress-wrapper { position: relative; }
-.progress-rail { padding-right: 88px; } /* hueco para el botón */
-#progress-cancel-btn {
-  position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
-  display: none; /* visible sólo en carga */
-  min-width: 88px; height: 28px;
-  border: 0; border-radius: 999px; cursor: pointer;
-  font-weight: 600; font-size: 13px; line-height: 28px; text-align: center;
-  background: linear-gradient(90deg,#5b4dd7,#7a53d6); color: #fff;
-  box-shadow: 0 2px 6px rgba(0,0,0,.25);
-  pointer-events: auto; z-index: 5;
+/* === Barra global + botón Cancelar: layout flex, sin solapes === */
+#global-progress-wrapper{
+  display: flex;                 /* barra + botón en fila */
+  align-items: center;           /* centrado vertical real */
+  gap: 8px;                      /* respiración entre barra y botón */
+  position: relative;
+  z-index: 40;
+  pointer-events: auto;
 }
+
+/* La barra se estira, el botón no */
+#global-progress-bar{
+  flex: 1 1 auto;                /* ocupa el espacio sobrante */
+  height: 10px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+/* La barrita no debe bloquear los clics del botón */
+#global-progress-bar,
+#progress-slot-global { pointer-events: none; }
+
+/* Botón Cancelar con texto centrado y color de la app */
+#progress-cancel-btn{
+  position: static !important;   /* fuera el absolute */
+  transform: none !important;
+  display: none;                 /* lo muestra el JS sólo en carga */
+  min-width: 92px;
+  height: 30px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 9999px;
+  background: linear-gradient(90deg,#5b4dd7,#7a53d6);
+  color: #fff;
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1;                /* evita desajustes */
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0,0,0,.25);
+  cursor: pointer;
+  pointer-events: auto;          /* clickeable */
+}
+
 #progress-cancel-btn:hover { opacity: .9; }
+#progress-cancel-btn:disabled { opacity:.6; cursor:not-allowed; }
+
+/* Compacto en pantallas angostas */
+@media (max-width: 700px){
+  #progress-cancel-btn{
+    min-width: 78px; height: 28px; padding: 0 10px; font-size: 12px;
+  }
+}

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -431,7 +431,7 @@ let __activeUploadXhr = null;   // para abort() de la subida
 let __activeAIJobId   = null;   // para cancelar en backend
 function showCancelButton(onClick) {
   cancelBtn.onclick = onClick;
-  cancelBtn.style.display = 'inline-block';
+  cancelBtn.style.display = 'inline-flex';
 }
 function hideCancelButton() {
   cancelBtn.style.display = 'none';


### PR DESCRIPTION
## Summary
- switch the global progress wrapper to a flex layout so the bar stretches and the cancel button sits to the right without overlap
- restyle the cancel button to remove absolute positioning while keeping the purple palette and clickable area clear of the bar
- update the cancel button toggling to use inline-flex so the centered flex styling applies when shown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dad75765188328a373879529d51649