### PR TITLE
Add monotonic AI progress tracking

### DIFF
--- a/frontend/src/components/TopBar/ProgressBar.tsx
+++ b/frontend/src/components/TopBar/ProgressBar.tsx
@@ -1,0 +1,23 @@
+
+type ProgressBarProps = {
+  progress: number;
+  total: number;
+  label: string;
+};
+
+export function ProgressBar({ progress, total, label }: ProgressBarProps) {
+  const pct = total > 0 ? Math.min(100, Math.round((progress / total) * 100)) : 0;
+  const complete = pct >= 100;
+  return (
+    <div className="topbar-progress">
+      <div className="topbar-progress__bar">
+        <div
+          className={`topbar-progress__fill${complete ? " topbar-progress__fill--complete" : ""}`}
+          style={{ width: `${Math.max(0, pct)}%` }}
+        />
+      </div>
+      {/* Eliminamos el contador (0/100) que confundía */}
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useAiEvents.ts
+++ b/frontend/src/hooks/useAiEvents.ts
@@ -1,0 +1,72 @@
+import { useEffect } from "react";
+import { useUIStore } from "../store/ui";
+import { useProductsStore } from "../store/products";
+
+export function useAiEvents() {
+  const setProgress = useUIStore((s) => s.setAiProgress);
+  const setLabel = useUIStore((s) => s.setAiLabel);
+  const setJob = useUIStore((s) => s.setAiJob);
+  const markDone = useUIStore((s) => s.markAiDone);
+  const refetch = useProductsStore((s) => s.refetch);
+
+  useEffect(() => {
+    const base = (import.meta as any).env?.VITE_API_BASE_URL ?? "";
+    let es: EventSource | undefined;
+
+    try {
+      es = new EventSource(`${base}/_ai_fill/stream`, { withCredentials: true } as EventSourceInit);
+      es.onmessage = (event) => {
+        if (!event.data) return;
+        try {
+          const payload = JSON.parse(event.data);
+          if (payload?.job_id && payload.status === "running") {
+            setJob(payload.job_id);
+            const pct = Math.round((payload.progress ?? 0) * 100);
+            setLabel("IA generando…");
+            setProgress(pct);
+          } else if (payload?.status === "done") {
+            setJob(undefined);
+            setProgress(100);
+            setLabel("Listo");
+            markDone();
+            refetch({ force: true });
+          }
+        } catch {
+          // ignore malformed events
+        }
+      };
+    } catch {
+      // ignore EventSource errors
+    }
+
+    // Polling de estado (monótono y sin resets a 0)
+    const poll = window.setInterval(async () => {
+      try {
+        const res = await fetch(`${base}/api/ai/progress`, { credentials: "include" });
+        const j = await res.json();
+        if (j?.job_id && j.status === "running") {
+          setJob(j.job_id);
+          const pct = Math.round((j.progress ?? 0) * 100);
+          setLabel("IA generando…");
+          setProgress(pct);
+        } else if (j?.status === "done") {
+          setJob(undefined);
+          setProgress(100);
+          setLabel("Listo");
+          markDone();
+          refetch({ force: true });
+        }
+        // Si está "idle" no tocamos nada para no pisar la barra a 0.
+      } catch {
+        // ignora errores de red
+      }
+    }, 2000);
+
+    return () => {
+      if (es) {
+        es.close();
+      }
+      window.clearInterval(poll);
+    };
+  }, [setProgress, setLabel, setJob, markDone, refetch]);
+}

--- a/frontend/src/store/ui.ts
+++ b/frontend/src/store/ui.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+type UIState = {
+  aiProgress: number;   // 0..100
+  aiLabel: string;      // "IA generando…" | "Listo" | "Error"
+  aiJobId?: string;     // identifica el run activo para evitar resets
+  setAiProgress: (p: number) => void;
+  setAiLabel: (s: string) => void;
+  setAiJob: (id?: string) => void;
+  markAiDone: () => void;
+};
+
+export const useUIStore = create<UIState>((set) => ({
+  aiProgress: 0,
+  aiLabel: "Listo",
+  aiJobId: undefined,
+  // No permitir regresión del porcentaje dentro del mismo job
+  setAiProgress: (p) =>
+    set((s) => {
+      const next = Math.max(0, Math.min(100, Math.round(p)));
+      if (next < s.aiProgress) return {}; // ignora bajadas
+      return { aiProgress: next };
+    }),
+  setAiLabel: (s) => set({ aiLabel: s }),
+  setAiJob: (id) => set({ aiJobId: id, aiProgress: id ? 0 : 100 }),
+  markAiDone: () => set({ aiProgress: 100, aiLabel: "Listo" }),
+}));

--- a/product_research_app/services/ai_progress.py
+++ b/product_research_app/services/ai_progress.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+import time, uuid
+
+@dataclass
+class AiJobState:
+    job_id: str = ""
+    status: str = "idle"        # idle | running | done | error
+    total: int = 0
+    processed: int = 0
+    max_progress: float = 0.0   # nunca decrece dentro del mismo job
+    started_at: float = 0.0
+
+state = AiJobState()
+
+def start_job(total: int) -> str:
+    state.job_id = uuid.uuid4().hex[:12]
+    state.status = "running"
+    state.total = max(1, int(total or 1))
+    state.processed = 0
+    state.max_progress = 0.0
+    state.started_at = time.time()
+    return state.job_id
+
+def bump_processed(n: int = 1) -> float:
+    state.processed = min(state.total, state.processed + int(n))
+    p = state.processed / float(state.total)
+    if p > state.max_progress:
+        state.max_progress = p
+    return state.max_progress
+
+def finish_job() -> str:
+    state.status = "done"
+    state.max_progress = 1.0
+    state.processed = state.total
+    return state.job_id
+
+def get_progress_payload() -> dict:
+    # Garantiza progreso monótono por job
+    return {
+        "job_id": state.job_id,
+        "status": state.status,
+        "progress": state.max_progress,  # 0.0..1.0
+    }


### PR DESCRIPTION
## Summary
- add a shared AI progress tracker that exposes monotonic progress updates with job identifiers
- integrate the tracker with the AI column fill job and expose it via the progress API endpoint
- update the frontend store, hooks, and progress bar UI to consume the monotonic updates without resetting to zero

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd179845708328bbeb1731aea9e644