### PR TITLE
Align AI scoring prompts with new structured schema

### DIFF
--- a/product_research_app/ai/strict_jsonl.py
+++ b/product_research_app/ai/strict_jsonl.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import json
 from typing import Dict, Iterable, List, Set
 
-REQUIRED_FIELDS = ("desire", "desire_label", "desire_magnitude")
+REQUIRED_FIELDS = (
+    "desire",
+    "desire_reason",
+    "competition",
+    "competition_level",
+    "revenue",
+    "units_sold",
+    "price",
+    "oldness",
+    "rating",
+)
 
 
 def parse_jsonl_and_validate(text: str, expected_ids: Iterable[int]) -> Dict[int, dict]:

--- a/product_research_app/services/prompt_templates.py
+++ b/product_research_app/services/prompt_templates.py
@@ -10,29 +10,47 @@ def _ids_to_text(ids: Iterable[int]) -> str:
 def STRICT_JSONL_PROMPT(ids: Iterable[int], fields: Tuple[str, ...]) -> str:
     ids_text = _ids_to_text(ids)
     example = (
-        "{\"items\":[{\"id\":101,\"desire\":\"Resumen del deseo\",\"desire_label\":\"High\",\"desire_magnitude\":0.88,\"competition_level\":0.32}]}"
+        "{\"items\":[{\"id\":101,\"desire\":0.78,\"desire_reason\":\"Alta búsqueda estacional y buenos reviews.\",\"competition\":0.41,"
+        "\"competition_level\":\"medium\",\"revenue\":12450.0,\"units_sold\":380,\"price\":32.99,\"oldness\":0.18,\"rating\":4.4}]}"
     )
     return (
-        "Salida requerida: un único objeto JSON con clave items cuyo valor es un array de objetos {id, desire, desire_label, desire_magnitude, ...}.\n"
-        "Prohibido: texto, explicaciones, comentarios, fences de markdown.\n"
-        f"IDs solicitados (orden estricto): [{ids_text}]\n"
-        "Mantén el mismo orden en el array. Cada objeto debe incluir al menos id, desire, desire_label, desire_magnitude.\n"
-        "Añade competition_level (0-1) y price cuando puedas inferirlos. Prohibidas las explicaciones.\n"
-        "Ejemplo de salida válida:\n"
-        f"{example}"
+        "TAREA\n"
+        "Eres un motor de transformación de datos. Dado un listado de productos, debes devolver SOLO un objeto JSON válido que cumpla este esquema lógico:\n\n"
+        "- Objeto raíz con clave \"items\": array.\n"
+        "- Cada elemento de \"items\" es un objeto con TODAS estas claves (todas obligatorias):\n"
+        "  - id (integer)\n"
+        "  - desire (number, 0..1, con 2 decimales)\n"
+        "  - desire_reason (string, breve y específica)\n"
+        "  - competition (number, 0..1, con 2 decimales)\n"
+        "  - competition_level (string, uno de: \"low\" | \"medium\" | \"high\")\n"
+        "  - revenue (number, >=0)\n"
+        "  - units_sold (number, >=0)\n"
+        "  - price (number, >=0)\n"
+        "  - oldness (number, 0..1, con 2 decimales)\n"
+        "  - rating (number, 0..5, con 1 o 2 decimales)\n\n"
+        "REGLAS\n"
+        "- La longitud de \"items\" debe coincidir EXACTAMENTE con el número de productos de entrada.\n"
+        "- Conserva los valores de \"id\" que vengan en la entrada.\n"
+        "- Estima valores faltantes de forma razonable usando las señales disponibles (títulos, categoría, precio, reviews, volumen de búsqueda, etc.). NO uses null.\n"
+        "- Redondea: números en [0..1] a 2 decimales; rating a 1–2 decimales.\n"
+        "- Mapea competition_level desde competition:\n"
+        "  - <= 0.33 → \"low\"\n"
+        "  - > 0.33 y <= 0.66 → \"medium\"\n"
+        "  - > 0.66 → \"high\"\n"
+        "- SALIDA: imprime ÚNICAMENTE el objeto JSON final. Sin texto antes/después, sin markdown, sin comentarios.\n\n"
+        "EJEMPLO DE SALIDA VÁLIDA\n"
+        f"{example}\n\n"
+        f"IDs de referencia (mantén el orden): [{ids_text}]\n"
+        "PRODUCTS:\n"
     )
 
 
 def MISSING_ONLY_JSONL_PROMPT(ids: Iterable[int], fields: Tuple[str, ...]) -> str:
     ids_text = _ids_to_text(ids)
-    example = (
-        "{\"items\":[{\"id\":42,\"desire\":\"Nuevo resumen\",\"desire_label\":\"Medium\",\"desire_magnitude\":0.55,\"competition_level\":0.61}]}"
-    )
     return (
-        "Reintento: salida requerida: un único objeto JSON con clave items cuyo valor sea un array con los IDs faltantes en el mismo orden.\n"
-        "Prohibido añadir texto adicional, comentarios o markdown.\n"
+        "REINTENTO\n"
+        "Debes repetir la misma estructura JSON indicada arriba, pero SOLO para los IDs pendientes en el orden indicado.\n"
+        "Nada de texto adicional, markdown ni comentarios.\n"
         f"IDs pendientes (mismo orden): [{ids_text}]\n"
-        "Cada objeto debe incluir al menos id, desire, desire_label, desire_magnitude (0-1). Añade competition_level y price si puedes.\n"
-        "Ejemplo de salida esperada:\n"
-        f"{example}"
+        "PRODUCTS:\n"
     )

--- a/product_research_app/tests/test_ai_prompts_parse.py
+++ b/product_research_app/tests/test_ai_prompts_parse.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from product_research_app.services import ai_prompts
+
+
+def test_parse_score_transforms_new_schema() -> None:
+    payload = {
+        "content": json.dumps(
+            {
+                "items": [
+                    {
+                        "id": 101,
+                        "desire": 0.78,
+                        "desire_reason": "Alta búsqueda estacional y buenos reviews.",
+                        "competition": 0.41,
+                        "competition_level": "medium",
+                        "revenue": 12450.0,
+                        "units_sold": 380,
+                        "price": 32.99,
+                        "oldness": 0.18,
+                        "rating": 4.4,
+                    }
+                ]
+            }
+        )
+    }
+
+    rows = ai_prompts.parse_score(payload)
+
+    assert rows == [
+        {
+            "id": 101,
+            "desire": "Alta búsqueda estacional y buenos reviews.",
+            "desire_magnitude": "High",
+            "awareness_level": "Product-Aware",
+            "competition_level": "Medium",
+        }
+    ]


### PR DESCRIPTION
## Summary
- align the batch scoring prompt templates with the new JSON schema instructions and system messaging
- normalize the AI column parsing pipeline to ingest desire/competition fractions, compute buckets, and keep strict/JSONL fallbacks consistent
- tighten the JSON schema used for scoring responses and add a regression test covering the new structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfc202c9b88328a32b5764dc018013