### PR TITLE
Fix AI progress synchronization

### DIFF
--- a/frontend/src/hooks/useAiEvents.ts
+++ b/frontend/src/hooks/useAiEvents.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from "react";
+import { useUIStore } from "../store/ui";
+import { useProductsStore } from "../store/products";
+
+export function useAiEvents() {
+  const setProgress = useUIStore((s) => s.setAiProgress);
+  const setLabel = useUIStore((s) => s.setAiLabel);
+  const markDone = useUIStore((s) => s.markAiDone);
+  const resetAi = useUIStore((s) => s.resetAi);
+  const refetch = useProductsStore((s) => s.refetch);
+  // Flag para saber si SSE está abierto (y entonces desactivar polling)
+  const sseOpenRef = useRef(false);
+
+  useEffect(() => {
+    const base = (import.meta as any).env?.VITE_API_BASE_URL ?? "";
+    const es = new EventSource(`${base}/events/ai`, { withCredentials: true });
+    sseOpenRef.current = false;
+
+    const handle = (msg: any) => {
+      // Normaliza inicio de run → reset a 0% solo aquí
+      if (msg?.type === "ai.progress" && (msg?.message === "starting" || msg?.reset === true)) {
+        resetAi();
+      }
+      switch (msg?.type) {
+        case "ai.progress": {
+          const pct = Math.round(((msg.progress ?? 0) as number) * 100);
+          setProgress(pct);
+          setLabel("IA Generando...");
+          break;
+        }
+        case "ai.done": {
+          setProgress(100);
+          setLabel("Listo");
+          markDone();
+          refetch({ force: true });
+          break;
+        }
+        case "products.updated":
+        case "products.reload": {
+          refetch({ force: true });
+          break;
+        }
+        case "ai.error": {
+          setLabel("Error");
+          break;
+        }
+      }
+    };
+
+    es.onopen = () => { sseOpenRef.current = true; };
+    es.onmessage = (ev) => {
+      try { handle(JSON.parse(ev.data)); } catch { /* ignore */ }
+    };
+    es.onerror = () => { sseOpenRef.current = false; /* polling tomará el relevo */ };
+
+    // Polling de respaldo SOLO cuando SSE no está abierto
+    const poll = window.setInterval(async () => {
+      if (sseOpenRef.current) return;
+      try {
+        const res = await fetch(`${base}/api/ai/progress`, { credentials: "include" });
+        const j = await res.json();
+        const pct = Math.round(((j.progress ?? 0) as number) * 100);
+        if (j.status === "running") {
+          setLabel("IA Generando...");
+          setProgress(pct);          // monótono (el store impide bajar)
+        } else {
+          if (pct >= 100 || j.status === "done") {
+            setProgress(100);
+            setLabel("Listo");
+            markDone();
+            refetch({ force: true });
+          }
+        }
+        if (j.reset === true || j.message === "starting") resetAi();
+      } catch {
+        /* ignore */
+      }
+    }, 2000);
+
+    return () => { window.clearInterval(poll); es.close(); };
+  }, [setProgress, setLabel, markDone, resetAi, refetch]);
+}

--- a/frontend/src/store/ui.ts
+++ b/frontend/src/store/ui.ts
@@ -1,0 +1,29 @@
+import create from "zustand";
+
+const clamp = (n: number) => Math.max(0, Math.min(100, Math.round(n)));
+
+type UIState = {
+  aiProgress: number;           // 0..100
+  aiLabel: string;              // "IA Generando..." | "Listo" | "Error"
+  aiRunning: boolean;           // control de monotonicidad
+  setAiProgress: (p: number) => void;
+  setAiLabel: (s: string) => void;
+  markAiDone: () => void;
+  resetAi: () => void;          // marcar nuevo run
+};
+
+export const useUIStore = create<UIState>((set) => ({
+  aiProgress: 0,
+  aiLabel: "Listo",
+  aiRunning: false,
+  // Monótono mientras aiRunning=true (no bajar el %)
+  setAiProgress: (p) =>
+    set((s) => {
+      const next = clamp(p);
+      if (s.aiRunning && next < s.aiProgress) return {};
+      return { aiProgress: next };
+    }),
+  setAiLabel: (s) => set({ aiLabel: s }),
+  resetAi: () => set({ aiProgress: 0, aiLabel: "IA Generando...", aiRunning: true }),
+  markAiDone: () => set({ aiProgress: 100, aiLabel: "Listo", aiRunning: false }),
+}));


### PR DESCRIPTION
## Summary
- add UI store state to track AI run lifecycle and enforce monotonic progress updates
- handle SSE events to reset progress only when a run truly starts and stop fallback polling while the stream is open
- gate fallback polling to resume only when SSE drops, preventing progress oscillation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd149522d083289aa7aa0c49001fd5