### PR TITLE
Add prompts for coding automation tasks

### DIFF
--- a/product_research_app/gpt.py
+++ b/product_research_app/gpt.py
@@ -101,6 +101,20 @@ STOPWORDS = {
 }
 
 
+_REQUEST_SECTION_TASKS = {
+    "TODO_TERRENO",
+    "REFACTOR",
+    "BUGFIX",
+    "UNIT_TESTS",
+    "DOCSTRINGS",
+    "MIGRATION",
+    "API_ENDPOINT",
+    "SQL_QUERY",
+    "CLI_TOOL",
+    "JSON_REPORT",
+}
+
+
 class OpenAIError(Exception):
     """Custom exception for OpenAI API errors."""
     pass
@@ -252,6 +266,8 @@ def build_messages(
         sections.append("### AGGREGATES\n" + _dumps_payload(aggregates))
     elif canonical == "E_auto":
         sections.append("### DATA\n" + _dumps_payload(data))
+    elif canonical in _REQUEST_SECTION_TASKS:
+        sections.append("### REQUEST\n" + _dumps_payload(context_json))
 
     if mode:
         sections.append(f"### MODE\n{mode}")

--- a/product_research_app/prompts/registry.py
+++ b/product_research_app/prompts/registry.py
@@ -1,6 +1,6 @@
 """Registro de prompts para Prompt Maestro v3.
 
-Fecha de actualización: 2024-09-15.
+Fecha de actualización: 2024-10-05.
 prompt_version = "prompt-maestro-v3".
 """
 
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 PROMPT_VERSION = "prompt-maestro-v3"
-PROMPT_RELEASE_DATE = "2024-09-15"
+PROMPT_RELEASE_DATE = "2024-10-05"
 
 PROMPT_MASTER_V3_SYSTEM = """SYSTEM — PROMPT MAESTRO v3\nFecha de publicación: 2024-09-15\nIdentificador: prompt-maestro-v3\nEres Prompt Maestro v3, director de orquesta de la investigación de productos. Orquesta análisis, síntesis y recomendaciones fiables.\n\nReglas núcleo:\n1. Trabaja en español neutro, preciso y accionable.\n2. Nunca inventes datos ni referencias: si faltan, indica la carencia con claridad.\n3. No encierres respuestas JSON en bloques de código ni escapes comillas salvo que el esquema lo exija.\n4. Respeta los formatos solicitados (texto, listas, tablas o JSON) sin añadir emojis, banners ni notas superfluas.\n5. No repitas el texto de entrada salvo cuando la tarea lo pida explícitamente.\n6. Limpia HTML, Markdown u otras secuencias peligrosas antes de razonar; evita propagar código o scripts.\n7. Lee los bloques etiquetados (### CONTEXT_JSON, ### AGGREGATES, ### DATA) como JSON UTF-8 válido y preserva los identificadores tal cual.\n\nFallbacks oficiales:\n- Si la entrada es ilegible o falta información crítica, responde literalmente "ERROR: entrada inválida".\n- Si la tarea requiere datos inexistentes, responde "SIN DATOS".\n- Si no puedes garantizar la estructura pedida, responde "ERROR: formato".\n\nCuando la tarea lo pida, incluye el campo prompt_version con el valor "prompt-maestro-v3" sin alterarlo."""
 
@@ -62,6 +62,217 @@ Reglas finales:
 - Antes de imprimir, AUTOCHEQUEA: si tu texto contiene nombres de producto/categoría, medidas o marcas, reescribe el “desire_statement”.
 - No añadas campos ni comentarios."""
 
+PROMPT_TODO_TERRENO = """TAREA TODO_TERRENO — Generación de código todo-terreno
+Objetivo: producir código ejecutable según los parámetros recibidos.
+
+Recibirás un JSON en "### REQUEST" con los campos:
+- "lenguaje" (str) — lenguaje de programación destino.
+- "objetivo" (str) — descripción del problema a resolver.
+- "version" (str) — versión o runtime a respetar.
+- "entrada" (str) — formato de entrada esperado.
+- "salida" (str) — formato de salida esperado.
+- "requisitos" (array[str]) — restricciones funcionales obligatorias.
+- "casos_borde" (array[str] | str) — escenarios límite que debes manejar.
+- "estilo" (str) — guía de estilo o patrones a seguir.
+
+Instrucciones:
+1. Sustituye cada marcador {…} del esqueleto con los valores de "### REQUEST".
+2. Diseña funciones pequeñas, nombres claros y sin dependencias innecesarias.
+3. Asegura validaciones de entrada y cobertura de los casos borde listados.
+4. Añade comentarios concisos solo cuando aporten claridad.
+
+Formato de salida:
+- Entrega exclusivamente el código final dentro de ```<lenguaje>``` sin texto adicional.
+
+Fallbacks específicos:
+- Si falta "lenguaje" u "objetivo", responde exactamente "SIN DATOS"."""
+
+PROMPT_REFACTOR = """TAREA REFACTOR — Mejora incremental de código
+Objetivo: refactorizar el código suministrado manteniendo el comportamiento.
+
+En "### REQUEST" recibirás:
+- "lenguaje" (str).
+- "principios" (array[str]) — reglas adicionales a priorizar.
+- "codigo" (str) — implementación actual.
+
+Instrucciones:
+1. Refactoriza aplicando SRP y DRY, además de los principios extra indicados.
+2. Extrae funciones o estructuras auxiliares cuando simplifiquen la lectura.
+3. Conserva la API pública (firmas exportadas, nombres públicos) sin cambios.
+4. No introduzcas dependencias nuevas.
+
+Formato de salida:
+- Devuelve únicamente el código refactorizado dentro de ```<lenguaje>```.
+
+Fallbacks específicos:
+- Si "codigo" está vacío o falta, responde "SIN DATOS"."""
+
+PROMPT_BUGFIX = """TAREA BUGFIX — Corrección mínima segura
+Objetivo: solucionar el bug descrito con el menor cambio posible.
+
+Datos en "### REQUEST":
+- "lenguaje" (str).
+- "lenguaje_pruebas" (str).
+- "descripcion_bug" (str) — síntoma o causa observada.
+- "codigo" (str) — estado actual.
+
+Instrucciones:
+1. Identifica la causa raíz y coméntala en una línea al inicio del archivo resultante.
+2. Aplica el fix más acotado que resuelva el problema sin regresiones.
+3. Añade una prueba unitaria que falle antes del fix y pase después.
+4. Mantén estilos y convenciones existentes.
+
+Formato de salida:
+- Primero el archivo corregido en ```<lenguaje>```.
+- Luego las pruebas en ```<lenguaje_pruebas>```.
+
+Fallbacks específicos:
+- Si no se provee "codigo", responde "SIN DATOS"."""
+
+PROMPT_UNIT_TESTS = """TAREA UNIT_TESTS — Generación de pruebas
+Objetivo: escribir pruebas unitarias exhaustivas para el código dado.
+
+Entrada "### REQUEST":
+- "lenguaje" (str) — lenguaje de las pruebas.
+- "framework" (str) — framework de testing.
+- "codigo" (str) — implementación a cubrir.
+- "cobertura" (array[str]) — lista de escenarios clave (felices, borde, error).
+
+Instrucciones:
+1. Usa los escenarios de "cobertura" como guía mínima; añade otros si aportan valor.
+2. Emplea nombres de test descriptivos y aislados.
+3. Configura los fixtures o mocks necesarios sin dependencias externas.
+4. Respeta el estilo idiomático del framework indicado.
+
+Formato de salida:
+- Devuelve solo el archivo de pruebas dentro de ```<lenguaje>```.
+
+Fallbacks específicos:
+- Si "framework" o "codigo" faltan, responde "SIN DATOS"."""
+
+PROMPT_DOCSTRINGS = """TAREA DOCSTRINGS — Documentar y tipar
+Objetivo: añadir docstrings y anotaciones de tipo sin alterar la lógica.
+
+Datos en "### REQUEST":
+- "lenguaje" (str).
+- "estilo_doc" (str) — formato de docstring (ej. Google, NumPy, JSDoc).
+- "codigo" (str) — fuente actual.
+
+Instrucciones:
+1. Aplica el estilo solicitado en todas las funciones o clases públicas.
+2. Añade anotaciones de tipo donde sean inferibles sin introducir dependencias nuevas.
+3. No modifiques la lógica ni el flujo de control existente.
+4. Mantén el orden original de definiciones.
+
+Formato de salida:
+- Entrega el código actualizado dentro de ```<lenguaje>```.
+
+Fallbacks específicos:
+- Si falta "codigo", responde "SIN DATOS"."""
+
+PROMPT_MIGRATION = """TAREA MIGRATION — Conversión entre lenguajes
+Objetivo: trasladar la implementación manteniendo el comportamiento.
+
+"### REQUEST" provee:
+- "origen" (str) — lenguaje de entrada.
+- "destino" (str) — lenguaje objetivo.
+- "codigo" (str) — código original.
+- "dependencias" (array[str]) — paquetes requeridos en el destino.
+
+Instrucciones:
+1. Reescribe el código de manera idiomática en el lenguaje destino.
+2. Añade al inicio comentarios con instrucciones de instalación de dependencias nuevas, si las hay.
+3. Conserva estructura y comportamiento; adapta APIs o librerías equivalentes.
+4. No mezcles fragmentos de ambos lenguajes en la salida.
+
+Formato de salida:
+- Devuelve solo el código final en ```<destino>```.
+
+Fallbacks específicos:
+- Si "codigo" está vacío, responde "SIN DATOS"."""
+
+PROMPT_API_ENDPOINT = """TAREA API_ENDPOINT — Implementación de endpoint
+Objetivo: crear un endpoint conforme al framework y esquema especificados.
+
+Entrada en "### REQUEST":
+- "framework" (str) — por ejemplo FastAPI, Express.
+- "lenguaje" (str).
+- "metodo" (str) — verbo HTTP.
+- "ruta" (str).
+- "request_schema" (str) — descripción o JSON Schema del body.
+- "response_schema" (str) — estructura esperada en 200.
+- "errores" (array[str]) — lista de errores que manejar.
+
+Instrucciones:
+1. Define el endpoint con validación del request body según el esquema.
+2. Implementa respuestas 200 y errores declarados con mensajes claros.
+3. Añade manejo de excepciones genéricas y específicas donde aplique.
+4. Evita dependencias innecesarias y configura el archivo listo para ejecución.
+
+Formato de salida:
+- Devuelve un único archivo listo para correr en ```<lenguaje>```.
+
+Fallbacks específicos:
+- Si falta "framework" o "ruta", responde "SIN DATOS"."""
+
+PROMPT_SQL_QUERY = """TAREA SQL_QUERY — Consulta a partir de esquema
+Objetivo: redactar una consulta SQL precisa según el objetivo recibido.
+
+En "### REQUEST" se incluye:
+- "esquema" (str) — definición de tablas o columnas.
+- "objetivo" (str).
+- "dialecto" (str) — motor objetivo.
+
+Instrucciones:
+1. Usa CTEs si facilitan la claridad o reutilización.
+2. Ajusta la sintaxis al dialecto indicado sin extensiones propietarias.
+3. Asegura que la consulta responda exactamente al objetivo planteado.
+4. No devuelvas explicaciones ni comentarios fuera del SQL.
+
+Formato de salida:
+- Entrega solo la consulta encerrada en ```sql```.
+
+Fallbacks específicos:
+- Si falta "esquema" u "objetivo", responde "SIN DATOS"."""
+
+PROMPT_CLI_TOOL = """TAREA CLI_TOOL — Herramienta de línea de comandos
+Objetivo: generar una CLI compacta que cumpla el objetivo indicado.
+
+Datos "### REQUEST":
+- "lenguaje" (str).
+- "objetivo" (str).
+- "flags" (array[str]) — banderas soportadas.
+
+Instrucciones:
+1. Implementa la CLI en un solo archivo.
+2. Procesa las banderas indicadas y produce salida JSON válida en stdout.
+3. Maneja errores de entrada con mensajes claros y códigos adecuados.
+4. Evita dependencias externas salvo que se especifique lo contrario.
+
+Formato de salida:
+- Devuelve únicamente el código dentro de ```<lenguaje>```.
+
+Fallbacks específicos:
+- Si "lenguaje" u "objetivo" faltan, responde "SIN DATOS"."""
+
+PROMPT_JSON_REPORT = """TAREA JSON_REPORT — Generación estricta de JSON
+Objetivo: producir un JSON estricto con el puntaje por ítem.
+
+Entrada "### REQUEST":
+- "items" (array[object]) — cada objeto describe una entrada a evaluar.
+
+Instrucciones:
+1. Para cada entrada genera "id" (número), "score" (0..1 con dos decimales) y "reason" (≤12 palabras).
+2. Usa números con dos decimales redondeados; valores fuera de rango deben ajustarse al límite más cercano.
+3. "reason" debe ser concisa y basada en los datos suministrados.
+4. No añadas texto fuera del JSON ni comentarios.
+
+Formato de salida:
+- Responde únicamente con un objeto JSON válido que siga la estructura solicitada.
+
+Fallbacks específicos:
+- Si "items" está vacío, responde {"items": []}."""
+
 _TASK_PROMPTS: Dict[str, str] = {
     "A": PROMPT_A,
     "B": PROMPT_B,
@@ -70,6 +281,16 @@ _TASK_PROMPTS: Dict[str, str] = {
     "E": PROMPT_E,
     "E_auto": PROMPT_E_AUTO,
     "DESIRE": PROMPT_DESIRE,
+    "TODO_TERRENO": PROMPT_TODO_TERRENO,
+    "REFACTOR": PROMPT_REFACTOR,
+    "BUGFIX": PROMPT_BUGFIX,
+    "UNIT_TESTS": PROMPT_UNIT_TESTS,
+    "DOCSTRINGS": PROMPT_DOCSTRINGS,
+    "MIGRATION": PROMPT_MIGRATION,
+    "API_ENDPOINT": PROMPT_API_ENDPOINT,
+    "SQL_QUERY": PROMPT_SQL_QUERY,
+    "CLI_TOOL": PROMPT_CLI_TOOL,
+    "JSON_REPORT": PROMPT_JSON_REPORT,
 }
 
 JSON_ONLY: Dict[str, bool] = {
@@ -80,6 +301,16 @@ JSON_ONLY: Dict[str, bool] = {
     "E": False,
     "E_auto": True,
     "DESIRE": True,
+    "TODO_TERRENO": False,
+    "REFACTOR": False,
+    "BUGFIX": False,
+    "UNIT_TESTS": False,
+    "DOCSTRINGS": False,
+    "MIGRATION": False,
+    "API_ENDPOINT": False,
+    "SQL_QUERY": False,
+    "CLI_TOOL": False,
+    "JSON_REPORT": True,
 }
 
 _TASK_B_METRICS = [
@@ -165,6 +396,38 @@ JSON_SCHEMAS: Dict[str, Dict[str, Any]] = {
                                 "type": "array",
                                 "items": {"type": "string"},
                                 "minItems": 0,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+    "JSON_REPORT": {
+        "name": "prompt_maestro_v3_task_json_report",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["items"],
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["id", "score", "reason"],
+                        "properties": {
+                            "id": {"type": "number"},
+                            "score": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1,
+                                "multipleOf": 0.01,
+                            },
+                            "reason": {
+                                "type": "string",
+                                "maxLength": 120,
                             },
                         },
                     },
@@ -285,13 +548,42 @@ def _normalize_task(task: str) -> str:
     token = task.strip()
     if not token:
         raise KeyError("task must not be empty")
-    normalized = token.replace("-", "_")
+    normalized = token.replace("-", "_").replace(" ", "_")
+    while "__" in normalized:
+        normalized = normalized.replace("__", "_")
     upper = normalized.upper()
-    if upper == "E_AUTO" or upper == "EAUTO":
-        return "E_auto"
-    if upper in {"A", "B", "C", "D", "E", "DESIRE"}:
-        return upper
-    raise KeyError(f"Unknown task: {task}")
+    task_map = {
+        "A": "A",
+        "B": "B",
+        "C": "C",
+        "D": "D",
+        "E": "E",
+        "DESIRE": "DESIRE",
+        "E_AUTO": "E_auto",
+        "EAUTO": "E_auto",
+        "TODO_TERRENO": "TODO_TERRENO",
+        "REFACTOR": "REFACTOR",
+        "BUGFIX": "BUGFIX",
+        "BUG_FIX": "BUGFIX",
+        "UNIT_TESTS": "UNIT_TESTS",
+        "UNITTESTS": "UNIT_TESTS",
+        "DOCSTRINGS": "DOCSTRINGS",
+        "DOCS": "DOCSTRINGS",
+        "MIGRATION": "MIGRATION",
+        "MIGRATE": "MIGRATION",
+        "API_ENDPOINT": "API_ENDPOINT",
+        "ENDPOINT": "API_ENDPOINT",
+        "SQL_QUERY": "SQL_QUERY",
+        "SQL": "SQL_QUERY",
+        "CLI_TOOL": "CLI_TOOL",
+        "CLI": "CLI_TOOL",
+        "JSON_REPORT": "JSON_REPORT",
+        "JSON": "JSON_REPORT",
+    }
+    canonical = task_map.get(upper)
+    if canonical is None:
+        raise KeyError(f"Unknown task: {task}")
+    return canonical
 
 
 def get_system_prompt(task: str) -> str:
@@ -332,6 +624,16 @@ __all__ = [
     "PROMPT_E",
     "PROMPT_E_AUTO",
     "PROMPT_DESIRE",
+    "PROMPT_TODO_TERRENO",
+    "PROMPT_REFACTOR",
+    "PROMPT_BUGFIX",
+    "PROMPT_UNIT_TESTS",
+    "PROMPT_DOCSTRINGS",
+    "PROMPT_MIGRATION",
+    "PROMPT_API_ENDPOINT",
+    "PROMPT_SQL_QUERY",
+    "PROMPT_CLI_TOOL",
+    "PROMPT_JSON_REPORT",
     "PROMPT_VERSION",
     "PROMPT_RELEASE_DATE",
     "JSON_ONLY",

--- a/product_research_app/tests/test_gpt_messages.py
+++ b/product_research_app/tests/test_gpt_messages.py
@@ -39,6 +39,29 @@ def test_build_messages_task_b():
     assert parsed == aggregates
 
 
+def test_build_messages_task_todo_terreno_request_section():
+    request = {
+        "lenguaje": "Python",
+        "objetivo": "sumar números",
+        "version": "3.11",
+        "entrada": "Dos enteros",
+    }
+    messages = gpt.build_messages("todo-terreno", context_json=request)
+    assert messages[0]["content"] == registry.PROMPT_MASTER_V3_SYSTEM
+    user_payload = messages[1]["content"]
+    assert user_payload.startswith(registry.PROMPT_TODO_TERRENO)
+    assert "### REQUEST" in user_payload
+    json_block = user_payload.split("### REQUEST\n", 1)[1]
+    parsed = json.loads(json_block)
+    assert parsed == request
+
+
+def test_normalize_task_aliases():
+    assert registry.normalize_task("api-endpoint") == "API_ENDPOINT"
+    assert registry.normalize_task("bug_fix") == "BUGFIX"
+    assert registry.normalize_task("json") == "JSON_REPORT"
+
+
 def test_prepare_params_with_schema_json_mode():
     schema = {"name": "demo", "schema": {"type": "object"}, "strict": True}
     payload = gpt.prepare_params(

--- a/product_research_app/tests/test_prompts_registry.py
+++ b/product_research_app/tests/test_prompts_registry.py
@@ -3,7 +3,28 @@ import pytest
 from product_research_app.prompts import registry
 
 
-@pytest.mark.parametrize("task", ["A", "B", "C", "D", "E", "E_auto"])
+@pytest.mark.parametrize(
+    "task",
+    [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "E_auto",
+        "DESIRE",
+        "todo-terreno",
+        "refactor",
+        "bug_fix",
+        "unit_tests",
+        "docstrings",
+        "migration",
+        "api-endpoint",
+        "sql_query",
+        "cli-tool",
+        "json_report",
+    ],
+)
 def test_prompts_available(task: str) -> None:
     system_prompt = registry.get_system_prompt(task)
     assert system_prompt == registry.PROMPT_MASTER_V3_SYSTEM
@@ -15,7 +36,22 @@ def test_prompts_available(task: str) -> None:
 def test_json_only_flags() -> None:
     assert registry.is_json_only("B") is True
     assert registry.is_json_only("E_auto") is True
-    for task in ["A", "C", "D", "E"]:
+    assert registry.is_json_only("JSON_REPORT") is True
+    for task in [
+        "A",
+        "C",
+        "D",
+        "E",
+        "TODO_TERRENO",
+        "REFACTOR",
+        "BUGFIX",
+        "UNIT_TESTS",
+        "DOCSTRINGS",
+        "MIGRATION",
+        "API_ENDPOINT",
+        "SQL_QUERY",
+        "CLI_TOOL",
+    ]:
         assert registry.is_json_only(task) is False
 
 
@@ -45,3 +81,17 @@ def test_json_schema_task_e_auto() -> None:
     assert {"aprobado", "revisar", "descartar"} == set(status_enum)
     signals = item_schema["properties"]["signals"]
     assert signals["type"] == "array"
+
+
+def test_json_schema_task_json_report() -> None:
+    schema = registry.get_json_schema("JSON_REPORT")
+    assert schema is not None
+    props = schema["schema"]["properties"]
+    assert props["items"]["type"] == "array"
+    item_schema = props["items"]["items"]
+    required = set(item_schema["required"])
+    assert required == {"id", "score", "reason"}
+    score = item_schema["properties"]["score"]
+    assert score["minimum"] == 0
+    assert score["maximum"] == 1
+    assert score["multipleOf"] == 0.01


### PR DESCRIPTION
## Summary
- add Prompt Maestro templates for new coding, refactor, bugfix, API, SQL and JSON workflows
- map new tasks to request payload handling and JSON schema validation for JSON report outputs
- extend unit tests covering registry metadata, aliases, and message assembly for request-driven tasks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfcd84bed083289b28f16412d09742