### PR TITLE
Add SSE-driven AI progress updates and table refresh

### DIFF
--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -654,6 +654,159 @@ let savedApiKeyLength = 0;
 const getGlobalProgressHost = () => document.querySelector('#progress-slot-global');
 const getActionHost = () => document.querySelector('#bottomBar') || getGlobalProgressHost();
 
+const AI_EVENTS_URL = '/events/ai';
+let __aiEventsInitialized = false;
+let __aiEventSource = null;
+let __aiPollTimer = null;
+let __aiLastMessageAt = 0;
+
+function __extractAiPercent(msg) {
+  if (!msg || typeof msg !== 'object') return null;
+  const fields = [msg.percent, msg.pct, msg.progress];
+  for (const field of fields) {
+    const num = Number(field);
+    if (Number.isFinite(num)) {
+      if (field === msg.progress) {
+        return Math.max(0, Math.min(100, num * 100));
+      }
+      return Math.max(0, Math.min(100, num));
+    }
+  }
+  const processed = Number(msg.processed);
+  const total = Number(msg.total);
+  if (Number.isFinite(processed) && Number.isFinite(total) && total > 0) {
+    return Math.max(0, Math.min(100, (processed / Math.max(total, 1)) * 100));
+  }
+  return null;
+}
+
+function __setAiStage(label) {
+  if (!label) return;
+  try {
+    if (window.__activeAITracker && typeof window.__activeAITracker.setStage === 'function') {
+      window.__activeAITracker.setStage(label);
+    } else {
+      const stageEl = document.querySelector('#progress-slot-global .progress-stage');
+      if (stageEl) stageEl.textContent = label;
+    }
+  } catch (_) {
+    // ignore
+  }
+}
+
+async function __triggerProductsReload() {
+  try {
+    if (typeof window.refreshProductsTable === 'function') {
+      await window.refreshProductsTable();
+      return;
+    }
+    if (typeof window.reloadTable === 'function') {
+      await window.reloadTable({ skipProgress: true });
+      return;
+    }
+  } catch (_) {
+    // continue to fallback
+  }
+  try {
+    if (typeof window.fetchProductsAndRender === 'function') {
+      await window.fetchProductsAndRender();
+      return;
+    }
+  } catch (_) {
+    // ignore and fallback to reload below
+  }
+  try {
+    location.reload();
+  } catch (_) {
+    // noop
+  }
+}
+
+function __handleAiEvent(msg) {
+  if (!msg || typeof msg !== 'object') return;
+  const type = String(msg.type || msg.event || '').toLowerCase();
+  if (!type) return;
+  __aiLastMessageAt = Date.now();
+  const pct = __extractAiPercent(msg);
+  if (Number.isFinite(pct) && typeof window.setProgressUI === 'function') {
+    window.setProgressUI(Math.round(pct));
+  }
+  const status = String(msg.status || '').toLowerCase();
+  if (type === 'ai.progress') {
+    if (status === 'canceling') {
+      __setAiStage('Cancelando…');
+    } else {
+      __setAiStage('IA generando…');
+    }
+  } else if (type === 'ai.done') {
+    if (status === 'canceled') {
+      __setAiStage('Cancelado');
+      if (typeof window.stopEtaProgress === 'function') window.stopEtaProgress(false);
+    } else {
+      __setAiStage('Completado');
+      if (typeof window.markBackendDone === 'function') window.markBackendDone();
+    }
+  } else if (type === 'ai.error') {
+    __setAiStage('Error');
+    if (typeof window.stopEtaProgress === 'function') window.stopEtaProgress(false);
+  }
+
+  if (type === 'products.reload' || type === 'products.updated' || (type === 'ai.done' && status === 'done')) {
+    __triggerProductsReload();
+  }
+}
+
+function __startAiPolling() {
+  if (__aiPollTimer) clearInterval(__aiPollTimer);
+  __aiPollTimer = window.setInterval(async () => {
+    if (Date.now() - __aiLastMessageAt < 4000) return;
+    try {
+      const resp = await fetch('/api/ai/progress', { cache: 'no-store', __skipLoadingHook: true });
+      if (!resp.ok) return;
+      const data = await resp.json();
+      if (!data || typeof data !== 'object') return;
+      const status = String(data.status || '').toLowerCase();
+      let type = 'ai.progress';
+      if (status === 'error') type = 'ai.error';
+      else if (status === 'done' || status === 'canceled') type = 'ai.done';
+      __handleAiEvent({ ...data, type });
+    } catch (_) {
+      // ignore errors
+    }
+  }, 1500);
+}
+
+function setupAiEvents() {
+  if (__aiEventsInitialized) return;
+  __aiEventsInitialized = true;
+  __startAiPolling();
+  if (!window.EventSource) return;
+  try {
+    const es = new EventSource(AI_EVENTS_URL);
+    __aiEventSource = es;
+    es.onmessage = (event) => {
+      if (!event || typeof event.data !== 'string') return;
+      try {
+        const payload = JSON.parse(event.data);
+        __handleAiEvent(payload);
+      } catch (_) {
+        // ignore payload parse errors
+      }
+    };
+    es.onerror = () => {
+      __aiLastMessageAt = Date.now();
+    };
+  } catch (_) {
+    __aiEventSource = null;
+  }
+}
+
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', setupAiEvents);
+} else {
+  setupAiEvents();
+}
+
 function formatPrice(n) {
   const num = Number(n);
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 })
@@ -894,6 +1047,7 @@ async function importCatalog(file, {
 
 async function runAIFillPhase({ tracker, aiStartUrl, aiStatusUrl, aiCancelUrl, importedCount, secondsPerItem = ETA_SECONDS_PER_ITEM }) {
   // 1) Iniciar job IA
+  window.__activeAITracker = tracker || null;
   tracker.setStage('Preparando IA…');
   let startData;
   try {
@@ -909,6 +1063,7 @@ async function runAIFillPhase({ tracker, aiStartUrl, aiStatusUrl, aiCancelUrl, i
   } catch (e) {
     tracker.setStage('Error al iniciar IA');
     stopEtaProgress(false);
+    window.__activeAITracker = null;
     throw e;
   }
 
@@ -978,13 +1133,20 @@ async function runAIFillPhase({ tracker, aiStartUrl, aiStatusUrl, aiCancelUrl, i
         ensureEtaFromSource(data, secondsPerItem);
         processed = Number(data?.processed || processed);
         const tot = Number(data?.total || total || 1);
-        const done = data?.status === 'done' || processed >= tot;
-        const safeTot = Math.max(1, tot);
-        const safeDone = Math.min(processed, safeTot);
-        tracker.setStage(done
-          ? 'IA finalizando…'
-          : `IA generando… (${safeDone}/${safeTot})`
-        );
+        const statusNow = String(data?.status || '').toLowerCase();
+        const done = statusNow === 'done' || processed >= tot;
+        if (statusNow === 'canceling') {
+          tracker.setStage('Cancelando…');
+        } else if (done) {
+          tracker.setStage('IA finalizando…');
+        } else {
+          tracker.setStage('IA generando…');
+        }
+        if (statusNow === 'canceled') {
+          tracker.setStage('Cancelado');
+          stopEtaProgress(false);
+          break;
+        }
         if (done) {
           await markBackendDone();
           tracker.setStage('Completado');
@@ -1001,11 +1163,10 @@ async function runAIFillPhase({ tracker, aiStartUrl, aiStatusUrl, aiCancelUrl, i
 
   __activeAIJobId = null;
   hideCancelButton();
+  window.__activeAITracker = null;
 
   // Auto-refresco de la tabla al terminar o cancelar
-  if (!finishedOk) {
-    try { await reloadTable({ skipProgress: true }); } catch {}
-  }
+  try { await reloadTable({ skipProgress: true }); } catch {}
 
   if (!finishedOk && !__cancelRequested) {
     stopEtaProgress(false);

--- a/product_research_app/static/js/loading.js
+++ b/product_research_app/static/js/loading.js
@@ -354,14 +354,16 @@ export const LoadingHelpers = {
   startEtaProgress,
   stopEtaProgress,
   markBackendDone,
-  wireJobDoneSignals
+  wireJobDoneSignals,
+  setProgressUI
 };
 
 export {
   startEtaProgress,
   stopEtaProgress,
   markBackendDone,
-  wireJobDoneSignals
+  wireJobDoneSignals,
+  setProgressUI
 };
 
 if (typeof window !== 'undefined') {
@@ -369,7 +371,8 @@ if (typeof window !== 'undefined') {
     startEtaProgress,
     stopEtaProgress,
     markBackendDone,
-    wireJobDoneSignals
+    wireJobDoneSignals,
+    setProgressUI
   });
 }
 

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -25,8 +25,10 @@ import os
 import io
 import re
 import logging
+import queue
 import requests
 from http.server import HTTPServer
+from socketserver import ThreadingMixIn
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
 from email.parser import BytesParser
@@ -55,7 +57,7 @@ from . import gpt
 from .prompts.registry import normalize_task
 from . import title_analyzer
 from . import product_enrichment
-from .sse import publish_progress
+from .sse import publish_progress, register_ai_queue, unregister_ai_queue
 from .utils import sanitize_product_name
 from .utils.db import row_to_dict, rget
 
@@ -77,6 +79,10 @@ logging.basicConfig(
     ],
 )
 logger = logging.getLogger(__name__)
+
+class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
 
 DEBUG = bool(os.environ.get("DEBUG"))
 
@@ -144,6 +150,21 @@ def _apply_weights_reset(existing: Dict[str, Any] | None = None) -> Dict[str, An
     except Exception as exc:  # pragma: no cover - defensive logging
         logger.warning("reset invalidate failed: %s", exc)
     return cfg
+
+
+def _ai_status_label(status: str) -> str:
+    value = (status or "").lower()
+    if value in {"running", "pending"}:
+        return "IA Generando..."
+    if value == "canceling":
+        return "Cancelando…"
+    if value == "canceled":
+        return "Cancelado"
+    if value == "error":
+        return "Error"
+    if value == "done":
+        return "Listo"
+    return "Listo"
 
 
 def _build_weights_payload(cfg: Dict[str, Any]) -> Dict[str, Any]:
@@ -1019,6 +1040,30 @@ class RequestHandler(QuietHandlerMixin):
             rel = path[len("/static/") :]
             self._serve_static(rel)
             return
+        if path == "/events/ai":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            client_queue = register_ai_queue()
+            try:
+                while True:
+                    try:
+                        msg = client_queue.get(timeout=10)
+                    except queue.Empty:
+                        payload = b":keepalive\n\n"
+                    else:
+                        payload = f"data: {msg}\n\n".encode("utf-8")
+                    try:
+                        self.wfile.write(payload)
+                        self.wfile.flush()
+                    except (BrokenPipeError, ConnectionResetError, ValueError):
+                        break
+            finally:
+                unregister_ai_queue(client_queue)
+            return
         if path == "/_ai_fill/status":
             params = parse_qs(parsed.query)
             job_id = params.get("job_id", [""])[0].strip()
@@ -1047,6 +1092,51 @@ class RequestHandler(QuietHandlerMixin):
                 "pct": round(pct, 2),
                 "eta_ms": eta_ms,
             }
+            self.safe_write(lambda: self.send_json(payload))
+            return
+        if path == "/api/ai/progress":
+            params = parse_qs(parsed.query)
+            job_id = params.get("job_id", [""])[0].strip()
+            job = (
+                AI_FILL_MANAGER.get_job(job_id)
+                if job_id
+                else AI_FILL_MANAGER.get_last_job()
+            )
+            if not job:
+                payload = {
+                    "status": "idle",
+                    "progress": 0.0,
+                    "percent": 0.0,
+                    "label": _ai_status_label("done"),
+                }
+            else:
+                total = int(job.get("total", 0) or 0)
+                processed = int(job.get("processed", 0) or 0)
+                remaining = max(total - processed, 0)
+                pct_val = float(job.get("pct", 0.0) or 0.0)
+                status_val = str(job.get("status", "") or "")
+                if total > 0:
+                    progress = processed / max(total, 1)
+                else:
+                    progress = pct_val / 100.0
+                    if status_val.lower() == "done":
+                        progress = 1.0
+                progress = max(0.0, min(1.0, progress))
+                payload = {
+                    "job_id": job.get("job_id"),
+                    "status": status_val,
+                    "total": total,
+                    "processed": processed,
+                    "remaining": remaining,
+                    "progress": round(progress, 4),
+                    "percent": round(progress * 100.0, 2),
+                    "eta_ms": int(job.get("eta_ms", 0) or 0),
+                    "label": _ai_status_label(status_val),
+                    "updated_at": job.get("updated_at"),
+                }
+                error_val = job.get("error")
+                if error_val:
+                    payload["error"] = str(error_val)
             self.safe_write(lambda: self.send_json(payload))
             return
         if path == "/api/log-path":
@@ -3504,7 +3594,7 @@ class RequestHandler(QuietHandlerMixin):
 def run(host: str = '127.0.0.1', port: int = 8000):
     ensure_db()
     resume_incomplete_imports()
-    httpd = HTTPServer((host, port), RequestHandler)
+    httpd = ThreadingHTTPServer((host, port), RequestHandler)
     print(f"Servidor iniciado en http://{host}:{port}")
     try:
         httpd.serve_forever()


### PR DESCRIPTION
## Summary
- add a dedicated `/events/ai` SSE stream plus an `/api/ai/progress` fallback endpoint for AI fill jobs
- publish AI job progress/done events and trigger product reload notifications from the fill manager
- subscribe the frontend to the new events to drive the progress bar without counters and refresh the table when jobs complete

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc6f45f8908328b46ff560015cafae