### PR TITLE
Fix product table header offset beneath sticky topbar

### DIFF
--- a/product_research_app/static/css/app.css
+++ b/product_research_app/static/css/app.css
@@ -1,4 +1,7 @@
 /* Global page styling */
+:root {
+  --topbar-sticky-offset: 0px;
+}
 body {
   margin: 0;
   padding: 0;
@@ -1255,3 +1258,14 @@ td.col-desire, td.col-desire .desire-text {
   overflow-wrap: anywhere;
   max-height: none !important;
 }
+
+/* Header sticky SOLO para la tabla principal de productos */
+#productTable thead th{
+  position: sticky;
+  top: var(--topbar-sticky-offset); /* pegado al topbar */
+  z-index: 50;                      /* por encima de filas */
+  background: #0f1223;              /* mismo tono de cabecera (dark) */
+}
+
+/* Si hay una regla previa que pone otro 'top', esta gana por especificidad. */
+/* No uses !important salvo que sea estrictamente necesario. */

--- a/product_research_app/static/js/loading.js
+++ b/product_research_app/static/js/loading.js
@@ -184,3 +184,24 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   if (btn) btn.style.display = 'none';
 });
+
+// Ajusta el offset del thead de #productTable para que quede justo bajo el topbar sticky
+(() => {
+  const root   = document.documentElement;
+  const topbar = document.getElementById('topBar') || document.querySelector('header');
+
+  function setStickyOffset(){
+    const h = topbar ? Math.round(topbar.getBoundingClientRect().height) : 0;
+    root.style.setProperty('--topbar-sticky-offset', `${h}px`);
+  }
+
+  // Inicial + en resize
+  setStickyOffset();
+  window.addEventListener('resize', setStickyOffset);
+
+  // Recalcular si cambia la altura del topbar (p.ej., aparece/desaparece la barra de progreso)
+  if (window.ResizeObserver && topbar){
+    const ro = new ResizeObserver(setStickyOffset);
+    ro.observe(topbar);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a CSS variable for the sticky top bar offset and apply sticky positioning to the product table header
- add a small script that updates the offset variable based on the top bar height and resizes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae368d3a0832882cc1e66b593c671