### PR TITLE
Fix AI column truncation handling and silence TLS handshake noise

### DIFF
--- a/README-changes.md
+++ b/README-changes.md
@@ -1,0 +1,23 @@
+# Cambios aplicados
+
+## Resumen del incidente
+- **Salida sin JSON / finish_reason=length**: las respuestas largas del modelo truncaban los batches grandes. Se añadió microbatcheo recursivo que detecta `finish_reason="length"`, divide el lote y vuelve a intentar hasta llegar a un solo producto antes de declarar fallo, registrando el error como `ko.json_truncated`.
+- **Errores `json_parse`**: ahora se vuelve a intentar con lotes más pequeños incluso tras un primer reintento para garantizar JSON válido, manteniendo las configuraciones de tokens.
+- **Ruido `Bad request version`**: el `QuietHandlerMixin` filtra las conexiones TLS mal dirigidas comprobando el primer byte del handshake y evita que aparezcan como errores HTTP 400 en los logs.
+
+## Configuración nueva/modificada
+- `TOKENS_POR_ITEM_ESTIMADOS` (`PRAPP_AI_COLUMNS_TOKENS_PER_ITEM`, default 96): estimación del presupuesto de tokens por producto. Ajusta esta constante si el modelo devuelve respuestas más largas o cortas; se usa con un margen del 15 % (`TOKEN_BUDGET_MARGIN`) para calcular el tamaño máximo inicial del batch.
+
+## Cómo ejecutar las pruebas
+```bash
+pip install -r requirements.txt
+pytest product_research_app/tests/test_ai_columns_microbatch.py product_research_app/tests/test_http_quiet.py -q
+pytest -q
+```
+
+## Runbook de verificación manual
+1. Arrancar la aplicación como de costumbre (`python -m product_research_app.app` o script equivalente).
+2. Lanzar un llenado de columnas de IA con varios productos (>40) y comprobar en los logs que:
+   - No aparecen mensajes `Salida sin JSON (finish_reason=length …)`; si los hay, deben ir seguidos de reintentos con lotes más pequeños.
+   - Las entradas de error para truncados se etiquetan como `ko.json_truncated` en la telemetría.
+3. Ejecutar un escaneo de puertos/sondeo TLS contra el puerto HTTP y verificar que no se registran entradas `code 400, message Bad request version …`.

--- a/product_research_app/tests/test_ai_columns_microbatch.py
+++ b/product_research_app/tests/test_ai_columns_microbatch.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from product_research_app.services import ai_columns
+
+
+def test_microbatch_splits_until_single_item(monkeypatch):
+    candidates: List[ai_columns.Candidate] = [
+        ai_columns.Candidate(
+            id=101,
+            sig_hash="a",
+            payload={"name": "Item 101"},
+            extra={"title": "Item 101"},
+        ),
+        ai_columns.Candidate(
+            id=102,
+            sig_hash="b",
+            payload={"name": "Item 102"},
+            extra={"title": "Item 102"},
+        ),
+    ]
+
+    batch = ai_columns._build_batch_request(
+        "001",
+        candidates,
+        trunc_title=120,
+        trunc_desc=240,
+    )
+
+    responses: List[Dict[str, Any]] = []
+
+    truncated_response = {
+        "choices": [
+            {
+                "message": {"content": ""},
+                "finish_reason": "length",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 800},
+    }
+    responses.append(truncated_response)
+
+    def _success_payload(pid: int) -> Dict[str, Any]:
+        item = {
+            "id": pid,
+            "desire": 0.8,
+            "desire_reason": "Alta demanda",
+            "competition": 0.2,
+            "competition_level": "Low",
+            "revenue": 120.0,
+            "units_sold": 10,
+            "price": 20.0,
+            "oldness": 0.1,
+            "rating": 4.5,
+        }
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {
+                                "type": "json",
+                                "json": {"items": [item]},
+                            }
+                        ]
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 200},
+        }
+
+    responses.append(_success_payload(101))
+    responses.append(_success_payload(102))
+
+    call_sizes: List[int] = []
+
+    async def fake_call_gpt_async(*, messages: List[Dict[str, Any]], **kwargs):
+        user_content = messages[-1]["content"]
+        idx = user_content.rfind("[")
+        payload_count = 0
+        if idx >= 0:
+            payload = json.loads(user_content[idx:])
+            if isinstance(payload, list):
+                payload_count = len(payload)
+        call_sizes.append(payload_count)
+        if not responses:
+            raise AssertionError("Se esperaban más respuestas simuladas")
+        return responses.pop(0)
+
+    async def fake_refine(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(ai_columns.gpt, "call_gpt_async", fake_call_gpt_async)
+    monkeypatch.setattr(ai_columns, "_refine_desire_statement", fake_refine)
+
+    async def run(batch_req: ai_columns.BatchRequest) -> Dict[str, Any]:
+        try:
+            return await ai_columns._call_batch_with_retries(
+                batch_req,
+                api_key="test",
+                model="gpt-test",
+                max_retries=0,
+            )
+        except ai_columns.BatchAdaptationRequired as exc:
+            assert exc.reason == "json_truncated"
+            assert len(batch_req.candidates) > 1
+            mid = max(1, len(batch_req.candidates) // 2)
+            first = ai_columns._build_batch_request(
+                f"{batch_req.req_id}a",
+                batch_req.candidates[:mid],
+                batch_req.trunc_title,
+                batch_req.trunc_desc,
+                depth=batch_req.depth + 1,
+                json_retry_count=batch_req.json_retry_count,
+                adapted=True,
+            )
+            second = ai_columns._build_batch_request(
+                f"{batch_req.req_id}b",
+                batch_req.candidates[mid:],
+                batch_req.trunc_title,
+                batch_req.trunc_desc,
+                depth=batch_req.depth + 1,
+                json_retry_count=batch_req.json_retry_count,
+                adapted=True,
+            )
+            results = []
+            for child in (first, second):
+                if child.candidates:
+                    results.append(await run(child))
+            aggregate: Dict[str, Any] = {"ok": {}, "ko": {}}
+            for entry in results:
+                aggregate["ok"].update(entry.get("ok", {}))
+                aggregate["ko"].update(entry.get("ko", {}))
+            return aggregate
+
+    result = asyncio.run(run(batch))
+
+    assert sorted(result["ok"].keys()) == ["101", "102"]
+    assert result["ko"] == {}
+    assert call_sizes == [2, 1, 1]
+

--- a/product_research_app/tests/test_http_quiet.py
+++ b/product_research_app/tests/test_http_quiet.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from server import http_quiet
+
+
+class DummyQuietHandler(http_quiet.QuietHandlerMixin):
+    def __init__(self) -> None:
+        self.server_version = "HTTP"
+        self.sys_version = ""
+        self.protocol_version = "HTTP/1.1"
+        self.requestline = ""
+        self.raw_requestline = b""
+        self.path = "/"
+        self._records: List[Tuple[str, Tuple]] = []
+
+    # BaseHTTPRequestHandler.log_error -> log_message
+    def log_message(self, fmt: str, *args) -> None:  # type: ignore[override]
+        self._records.append((fmt, args))
+
+
+def test_tls_client_hello_is_silenced():
+    handler = DummyQuietHandler()
+    handler.requestline = "\x16\x03\x01\x02"
+    handler.raw_requestline = b"\x16\x03\x01\x02"
+    handler.log_error("code %d, message %s", 400, "Bad request version ('\x16\x03')")
+    assert handler._records == []
+
+
+def test_regular_error_is_logged():
+    handler = DummyQuietHandler()
+    handler.requestline = "GET / HTTP/1.1"
+    handler.log_error("code %d, message %s", 404, "File not found")
+    assert handler._records == [("code %d, message %s", (404, "File not found"))]
+


### PR DESCRIPTION
## Summary
- ensure AI column batches split recursively on finish_reason=length, tag truncation as ko.json_truncated, and document the new token budget constant
- cap the initial batch size based on estimated tokens per item while keeping existing concurrency settings intact
- filter TLS ClientHello "Bad request version" noise and add regression tests for both microbatching and TLS log filtering

## Testing
- pytest product_research_app/tests/test_ai_columns_microbatch.py product_research_app/tests/test_http_quiet.py -q
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dfdb0a2ac88328b4fd8d31522e479b