### PR TITLE
Fix ai_columns batch post-processing and relax triage strictness

### DIFF
--- a/product_research_app/services/ai_prompts.py
+++ b/product_research_app/services/ai_prompts.py
@@ -9,7 +9,7 @@ AI_FIELDS = ["desire", "desire_magnitude", "awareness_level", "competition_level
 def build_triage_messages(batch: List[Dict[str, Any]]) -> List[Dict[str, str]]:
     """Construye mensajes para decidir si un producto requiere puntuación completa."""
     sys = (
-        "Eres un clasificador. Responde SOLO con JSON válido. "
+        "Eres un clasificador. Procura responder en JSON limpio cuando sea posible. "
         "Entrada: lista de productos. Salida: array con objetos {id, needs_scoring}."
     )
     items = []
@@ -25,7 +25,7 @@ def build_triage_messages(batch: List[Dict[str, Any]]) -> List[Dict[str, str]]:
     user = (
         "Decide si se requiere evaluación completa (needs_scoring=true) "
         "solo cuando el título/desc no permitan inferir con reglas obvias.\n"
-        "Responde JSON estricto: [{\"id\": <int>, \"needs_scoring\": <bool>}, ...]\n"
+        "Devuelve una lista JSON si puedes, con objetos {\"id\": <int>, \"needs_scoring\": <bool>}.\n"
         f"INPUT={json.dumps(items, ensure_ascii=False)}"
     )
     return [{"role": "system", "content": sys}, {"role": "user", "content": user}]


### PR DESCRIPTION
## Summary
- ensure ai_columns batch results are processed even when cancellation is requested mid-loop
- increase batch and triage throughput limits and relax triage prompt JSON strictness to reduce latency

## Testing
- python -m compileall product_research_app/services/ai_columns.py product_research_app/services/prompt_templates.py
- python -m product_research_app.dev_run_pipeline --limit 40

------
https://chatgpt.com/codex/tasks/task_e_68daeaf070808328a3fb1fcc66bad2b5