### PR TITLE
Handle OpenAI token limits and cap AI concurrency

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,16 @@
+# OpenAI
+OPENAI_API_KEY=changeme
+OPENAI_BASE=https://api.openai.com
+
+# Límites y concurrencia
+PRAPP_OPENAI_TPM=30000
+PRAPP_OPENAI_RPM=3000
+PRAPP_OPENAI_HEADROOM=0.85
+# Concurrencia por defecto (4 seguro con gpt-5-mini; ajusta si lo necesitas)
+PRAPP_OPENAI_MAX_CONCURRENCY=4
+
+# Selección de endpoint y tokens de salida
+# 0 = usar Chat Completions; 1 = usar Responses API
+PRAPP_OPENAI_USE_RESPONSES=0
+# Límite por defecto si la llamada no lo especifica (se traduce al nombre correcto)
+PRAPP_OPENAI_DEFAULT_MAX_COMPLETION_TOKENS=2048

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ run_ai_fill_job: job=42 total=100 ok=92 cached=8 ko=0 cost=0.2150 pending=0 erro
 ```
 
 Logs tagged `ai_columns.request` are useful to verify concurrency in smoke tests: with the GPT-5 Mini defaults you should see the system happily running a few dozen overlapping requests for 100 products without tripping the new 500k TPM / 5M TPD allowances. The start/end summary logs also emit `tpm_cap`, `rpm_cap` and `tpd_cap` fields so alerting rules can be updated around the higher quotas.
+
+## Troubleshooting
+
+- Mensajes code 400, Bad request version ('JJ…') pueden aparecer si algún cliente intenta TLS contra el puerto HTTP. No afectan al pipeline.


### PR DESCRIPTION
## Summary
- normalize token limit parameters for reasoning models and the Responses API, logging the active option and supporting either endpoint
- cap AI column concurrency by environment configuration, updating defaults and documenting TLS noise troubleshooting
- add the new OpenAI environment flags to `.env.sample`

## Testing
- python -m compileall product_research_app/gpt.py product_research_app/services/ai_columns.py

------
https://chatgpt.com/codex/tasks/task_e_68dfa92e0c8483288db88995ee3a1158