### PR TITLE
Add SSE progress tracking for AI fill jobs

### DIFF
--- a/product_research_app/api/__init__.py
+++ b/product_research_app/api/__init__.py
@@ -8,9 +8,11 @@ app = Flask(__name__)
 from . import config  # noqa: E402,F401
 from .winner_score import winner_score_api  # noqa: E402
 from ..sse import sse_bp  # noqa: E402
+from ..routes.ai_events import ai_events_bp  # noqa: E402
 
 app.register_blueprint(winner_score_api, url_prefix="/api")
 app.register_blueprint(sse_bp)
+app.register_blueprint(ai_events_bp)
 
 
 @app.get("/healthz")

--- a/product_research_app/routes/__init__.py
+++ b/product_research_app/routes/__init__.py
@@ -1,0 +1,2 @@
+"""Flask route modules for API endpoints."""
+

--- a/product_research_app/routes/ai_events.py
+++ b/product_research_app/routes/ai_events.py
@@ -1,0 +1,60 @@
+"""AI progress streaming endpoints."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+from flask import Blueprint, Response, jsonify, stream_with_context
+
+from ..utils.event_broker import broker
+
+
+ai_events_bp = Blueprint("ai_events", __name__)
+
+_last_progress: Dict[str, Any] = {"progress": 0.0, "status": "idle"}
+
+
+def _sse_headers() -> Dict[str, str]:
+    return {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+        "X-Accel-Buffering": "no",
+        "Access-Control-Allow-Origin": "*",
+    }
+
+
+@ai_events_bp.route("/events/ai")
+def events_ai() -> Response:
+    generator = broker.subscribe_sync()
+
+    @stream_with_context
+    def event_stream():
+        for chunk in generator:
+            yield chunk
+
+    return Response(event_stream(), headers=_sse_headers())
+
+
+@ai_events_bp.route("/api/ai/progress")
+def get_ai_progress() -> Response:
+    return jsonify(_last_progress)
+
+
+def _update_progress_for_legacy(progress: float, status: str) -> None:
+    _last_progress["progress"] = max(0.0, min(float(progress), 1.0))
+    _last_progress["status"] = status
+
+
+def legacy_progress_updater() -> Callable[[float, str], None]:
+    def _callback(pct: float, message: str) -> None:
+        _update_progress_for_legacy(pct, message or "running")
+
+    return _callback
+
+
+__all__ = [
+    "ai_events_bp",
+    "legacy_progress_updater",
+]
+

--- a/product_research_app/utils/event_broker.py
+++ b/product_research_app/utils/event_broker.py
@@ -1,0 +1,91 @@
+"""Simple asynchronous event broker for SSE streaming."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from typing import AsyncIterator, Dict, Iterable, Iterator, List
+
+
+def _json_dumps(payload: Dict) -> str:
+    """Serialize payload defensively for SSE."""
+
+    try:
+        return json.dumps(payload, separators=(",", ":"))
+    except TypeError:
+        safe: Dict[str, object] = {}
+        for key, value in payload.items():
+            try:
+                json.dumps(value)
+            except TypeError:
+                safe[key] = str(value)
+            else:
+                safe[key] = value  # type: ignore[assignment]
+        return json.dumps(safe, separators=(",", ":"))
+
+
+class AsyncEventBroker:
+    """Very small async-friendly broker for Server-Sent Events."""
+
+    def __init__(self) -> None:
+        self._queues: List[asyncio.Queue] = []
+        self._lock = asyncio.Lock()
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+
+    async def _register_queue(self) -> asyncio.Queue:
+        q: asyncio.Queue = asyncio.Queue()
+        async with self._lock:
+            self._queues.append(q)
+        return q
+
+    async def _remove_queue(self, q: asyncio.Queue) -> None:
+        async with self._lock:
+            if q in self._queues:
+                self._queues.remove(q)
+
+    async def subscribe(self) -> AsyncIterator[str]:
+        q = await self._register_queue()
+        try:
+            while True:
+                msg = await q.get()
+                yield f"data: {_json_dumps(msg)}\n\n"
+        finally:
+            await self._remove_queue(q)
+
+    def subscribe_sync(self) -> Iterator[str]:
+        fut = asyncio.run_coroutine_threadsafe(self._register_queue(), self._loop)
+        q = fut.result()
+
+        def generator() -> Iterable[str]:
+            try:
+                while True:
+                    msg_fut = asyncio.run_coroutine_threadsafe(q.get(), self._loop)
+                    msg = msg_fut.result()
+                    yield f"data: {_json_dumps(msg)}\n\n"
+            finally:
+                asyncio.run_coroutine_threadsafe(self._remove_queue(q), self._loop).result()
+
+        return iter(generator())
+
+    async def _publish(self, msg: Dict) -> None:
+        payload = dict(msg)
+        payload.setdefault("ts", time.time())
+        async with self._lock:
+            targets = list(self._queues)
+        for q in targets:
+            try:
+                q.put_nowait(payload)
+            except asyncio.QueueFull:
+                continue
+
+    def publish(self, msg: Dict) -> None:
+        asyncio.run_coroutine_threadsafe(self._publish(msg), self._loop)
+
+
+# Module level singleton for convenience.
+broker = AsyncEventBroker()
+

--- a/product_research_app/utils/progress.py
+++ b/product_research_app/utils/progress.py
@@ -1,0 +1,41 @@
+"""Utilities to track progress of multi-step pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+ProgressCallback = Callable[[float, str], None]
+
+
+@dataclass
+class ProgressTracker:
+    total: int
+    on_progress: Optional[ProgressCallback] = None
+    _done: int = field(default=0, init=False)
+
+    def step(self, inc: int = 1, message: str = "") -> float:
+        self._done += max(0, inc)
+        pct = 0.0 if self.total <= 0 else self._done / max(self.total, 1)
+        pct = min(max(pct, 0.0), 1.0)
+        if self.on_progress:
+            self.on_progress(pct, message)
+        return pct
+
+    def update_absolute(self, value: int, message: str = "") -> float:
+        if value < 0:
+            value = 0
+        prev_done = self._done
+        self._done = max(self._done, value)
+        pct = 0.0 if self.total <= 0 else self._done / max(self.total, 1)
+        pct = min(max(pct, 0.0), 1.0)
+        if self.on_progress and (self._done != prev_done or message):
+            self.on_progress(pct, message)
+        return pct
+
+    def force_100(self, message: str = "done") -> float:
+        self._done = max(self._done, self.total if self.total > 0 else 1)
+        if self.on_progress:
+            self.on_progress(1.0, message)
+        return 1.0
+


### PR DESCRIPTION
## Summary
- add a lightweight async SSE broker plus AI events routes with legacy progress shim
- wrap the AI fill job with a progress tracker and emit final ai.done/products.updated events
- provide reusable progress utilities to publish consistent AI pipeline updates

## Testing
- python -m compileall product_research_app/routes/ai_events.py product_research_app/utils/event_broker.py product_research_app/utils/progress.py product_research_app/services/ai_columns.py

------
https://chatgpt.com/codex/tasks/task_e_68dc649310488328821dbdcd52845bab