### PR TITLE
Normalize estimated_tokens handling across GPT helpers

### DIFF
--- a/product_research_app/dev_test_ratelimit.py
+++ b/product_research_app/dev_test_ratelimit.py
@@ -40,7 +40,7 @@ def call_gpt_stubbed(fails: int = 3):
     orig = getattr(_g, "call_openai_chat")
     try:
         setattr(_g, "call_openai_chat", lambda **_: stub.run())
-        return call_gpt(messages=messages)
+        return call_gpt(model="stub-model", messages=messages)
     finally:
         setattr(_g, "call_openai_chat", orig)
 
@@ -81,7 +81,7 @@ def call_gpt_stubbed_5xx(fails: int = 2):
     orig = getattr(_g, "call_openai_chat")
     try:
         setattr(_g, "call_openai_chat", lambda **_: stub.run())
-        return call_gpt(messages=messages)
+        return call_gpt(model="stub-model", messages=messages)
     finally:
         setattr(_g, "call_openai_chat", orig)
         

--- a/product_research_app/ratelimit.py
+++ b/product_research_app/ratelimit.py
@@ -58,7 +58,7 @@ _eff_conc = max(1, min(_MAX_CONC, int(max(1, _MAX_CONC * _HEADROOM))))
 _conc_sem = threading.BoundedSemaphore(_eff_conc)
 
 @contextmanager
-def reserve(tokens_estimate: int):
+def reserve(estimated_tokens: int):
     """
     Embudo global de RPM/TPM + concurrencia.
     Debe envolver TODA llamada real al proveedor (batch y refine).
@@ -68,7 +68,7 @@ def reserve(tokens_estimate: int):
         # 1) limita RPM (una unidad por request)
         _requests_bucket.acquire(1)
         # 2) limita TPM (tokens estimados)
-        _tokens_bucket.acquire(max(1, int(tokens_estimate)))
+        _tokens_bucket.acquire(max(1, int(estimated_tokens)))
         yield
     finally:
         _conc_sem.release()

--- a/product_research_app/services/ai_columns.py
+++ b/product_research_app/services/ai_columns.py
@@ -752,12 +752,12 @@ def _recover_missing_sync(
         ]
         try:
             raw = gpt.call_gpt(
+                model=model,
                 messages=messages,
                 api_key=api_key,
-                model=model,
                 temperature=0.2,
                 max_tokens=max_tokens,
-                tokens_estimate=est_tokens,
+                estimated_tokens=est_tokens,
             )
         except gpt.OpenAIError:
             break
@@ -1271,12 +1271,13 @@ async def _call_batch_with_retries(
         start_ts = time.perf_counter()
         try:
             raw = await gpt.call_gpt_async(
+                model=model,
                 messages=messages,
                 api_key=api_key,
-                model=model,
                 temperature=0.2,
                 max_tokens=max_tokens,
-                tokens_estimate=tokens_est,
+                estimated_tokens=tokens_est,
+                strict_json=STRICT_JSON_ENABLED,
             )
         except gpt.OpenAIError as exc:
             duration = time.perf_counter() - start_ts
@@ -1380,12 +1381,13 @@ async def _call_triage_batch(
     ]
     start_ts = time.perf_counter()
     raw = await gpt.call_gpt_async(
+        model=model,
         messages=messages,
         api_key=api_key,
-        model=model,
         temperature=0.2,
         max_tokens=max_tokens,
-        tokens_estimate=tokens_est,
+        estimated_tokens=tokens_est,
+        strict_json=strict_json,
     )
     duration = time.perf_counter() - start_ts
     expected_ids = [cand.id for cand in batch.candidates]

--- a/product_research_app/services/ai_pipeline.py
+++ b/product_research_app/services/ai_pipeline.py
@@ -188,7 +188,7 @@ def _triage(pending: List[Dict[str, Any]]) -> List[int]:
 
 def _triage_one_batch(batch: List[Dict[str, Any]]) -> List[int]:
     msgs = ai_prompts.build_triage_messages(batch)
-    raw = gpt.call_gpt(messages=msgs, model=os.getenv("PRAPP_AI_TRIAGE_MODEL"))
+    raw = gpt.call_gpt(model=os.getenv("PRAPP_AI_TRIAGE_MODEL"), messages=msgs)
     rows = ai_prompts.parse_triage(raw)
     return [r["id"] for r in rows if r.get("needs_scoring")]
 
@@ -202,7 +202,7 @@ def _score(ids: List[int], loader_index: Dict[int, Dict[str, Any]]):
 
     def _score_batch(batch: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         msgs = ai_prompts.build_score_messages(batch)
-        raw = gpt.call_gpt(messages=msgs, model=os.getenv("PRAPP_AI_SCORE_MODEL"))
+        raw = gpt.call_gpt(model=os.getenv("PRAPP_AI_SCORE_MODEL"), messages=msgs)
         return ai_prompts.parse_score(raw)
 
     with ThreadPoolExecutor(max_workers=max(1, _CONC)) as ex:

--- a/product_research_app/tests/test_winner_score.py
+++ b/product_research_app/tests/test_winner_score.py
@@ -107,10 +107,10 @@ def test_awareness_weight_impacts_score():
 
 def test_recommend_winner_weights_includes_awareness(monkeypatch):
     # simulate GPT returning weights for price and awareness
-    def fake_call(api_key, model, messages):
+    def fake_call(*, model, messages, **kwargs):
         return {"choices": [{"message": {"content": '{"pesos": {"price": 1, "awareness": 3}}'}}]}
 
-    monkeypatch.setattr(gpt, "call_openai_chat", fake_call)
+    monkeypatch.setattr(gpt, "call_gpt", fake_call)
     samples = [{"price": 10.0, "awareness": 0.75, "target": 5.0}]
     res = gpt.recommend_winner_weights("k", "m", samples, "target")
     weights = res["weights"]

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -2706,12 +2706,12 @@ class RequestHandler(BaseHTTPRequestHandler):
             return
         try:
             resp = gpt.call_gpt(
+                model=model,
                 messages=[
                     {"role": "system", "content": "Eres un asistente útil."},
                     {"role": "user", "content": prompt},
                 ],
                 api_key=api_key,
-                model=model,
             )
             content = resp['choices'][0]['message']['content']
             self._set_json()
@@ -2936,12 +2936,12 @@ class RequestHandler(BaseHTTPRequestHandler):
                         "momentum, saturation, differentiation, social_proof, margin, logistics."
                     )
                     resp = gpt.call_gpt(
+                        model=model,
                         messages=[
                             {"role": "system", "content": "Eres un asistente experto en scoring de productos."},
                             {"role": "user", "content": prompt},
                         ],
                         api_key=api_key,
-                        model=model,
                     )
                     content = resp['choices'][0]['message']['content']
                     # Attempt to parse JSON from content


### PR DESCRIPTION
## Summary
- normalize the GPT bridge to accept only `estimated_tokens`, clean legacy aliases, and wrap async calls with the non-blocking rate limiter
- update AI columns workflows to send the normalized token estimates with the appropriate strict_json settings for triage and main scoring
- align supporting helpers, data structures, and tests with the unified naming so callers consistently pass `estimated_tokens`

## Testing
- python -m compileall -f product_research_app/gpt.py product_research_app/services/ai_columns.py product_research_app/ratelimit.py

------
https://chatgpt.com/codex/tasks/task_e_68daf8d21d7883289fc4a36af86ca124