### PR TITLE
Improve AI fill progress reporting and reuse existing job id

### DIFF
--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -503,11 +503,14 @@ def _schedule_post_import_tasks(
             done_ai = int(final_counts.get("ok", 0) + final_counts.get("cached", 0))
             _update_import_status(
                 task_key,
+                stage="scoring",
                 phase="winner",
                 ai_counts=final_counts,
                 ai_total=total_ai,
                 ai_done=done_ai,
                 ai_pending=pending_ids,
+                finished=False,
+                fill_finished=done_ai >= total_ai if total_ai else True,
                 message="Calculando Winner Score",
             )
             database.update_import_job_progress(conn, job_id, phase="winner")
@@ -524,6 +527,7 @@ def _schedule_post_import_tasks(
                 message="Completado",
                 state="done",
                 stage="done",
+                finished=True,
                 imported=rows_imported,
                 finished_at=time.time(),
                 phase="done",


### PR DESCRIPTION
## Summary
- enrich AI fill status payloads with percent, stage and finished markers so the UI can close progress once the fill stage is complete
- return the existing job identifier when a duplicate AI fill request is received and include the job id in the normal response for downstream tracking
- flag the scoring phase explicitly in import progress updates and mark the job as finished when all post-processing completes

## Testing
- python -m compileall product_research_app/services/ai_columns.py product_research_app/web_app.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4ffec2348328ad20c759f5d57e68