### PR TITLE
Adjust global progress visibility handling

### DIFF
--- a/product_research_app/static/css/loading.css
+++ b/product_research_app/static/css/loading.css
@@ -41,7 +41,11 @@
 /* ===== Barra global + botón Cancelar (layout flex) ===== */
 :root{ --gp-height:16px; }
 
-#global-progress-wrapper{
+/* Oculto si no hay tareas */
+#global-progress-wrapper{ display:none; }
+
+/* Visible solo cuando el JS lo marca como .show */
+#global-progress-wrapper.show{
   display:flex;
   align-items:center;
   gap:8px;


### PR DESCRIPTION
## Summary
- hide the global progress wrapper by default and reveal it only when tasks are active
- toggle wrapper, slot, and cancel button visibility in `refreshHost`, clearing the slot when idle
- reset the global progress elements to a hidden state on initial page load

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dadd6bc2088328a3e51187daeee099