### PR TITLE
Improve AI progress smoothing and refresh signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ The AI enrichment flow now uses configurable micro-batching and parallel HTTP ca
 
 All variables also exist under `config["ai"]` so they can be persisted in `product_research_app/config.json` when running locally.
 
+### Progress smoothing
+
+The AI progress indicator now blends step-based updates with a time estimator controlled through environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PRAPP_AI_ITEM_SEC_BASE` | `3.0` | Base time (seconds) assumed per product when estimating duration. |
+| `PRAPP_AI_ITEM_SEC_OFFSET` | `-0.2` | Offset applied to the per-item estimate (defaults to subtracting 0.2 s). |
+| `PRAPP_AI_PROGRESS_TICK` | `0.4` | Interval (seconds) between background progress updates. |
+
+The time-based loop gently advances progress up to 98 % while the job is running and hands off to the step tracker once results arrive.
+
 ## Calibration cache
 
 Calibrations for desire/competition percentiles are cached once per weights version in `product_research_app/ai_calibration_cache.json`. When insufficient data is available the fallback percentiles are persisted so subsequent jobs skip the heavy recalculation step.

--- a/product_research_app/utils/progress.py
+++ b/product_research_app/utils/progress.py
@@ -2,10 +2,23 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
+import threading
+import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
 ProgressCallback = Callable[[float, str], None]
+
+
+def _env_float(key: str, default: float) -> float:
+    """Obtain a float value from environment variables with fallback."""
+
+    try:
+        return float(os.getenv(key, str(default)))
+    except Exception:
+        return default
 
 
 @dataclass
@@ -38,4 +51,56 @@ class ProgressTracker:
         if self.on_progress:
             self.on_progress(1.0, message)
         return 1.0
+
+
+class TimeProgressLoop:
+    """Smooth progress driver based on estimated per-item duration."""
+
+    def __init__(self, n_items: int, on_progress: Optional[ProgressCallback] = None):
+        self.n_items = max(int(n_items or 0), 0)
+        self.on_progress = on_progress
+        self._tick = _env_float("PRAPP_AI_PROGRESS_TICK", 0.4)
+        base = _env_float("PRAPP_AI_ITEM_SEC_BASE", 3.0)
+        offset = _env_float("PRAPP_AI_ITEM_SEC_OFFSET", -0.2)
+        per_item = max(base + offset, 0.05)
+        self._total_time = max(self.n_items * per_item, 0.2)
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+        self._thread: Optional[threading.Thread] = None
+        self._start = 0.0
+
+    async def _run(self) -> None:
+        self._start = time.monotonic()
+        self._running = True
+        cap = 0.98
+        while self._running:
+            elapsed = max(time.monotonic() - self._start, 0.0)
+            pct = 0.0 if self._total_time <= 0 else min(elapsed / self._total_time, cap)
+            if self.on_progress:
+                try:
+                    self.on_progress(pct, "running-time")
+                except Exception:
+                    pass
+            await asyncio.sleep(self._tick)
+
+    def start(self) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._task = None
+            self._thread = threading.Thread(target=lambda: asyncio.run(self._run()), daemon=True)
+            self._thread.start()
+        else:
+            self._task = loop.create_task(self._run())
+            self._thread = None
+
+    def stop_and_force_100(self) -> None:
+        self._running = False
+        if self.on_progress:
+            try:
+                self.on_progress(1.0, "done")
+            except Exception:
+                pass
+        if self._task and not self._task.done():
+            self._task.cancel()
 


### PR DESCRIPTION
## Summary
- add a time-based progress loop with configurable timing offsets to complement the existing step tracker
- expose smoother status metadata over the AI events endpoint and document the environment flags
- trigger table refresh events after commits and when finishing the AI job

## Testing
- `python -m compileall product_research_app`


------
https://chatgpt.com/codex/tasks/task_e_68dc6b4015d883288a28e56eb17c9b3a