### PR TITLE
Refactor AI scoring prompts to use strict JSON schema

### DIFF
--- a/product_research_app/services/prompt_templates.py
+++ b/product_research_app/services/prompt_templates.py
@@ -10,14 +10,13 @@ def _ids_to_text(ids: Iterable[int]) -> str:
 def STRICT_JSONL_PROMPT(ids: Iterable[int], fields: Tuple[str, ...]) -> str:
     ids_text = _ids_to_text(ids)
     example = (
-        "[{\"aw\":\"Medium\",\"aw_m\":55,\"d\":\"Beneficio principal\",\"d_m\":72,\"c\":\"Low\",\"c_m\":18,\"confidence\":0.9}]"
+        "[{\"id\":101,\"desire\":\"Resumen del deseo\",\"desire_label\":\"High\",\"desire_magnitude\":0.88,\"competition_level\":0.32}]"
     )
     return (
-        "Formato obligatorio: devuelve un único array JSON con un objeto por producto solicitado.\n"
-        "No añadas texto extra, comentarios ni encabezados.\n"
+        "Devuelve únicamente un ARRAY JSON. Sin comentarios, sin markdown, sin texto antes o después.\n"
         f"IDs solicitados (orden estricto): [{ids_text}]\n"
-        "Mantén el mismo orden en el array. Cada objeto debe contener únicamente las claves aw, aw_m, d, d_m, c, c_m, confidence.\n"
-        "aw y c deben ser Low|Medium|High. aw_m, d_m y c_m son enteros 0-100. confidence es un número entre 0 y 1.\n"
+        "Mantén el mismo orden en el array. Cada objeto debe incluir al menos id, desire, desire_label, desire_magnitude.\n"
+        "Añade competition_level (0-1) y price cuando puedas inferirlos. Prohibidas las explicaciones.\n"
         "Ejemplo de salida válida:\n"
         f"{example}"
     )
@@ -26,13 +25,13 @@ def STRICT_JSONL_PROMPT(ids: Iterable[int], fields: Tuple[str, ...]) -> str:
 def MISSING_ONLY_JSONL_PROMPT(ids: Iterable[int], fields: Tuple[str, ...]) -> str:
     ids_text = _ids_to_text(ids)
     example = (
-        "[{\"aw\":\"High\",\"aw_m\":80,\"d\":\"Nueva respuesta\",\"d_m\":64,\"c\":\"Medium\",\"c_m\":45,\"confidence\":0.82}]"
+        "[{\"id\":42,\"desire\":\"Nuevo resumen\",\"desire_label\":\"Medium\",\"desire_magnitude\":0.55,\"competition_level\":0.61}]"
     )
     return (
-        "Reintento: devuelve únicamente un array JSON para los IDs faltantes indicados.\n"
-        "No repitas IDs ya completados ni añadas explicaciones.\n"
+        "Reintento: devuelve únicamente un ARRAY JSON para los IDs faltantes indicados.\n"
+        "No repitas IDs ya completados ni añadas explicaciones ni comentarios.\n"
         f"IDs pendientes (mismo orden): [{ids_text}]\n"
-        "Cada objeto debe incluir solo aw, aw_m, d, d_m, c, c_m, confidence con el mismo formato estricto.\n"
+        "Cada objeto debe incluir al menos id, desire, desire_label, desire_magnitude (0-1). Añade competition_level y price si puedes.\n"
         "Ejemplo de salida esperada:\n"
         f"{example}"
     )

--- a/product_research_app/static/js/completar-ia.js
+++ b/product_research_app/static/js/completar-ia.js
@@ -69,8 +69,20 @@ async function processBatch(items) {
   });
   if (!res.ok) {
     let msg = res.statusText;
-    try { const err = await res.json(); if (err.error) msg = err.error; } catch {}
-    throw new Error(msg);
+    let detail = '';
+    try {
+      const err = await res.json();
+      if (err && typeof err === 'object') {
+        if (err.error) msg = err.error;
+        const extras = [];
+        if (err.finish_reason) extras.push(`finish_reason=${err.finish_reason}`);
+        if (err.usage) {
+          try { extras.push(`usage=${JSON.stringify(err.usage)}`); } catch {}
+        }
+        if (extras.length) detail = ` (${extras.join(' ')})`;
+      }
+    } catch {}
+    throw new Error(`${msg}${detail}`);
   }
   const data = await res.json();
   let ok = 0;

--- a/product_research_app/tests/test_gpt_messages.py
+++ b/product_research_app/tests/test_gpt_messages.py
@@ -37,3 +37,16 @@ def test_build_messages_task_b():
     json_block = user_payload.split("### AGGREGATES\n", 1)[1]
     parsed = json.loads(json_block)
     assert parsed == aggregates
+
+
+def test_prepare_params_with_schema_json_mode():
+    schema = {"name": "demo", "schema": {"type": "object"}, "strict": True}
+    payload = gpt.prepare_params(
+        model="gpt-5-mini",
+        messages=[{"role": "system", "content": "hola"}],
+        strict_json=True,
+        json_schema=schema,
+    )
+    assert payload["response_format"]["type"] == "json_schema"
+    assert payload["response_format"]["json_schema"] == schema
+    assert "temperature" not in payload

--- a/product_research_app/web_app.py
+++ b/product_research_app/web_app.py
@@ -2811,9 +2811,16 @@ class RequestHandler(QuietHandlerMixin):
             logger.info("/api/ba/insights tokens=%s duration=%.2fs", usage.get('total_tokens'), duration)
             self._set_json()
             self.wfile.write(json.dumps({"grid_updates": grid_updates}).encode('utf-8'))
-        except gpt.InvalidJSONError:
+        except gpt.InvalidJSONError as exc:
             self._set_json(502)
-            self.wfile.write(json.dumps({"error": "Respuesta IA no es JSON"}).encode('utf-8'))
+            payload = {"error": str(exc) or "Respuesta IA no es JSON"}
+            finish_reason = getattr(exc, "finish_reason", None)
+            if finish_reason:
+                payload["finish_reason"] = finish_reason
+            usage_payload = getattr(exc, "usage", None)
+            if usage_payload:
+                payload["usage"] = usage_payload
+            self.wfile.write(json.dumps(payload).encode('utf-8'))
         except Exception:
             self._set_json(503)
             self.wfile.write(json.dumps({"error": "OpenAI no disponible"}).encode('utf-8'))
@@ -2842,9 +2849,16 @@ class RequestHandler(QuietHandlerMixin):
             logger.info("/api/ia/batch-columns tokens=%s duration=%.2fs", usage.get('total_tokens'), duration)
             self._set_json()
             self.wfile.write(json.dumps({"ok": ok, "ko": ko}).encode('utf-8'))
-        except gpt.InvalidJSONError:
+        except gpt.InvalidJSONError as exc:
             self._set_json(502)
-            self.wfile.write(json.dumps({"error": "Respuesta IA no es JSON"}).encode('utf-8'))
+            payload = {"error": str(exc) or "Respuesta IA no es JSON"}
+            finish_reason = getattr(exc, "finish_reason", None)
+            if finish_reason:
+                payload["finish_reason"] = finish_reason
+            usage_payload = getattr(exc, "usage", None)
+            if usage_payload:
+                payload["usage"] = usage_payload
+            self.wfile.write(json.dumps(payload).encode('utf-8'))
         except Exception:
             self._set_json(503)
             self.wfile.write(json.dumps({"error": "OpenAI no disponible"}).encode('utf-8'))


### PR DESCRIPTION
## Summary
- enforce the new score batch JSON schema throughout prompts and column parsing, deriving labels and awareness from normalized scores
- add a reusable `prepare_params` helper so chat calls attach the provided json schema and avoid temperature for gpt-5 mini models
- surface finish_reason and usage diagnostics when JSON extraction fails, including improved frontend toast feedback

## Testing
- PYTHONPATH=. pytest product_research_app/tests/test_gpt_messages.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb79b4dc08328bc23bbbc46fe14e4