### PR TITLE
Reduce noisy HTTP server logs for polling routes

### DIFF
--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -26,7 +26,7 @@ import io
 import re
 import logging
 import requests
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import HTTPServer
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
 from email.parser import BytesParser
@@ -909,7 +909,10 @@ class _SilentWriter:
         return getattr(self._raw, name)
 
 
-class RequestHandler(BaseHTTPRequestHandler):
+from server.http_quiet import QuietHandlerMixin
+
+
+class RequestHandler(QuietHandlerMixin):
     server_version = "ProductResearchCopilot/1.0"
 
     def setup(self):
@@ -1002,6 +1005,11 @@ class RequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self):
+        if getattr(self, "path", "") == "/favicon.ico":
+            self.send_response(204)
+            self.send_header("Cache-Control", "max-age=3600")
+            self.end_headers()
+            return
         parsed = urlparse(self.path)
         path = parsed.path
         if path == "/" or path == "/index.html":

--- a/server/http_quiet.py
+++ b/server/http_quiet.py
@@ -1,0 +1,49 @@
+from http.server import BaseHTTPRequestHandler
+import json
+import os
+
+# Coma-separado por env; por defecto estas rutas se silencian
+DEFAULT_QUIET = "/_ai_fill/status,/_import_status"
+QUIET_PATHS = tuple(
+    p.strip() for p in os.getenv("PRAPP_HTTP_QUIET", DEFAULT_QUIET).split(",") if p.strip()
+)
+
+
+class QuietHandlerMixin(BaseHTTPRequestHandler):
+    # Evita 501 en HEAD
+    def do_HEAD(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.end_headers()
+
+    # Favicon “silencioso”
+    def do_GET(self):
+        if getattr(self, "path", "") == "/favicon.ico":
+            # Responde 204 sin log de error
+            self.send_response(204)
+            self.send_header("Cache-Control", "max-age=3600")
+            self.end_headers()
+            return
+        # Delega al handler real si existe método real; si no, 404 estándar
+        if hasattr(super(), "do_GET"):
+            return super().do_GET()
+        self.send_error(404, "Not Found")
+
+    # Silenciar GETs de estado del poller
+    def log_message(self, fmt, *args):
+        path = getattr(self, "path", "")
+        if any(path.startswith(p) for p in QUIET_PATHS) or path == "/favicon.ico":
+            return
+        return super().log_message(fmt, *args)
+
+    # Ocultar “Bad request version …” de handshakes TLS erróneos
+    def log_error(self, fmt, *args):
+        reqline = getattr(self, "requestline", "") or ""
+        # Muchos clientes TLS empiezan por 0x16 0x03; aquí llega como bytes escapados
+        if "Bad request version" in fmt and reqline.startswith("\x16\x03"):
+            return
+        # También podemos ignorar 404 de favicon
+        path = getattr(self, "path", "")
+        if path == "/favicon.ico":
+            return
+        return super().log_error(fmt, *args)


### PR DESCRIPTION
## Summary
- add a QuietHandlerMixin wrapper that quiets polling endpoints, favicon requests, and TLS noise
- update the web app RequestHandler to use the mixin and serve an explicit favicon response

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbd95524a48328ad7f7d725b03e636