### PR TITLE
Implement SSE-driven AI progress tracking with refreshed UI

### DIFF
--- a/product_research_app/static/css/loading.css
+++ b/product_research_app/static/css/loading.css
@@ -27,10 +27,17 @@
 
 .progress-meta {
   position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-size: 12px; color: rgba(255,255,255,0.9); text-shadow: 0 1px 2px rgba(0,0,0,.25);
 }
 .progress-title { font-weight: 600; margin-right: 8px; }
 .progress-stage { opacity: .9; }
+.progress-eta {
+  opacity: .8;
+  font-variant-numeric: tabular-nums;
+}
 
 /* Modal: el slot está dentro del header del diálogo, así que no se difumina ni queda tapado */
 .modal .progress-slot { margin-top: 6px; }

--- a/product_research_app/static/index.html
+++ b/product_research_app/static/index.html
@@ -654,47 +654,7 @@ let savedApiKeyLength = 0;
 const getGlobalProgressHost = () => document.querySelector('#progress-slot-global');
 const getActionHost = () => document.querySelector('#bottomBar') || getGlobalProgressHost();
 
-const AI_EVENTS_URL = '/events/ai';
-let __aiEventsInitialized = false;
-let __aiEventSource = null;
-let __aiPollTimer = null;
-let __aiLastMessageAt = 0;
-
-function __extractAiPercent(msg) {
-  if (!msg || typeof msg !== 'object') return null;
-  const fields = [msg.percent, msg.pct, msg.progress];
-  for (const field of fields) {
-    const num = Number(field);
-    if (Number.isFinite(num)) {
-      if (field === msg.progress) {
-        return Math.max(0, Math.min(100, num * 100));
-      }
-      return Math.max(0, Math.min(100, num));
-    }
-  }
-  const processed = Number(msg.processed);
-  const total = Number(msg.total);
-  if (Number.isFinite(processed) && Number.isFinite(total) && total > 0) {
-    return Math.max(0, Math.min(100, (processed / Math.max(total, 1)) * 100));
-  }
-  return null;
-}
-
-function __setAiStage(label) {
-  if (!label) return;
-  try {
-    if (window.__activeAITracker && typeof window.__activeAITracker.setStage === 'function') {
-      window.__activeAITracker.setStage(label);
-    } else {
-      const stageEl = document.querySelector('#progress-slot-global .progress-stage');
-      if (stageEl) stageEl.textContent = label;
-    }
-  } catch (_) {
-    // ignore
-  }
-}
-
-async function __triggerProductsReload() {
+async function refreshTable() {
   try {
     if (typeof window.refreshProductsTable === 'function') {
       await window.refreshProductsTable();
@@ -705,7 +665,7 @@ async function __triggerProductsReload() {
       return;
     }
   } catch (_) {
-    // continue to fallback
+    // ignore and continue with fallbacks
   }
   try {
     if (typeof window.fetchProductsAndRender === 'function') {
@@ -713,7 +673,7 @@ async function __triggerProductsReload() {
       return;
     }
   } catch (_) {
-    // ignore and fallback to reload below
+    // ignore and fallback to reload
   }
   try {
     location.reload();
@@ -722,89 +682,303 @@ async function __triggerProductsReload() {
   }
 }
 
-function __handleAiEvent(msg) {
-  if (!msg || typeof msg !== 'object') return;
-  const type = String(msg.type || msg.event || '').toLowerCase();
-  if (!type) return;
-  __aiLastMessageAt = Date.now();
-  const pct = __extractAiPercent(msg);
-  if (Number.isFinite(pct) && typeof window.setProgressUI === 'function') {
-    window.setProgressUI(Math.round(pct));
+const AI_EVENTS_URL = '/api/ai/events';
+const AI_PROGRESS_URL = '/api/ai/progress';
+let aiEventSource = null;
+let aiPollTimer = null;
+let aiProgressPct = 0;
+let aiJobRunning = false;
+let aiDoneNotified = false;
+let aiEtaSamples = [];
+let aiLastEtaSample = null;
+let aiCompletionResolvers = [];
+let aiLastOutcome = null;
+
+const AI_DISABLE_SELECTORS = ['#uploadBtn', '#fileInput'];
+
+function setAiButtonsDisabled(disabled) {
+  AI_DISABLE_SELECTORS.forEach((selector) => {
+    const el = document.querySelector(selector);
+    if (!el) return;
+    if (disabled) {
+      el.setAttribute('disabled', 'disabled');
+    } else {
+      el.removeAttribute('disabled');
+    }
+  });
+}
+
+function ensureProgressShell() {
+  const wrapper = document.getElementById('global-progress-wrapper');
+  if (wrapper) wrapper.classList.add('show');
+  const host = document.getElementById('progress-slot-global');
+  if (host) {
+    host.classList.add('active');
+    const titleEl = host.querySelector('.progress-title');
+    if (titleEl) titleEl.textContent = 'Columnas IA';
   }
-  const status = String(msg.status || '').toLowerCase();
-  if (type === 'ai.progress') {
-    if (status === 'canceling') {
-      __setAiStage('Cancelando…');
-    } else {
-      __setAiStage('IA generando…');
+}
+
+function cleanupProgressShell() {
+  const host = document.getElementById('progress-slot-global');
+  if (!host) return;
+  const etaEl = host.querySelector('.progress-eta');
+  if (etaEl) {
+    etaEl.textContent = '';
+    etaEl.setAttribute('hidden', '');
+  }
+}
+
+function resetEtaTracking() {
+  aiEtaSamples = [];
+  aiLastEtaSample = null;
+}
+
+function resetAiCompletion() {
+  aiCompletionResolvers = [];
+  aiLastOutcome = null;
+}
+
+function waitForAiCompletion() {
+  if (aiLastOutcome) return Promise.resolve(aiLastOutcome);
+  return new Promise((resolve) => aiCompletionResolvers.push(resolve));
+}
+
+function resolveAiCompletion(outcome) {
+  aiLastOutcome = outcome;
+  while (aiCompletionResolvers.length) {
+    const resolver = aiCompletionResolvers.shift();
+    try { resolver(outcome); } catch (_) {}
+  }
+}
+
+function formatEta(etaMs) {
+  if (!Number.isFinite(etaMs) || etaMs <= 0) return '';
+  const totalSeconds = Math.round(etaMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes && seconds) return `~${minutes}m ${seconds}s`;
+  if (minutes) return `~${minutes}m`;
+  return `~${seconds}s`;
+}
+
+function computeEta(processed, total, etaMs) {
+  const etaFromServer = Number(etaMs);
+  const now = Date.now();
+  if (Number.isFinite(processed)) {
+    if (aiLastEtaSample && processed > aiLastEtaSample.processed) {
+      const deltaItems = processed - aiLastEtaSample.processed;
+      const deltaSec = (now - aiLastEtaSample.time) / 1000;
+      if (deltaItems > 0 && deltaSec > 0) {
+        const secPerItem = deltaSec / deltaItems;
+        aiEtaSamples.push(secPerItem);
+        if (aiEtaSamples.length > 10) aiEtaSamples.shift();
+      }
     }
-  } else if (type === 'ai.done') {
-    if (status === 'canceled') {
-      __setAiStage('Cancelado');
-      if (typeof window.stopEtaProgress === 'function') window.stopEtaProgress(false);
+    aiLastEtaSample = { processed, time: now };
+  }
+  if (Number.isFinite(etaFromServer) && etaFromServer >= 0) {
+    return etaFromServer;
+  }
+  if (!Number.isFinite(processed) || !Number.isFinite(total) || total <= processed) {
+    return 0;
+  }
+  if (!aiEtaSamples.length) return null;
+  const avgSecPerItem = aiEtaSamples.reduce((sum, val) => sum + val, 0) / aiEtaSamples.length;
+  const remaining = Math.max(0, total - processed);
+  return Math.max(0, (avgSecPerItem - 0.2) * remaining * 1000);
+}
+
+function renderProgress(pct, etaMs, status = 'running') {
+  ensureProgressShell();
+  if (typeof window.setProgressUI === 'function') {
+    window.setProgressUI(Math.max(0, Math.min(100, pct)));
+  }
+  const host = document.getElementById('progress-slot-global');
+  if (!host) return;
+  const percentEl = host.querySelector('.progress-percent');
+  if (percentEl) percentEl.textContent = `${pct}%`;
+  const etaEl = host.querySelector('.progress-eta');
+  const etaText = Number.isFinite(etaMs) && etaMs > 0 ? formatEta(etaMs) : '';
+  if (etaEl) {
+    if (etaText) {
+      etaEl.textContent = etaText;
+      etaEl.removeAttribute('hidden');
     } else {
-      __setAiStage('Completado');
-      if (typeof window.markBackendDone === 'function') window.markBackendDone();
+      etaEl.textContent = '';
+      etaEl.setAttribute('hidden', '');
     }
-  } else if (type === 'ai.error') {
-    __setAiStage('Error');
+  }
+  const stageEl = host.querySelector('.progress-stage');
+  if (stageEl) {
+    let stageText = 'IA generando…';
+    if (status === 'canceling') stageText = 'Cancelando…';
+    else if (status === 'canceled') stageText = 'Cancelado';
+    else if (status === 'error') stageText = 'Error';
+    else if (status === 'done') stageText = 'Completado';
+    if (etaText && status === 'running') {
+      stageText = `${stageText} · ${etaText}`;
+    }
+    stageEl.textContent = stageText;
+    if (window.__activeAITracker && typeof window.__activeAITracker.setStage === 'function') {
+      try { window.__activeAITracker.setStage(stageText); } catch (_) {}
+    }
+  }
+}
+
+function parseAiEventData(data) {
+  if (!data) return null;
+  if (typeof data === 'string') {
+    try { return JSON.parse(data); }
+    catch (_) { return null; }
+  }
+  if (typeof data === 'object') return data;
+  return null;
+}
+
+function handleAiProgressPayload(payload = {}) {
+  if (!payload || typeof payload !== 'object') return;
+  const processed = Number(payload.processed ?? payload.done ?? payload.ok ?? 0);
+  const total = Number(payload.total ?? payload.expected ?? payload.count ?? payload.items ?? 0);
+  const status = String(payload.status || 'running').toLowerCase();
+  if (status === 'done') {
+    handleAiComplete('done', payload);
+    return;
+  }
+  if (status === 'error') {
+    handleAiComplete('error', payload);
+    return;
+  }
+  if (status === 'canceled') {
+    handleAiComplete('canceled', payload);
+    return;
+  }
+  if (status === 'idle' || status === 'ready' || status === 'none') {
+    return;
+  }
+  if (!aiJobRunning && status === 'running') {
+    aiJobRunning = true;
+    setAiButtonsDisabled(true);
+  }
+  const pct = total > 0 ? Math.floor((processed / total) * 100) : 0;
+  aiProgressPct = Math.max(aiProgressPct, pct);
+  const etaMs = computeEta(processed, total, payload.eta_ms);
+  renderProgress(aiProgressPct, etaMs, status);
+}
+
+function handleAiComplete(status, payload = {}) {
+  const normalized = String(status || '').toLowerCase();
+  if (aiLastOutcome && aiLastOutcome.status === normalized) return;
+  if (normalized === 'done') {
+    aiProgressPct = 100;
+    renderProgress(aiProgressPct, 0, 'done');
+    notifyDoneAndRefresh();
+  } else if (normalized === 'error') {
+    renderProgress(aiProgressPct, 0, 'error');
+    if (window.toast && typeof toast.error === 'function') {
+      const msg = payload?.error || payload?.message || 'Error generando columnas IA';
+      toast.error(msg);
+    }
+    if (typeof window.stopEtaProgress === 'function') window.stopEtaProgress(false);
+  } else if (normalized === 'canceled') {
+    renderProgress(aiProgressPct, 0, 'canceled');
     if (typeof window.stopEtaProgress === 'function') window.stopEtaProgress(false);
   }
-
-  if (type === 'products.reload' || type === 'products.updated' || (type === 'ai.done' && status === 'done')) {
-    __triggerProductsReload();
+  if (normalized === 'done' || normalized === 'error' || normalized === 'canceled') {
+    aiJobRunning = false;
+    setAiButtonsDisabled(false);
+    stopProgress();
+    cleanupProgressShell();
+    resolveAiCompletion({ status: normalized, payload });
   }
 }
 
-function __startAiPolling() {
-  if (__aiPollTimer) clearInterval(__aiPollTimer);
-  __aiPollTimer = window.setInterval(async () => {
-    if (Date.now() - __aiLastMessageAt < 4000) return;
-    try {
-      const resp = await fetch('/api/ai/progress', { cache: 'no-store', __skipLoadingHook: true });
-      if (!resp.ok) return;
-      const data = await resp.json();
-      if (!data || typeof data !== 'object') return;
-      const status = String(data.status || '').toLowerCase();
-      let type = 'ai.progress';
-      if (status === 'error') type = 'ai.error';
-      else if (status === 'done' || status === 'canceled') type = 'ai.done';
-      __handleAiEvent({ ...data, type });
-    } catch (_) {
-      // ignore errors
-    }
-  }, 1500);
+function stopPolling() {
+  if (aiPollTimer) {
+    clearInterval(aiPollTimer);
+    aiPollTimer = null;
+  }
 }
 
-function setupAiEvents() {
-  if (__aiEventsInitialized) return;
-  __aiEventsInitialized = true;
-  __startAiPolling();
-  if (!window.EventSource) return;
+function stopProgress() {
+  if (aiEventSource) {
+    try { aiEventSource.close(); } catch (_) {}
+    aiEventSource = null;
+  }
+  stopPolling();
+}
+
+function startPolling() {
+  if (aiPollTimer) return;
+  aiPollTimer = window.setInterval(async () => {
+    try {
+      const resp = await fetch(AI_PROGRESS_URL, { cache: 'no-store', credentials: 'include', __skipLoadingHook: true });
+      if (!resp.ok) return;
+      const payload = await resp.json();
+      handleAiProgressPayload(payload);
+    } catch (_) {
+      // ignore polling errors
+    }
+  }, 2500);
+}
+
+function startProgress() {
+  if (aiEventSource) return;
+  stopPolling();
   try {
-    const es = new EventSource(AI_EVENTS_URL);
-    __aiEventSource = es;
-    es.onmessage = (event) => {
-      if (!event || typeof event.data !== 'string') return;
-      try {
-        const payload = JSON.parse(event.data);
-        __handleAiEvent(payload);
-      } catch (_) {
-        // ignore payload parse errors
+    aiEventSource = new EventSource(AI_EVENTS_URL, { withCredentials: true });
+    aiEventSource.addEventListener('progress', (event) => {
+      const payload = parseAiEventData(event?.data);
+      if (payload) handleAiProgressPayload(payload);
+    });
+    aiEventSource.addEventListener('done', (event) => {
+      const payload = parseAiEventData(event?.data) || {};
+      handleAiComplete('done', payload);
+    });
+    aiEventSource.onerror = () => {
+      if (aiEventSource) {
+        try { aiEventSource.close(); } catch (_) {}
+        aiEventSource = null;
       }
-    };
-    es.onerror = () => {
-      __aiLastMessageAt = Date.now();
+      startPolling();
     };
   } catch (_) {
-    __aiEventSource = null;
+    aiEventSource = null;
+    startPolling();
   }
 }
 
-if (document.readyState === 'loading') {
-  window.addEventListener('DOMContentLoaded', setupAiEvents);
-} else {
-  setupAiEvents();
+async function notifyDoneAndRefresh() {
+  if (aiDoneNotified) return;
+  aiDoneNotified = true;
+  try {
+    if (window.toast && typeof toast.success === 'function') {
+      toast.success('Columnas generadas. Actualizando tabla…');
+    }
+  } catch (_) {}
+  try {
+    await refreshTable();
+  } catch (err) {
+    console.error('No se pudo refrescar la tabla tras IA:', err);
+  } finally {
+    if (typeof window.stopEtaProgress === 'function') {
+      try { window.stopEtaProgress(true); } catch (_) {}
+    }
+    cleanupProgressShell();
+    resetEtaTracking();
+  }
+}
+
+function beginAiJobTracking() {
+  aiProgressPct = 0;
+  aiDoneNotified = false;
+  aiJobRunning = true;
+  resetEtaTracking();
+  resetAiCompletion();
+  setAiButtonsDisabled(true);
+  ensureProgressShell();
+  renderProgress(0, null, 'running');
+  startProgress();
 }
 
 function formatPrice(n) {
@@ -1045,10 +1219,12 @@ async function importCatalog(file, {
   }
 }
 
-async function runAIFillPhase({ tracker, aiStartUrl, aiStatusUrl, aiCancelUrl, importedCount, secondsPerItem = ETA_SECONDS_PER_ITEM }) {
-  // 1) Iniciar job IA
+async function runAIFillPhase({ tracker, aiStartUrl, aiStatusUrl, aiCancelUrl, importedCount }) {
   window.__activeAITracker = tracker || null;
   tracker.setStage('Preparando IA…');
+  __cancelRequested = false;
+  setAiButtonsDisabled(true);
+
   let startData;
   try {
     const resp = await fetch(aiStartUrl, {
@@ -1060,39 +1236,24 @@ async function runAIFillPhase({ tracker, aiStartUrl, aiStatusUrl, aiCancelUrl, i
     });
     if (!resp.ok) throw new Error('No se pudo iniciar IA');
     startData = await resp.json();
-  } catch (e) {
+  } catch (err) {
+    setAiButtonsDisabled(false);
     tracker.setStage('Error al iniciar IA');
-    stopEtaProgress(false);
     window.__activeAITracker = null;
-    throw e;
+    throw err;
   }
 
-  ensureEtaFromSource(startData, secondsPerItem);
-  if (!etaTimer) {
-    const fallback = startData?.total ?? importedCount ?? 1;
-    startEtaProgress(Number(fallback) || 1, secondsPerItem);
-  }
-
-  const total     = Number(startData?.total || importedCount || 0);
+  const total = Number(startData?.total || importedCount || 0);
   __activeAIJobId = String(startData?.job_id || '');
 
-  if (__activeAIJobId) {
-    const pollUrl = `${aiStatusUrl}?job_id=${encodeURIComponent(__activeAIJobId)}`;
-    const sseUrl = typeof startData?.sse_url === 'string' ? startData.sse_url : null;
-    const totalItems = Number.isFinite(total) && total > 0
-      ? total
-      : Number.isFinite(importedCount) && importedCount > 0
-        ? importedCount
-        : undefined;
-    wireJobDoneSignals({
-      jobId: __activeAIJobId,
-      sseUrl,
-      pollUrl,
-      totalItems
-    });
-  }
+  beginAiJobTracking();
+  handleAiProgressPayload({
+    processed: Number(startData?.processed || 0),
+    total,
+    status: startData?.status || 'running',
+    eta_ms: startData?.eta_ms
+  });
 
-  // Botón cancelar (aborta XHR si quedara algo y pide cancelación del job IA)
   showCancelButton(async () => {
     __cancelRequested = true;
     try { __activeUploadXhr?.abort(); } catch {}
@@ -1109,69 +1270,24 @@ async function runAIFillPhase({ tracker, aiStartUrl, aiStatusUrl, aiCancelUrl, i
     } catch {}
   });
 
-  // 2) Poll + ETA suave
-  let processed = 0;
-  let finishedOk = false;
-
-  while (true) {
-    if (__cancelRequested) {
-      tracker.setStage('Cancelando…');
-      stopEtaProgress(false);
-      break;
+  try {
+    const outcome = await waitForAiCompletion();
+    if (outcome?.status === 'done') {
+      tracker.setStage('Completado');
+    } else if (outcome?.status === 'canceled') {
+      tracker.setStage('Cancelado');
+    } else if (outcome?.status === 'error') {
+      tracker.setStage('Error');
+      throw new Error(outcome.payload?.error || outcome.payload?.message || 'Error en IA');
     }
-    if (etaFinished) {
-      finishedOk = true;
-      break;
-    }
-    try {
-      const r = await fetch(`${aiStatusUrl}?job_id=${encodeURIComponent(__activeAIJobId)}&t=${Date.now()}`, {
-        cache: 'no-store', __skipLoadingHook: true, __hostEl: getGlobalProgressHost()
-      });
-      if (r.ok) {
-        const data = await r.json();
-        backendHeartbeat();
-        ensureEtaFromSource(data, secondsPerItem);
-        processed = Number(data?.processed || processed);
-        const tot = Number(data?.total || total || 1);
-        const statusNow = String(data?.status || '').toLowerCase();
-        const done = statusNow === 'done' || processed >= tot;
-        if (statusNow === 'canceling') {
-          tracker.setStage('Cancelando…');
-        } else if (done) {
-          tracker.setStage('IA finalizando…');
-        } else {
-          tracker.setStage('IA generando…');
-        }
-        if (statusNow === 'canceled') {
-          tracker.setStage('Cancelado');
-          stopEtaProgress(false);
-          break;
-        }
-        if (done) {
-          await markBackendDone();
-          tracker.setStage('Completado');
-          finishedOk = true;
-          break;
-        }
-      }
-    } catch {
-      tracker.setStage('Esperando IA…');
-    }
-
-    await sleep(600);
+    return outcome?.payload;
+  } finally {
+    hideCancelButton();
+    window.__activeAITracker = null;
+    __activeAIJobId = null;
+    __cancelRequested = false;
+    setAiButtonsDisabled(false);
   }
-
-  __activeAIJobId = null;
-  hideCancelButton();
-  window.__activeAITracker = null;
-
-  // Auto-refresco de la tabla al terminar o cancelar
-  try { await reloadTable({ skipProgress: true }); } catch {}
-
-  if (!finishedOk && !__cancelRequested) {
-    stopEtaProgress(false);
-  }
-  __cancelRequested = false;
 }
 
 // Ensure the server shuts down cleanly when the tab or window is closed.

--- a/product_research_app/static/js/loading.js
+++ b/product_research_app/static/js/loading.js
@@ -235,7 +235,7 @@ function createRailInHost(host) {
   rail.className = 'progress-rail';
   rail.innerHTML = `
     <div class="progress-fill"></div>
-    <span class="progress-meta"><span class="progress-title">Proceso</span><span class="progress-stage">Iniciando…</span></span>
+    <span class="progress-meta"><span class="progress-title">Proceso</span><span class="progress-stage">Iniciando…</span><span class="progress-eta" hidden></span></span>
     <span class="progress-percent">0%</span>
   `;
   host.appendChild(rail);
@@ -270,7 +270,8 @@ function getRailState(host) {
   const pctEl = rail.querySelector('.progress-percent');
   const titleEl = rail.querySelector('.progress-title');
   const stageEl = rail.querySelector('.progress-stage');
-  state = { rail, fill, pctEl, titleEl, stageEl, tasks: new Map(), hideTimer: null };
+  const etaEl = rail.querySelector('.progress-eta');
+  state = { rail, fill, pctEl, titleEl, stageEl, etaEl, tasks: new Map(), hideTimer: null };
   Rails.set(host, state);
   return state;
 }


### PR DESCRIPTION
## Summary
- replace the legacy AI progress listener with SSE plus a polling fallback while keeping the percentage monotonic
- surface a refreshed progress rail that shows percent and ETA, handling toast notifications and table refresh from a single place
- disable AI-triggering controls during runs and rework the run handler to rely on the new tracking helpers

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dd27e1c234832893b74ffd885df2bb