### PR TITLE
Make product table header sticky

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -20,6 +20,7 @@ body {
   --ws-thumb: var(--ws-accent);
   --ws-pill-bg: rgba(167,139,250,.15);
   --ws-pill-border: rgba(167,139,250,.45);
+  --table-sticky-top: 0px; /* se calcula dinámicamente desde JS */
 }
 
 body.dark {
@@ -1214,6 +1215,16 @@ th.col-desire, td.col-desire { width: 360px; max-width: 360px; }
 .table--compact tbody tr:hover{ background:#0f1430; }
 th[aria-sort="ascending"]::after{ content:" ▲"; opacity:.6; }
 th[aria-sort="descending"]::after{ content:" ▼"; opacity:.6; }
+
+/* Cabecera sticky específica para la tabla principal */
+#productTable.table--compact thead th {
+  position: sticky;
+  top: var(--table-sticky-top);
+  z-index: 30;               /* por encima de filas/scroll */
+  background: #0f1223;       /* mismo tono que el resto de cabeceras en dark */
+  /* evita que se vea “traslúcida” al pasar por celdas con contenido */
+  box-shadow: 0 1px 0 rgba(255,255,255,0.04) inset;
+}
 
 /* Insights */
 .insights-toolbar {

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -230,7 +230,7 @@ body.dark .skeleton{background:#333;}
 </section>
 
 <section id="section-products">
-  <table id="productTable">
+  <table id="productTable" class="table--compact">
   <thead class="sticky-thead">
     <tr id="headerRow"></tr>
   </thead>

--- a/product_research_app/static/js/loading.js
+++ b/product_research_app/static/js/loading.js
@@ -184,3 +184,27 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   if (btn) btn.style.display = 'none';
 });
+
+// === Sticky header offset for product table (header + global progress height) ===
+(() => {
+  const root = document.documentElement;
+  const headerEl = document.getElementById('topBar');
+  const progWrap = document.getElementById('global-progress-wrapper');
+
+  function setStickyTop() {
+    // Altura total del header (incluye barra de progreso si está activa porque va dentro)
+    const h = headerEl ? headerEl.getBoundingClientRect().height : 0;
+    root.style.setProperty('--table-sticky-top', `${Math.round(h)}px`);
+  }
+
+  // Inicial y en cambios de tamaño
+  setStickyTop();
+  window.addEventListener('resize', setStickyTop);
+
+  // Recalcular si cambia el header o la barra de progreso
+  if (window.ResizeObserver) {
+    const ro = new ResizeObserver(setStickyTop);
+    if (headerEl) ro.observe(headerEl);
+    if (progWrap) ro.observe(progWrap);
+  }
+})();


### PR DESCRIPTION
## Summary
- add compact table styling class to the main product table
- expose CSS variable and override sticky header styles to use a dynamic offset
- compute sticky offset in JavaScript based on the header and global progress heights

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae185bf4883288d84934da39b97c7