### PR TITLE
Improve JSON handling and microbatch retries for AI fill

### DIFF
--- a/README-changes.md
+++ b/README-changes.md
@@ -1,23 +1,29 @@
 # Cambios aplicados
 
 ## Resumen del incidente
-- **Salida sin JSON / finish_reason=length**: las respuestas largas del modelo truncaban los batches grandes. Se añadió microbatcheo recursivo que detecta `finish_reason="length"`, divide el lote y vuelve a intentar hasta llegar a un solo producto antes de declarar fallo, registrando el error como `ko.json_truncated`.
-- **Errores `json_parse`**: ahora se vuelve a intentar con lotes más pequeños incluso tras un primer reintento para garantizar JSON válido, manteniendo las configuraciones de tokens.
-- **Ruido `Bad request version`**: el `QuietHandlerMixin` filtra las conexiones TLS mal dirigidas comprobando el primer byte del handshake y evita que aparezcan como errores HTTP 400 en los logs.
+- **`finish_reason=length` / `reason=json_truncated` en batches grandes**: el modelo cortaba las respuestas JSON cuando el presupuesto de tokens era insuficiente. Ahora `call_prompt_task_async` amplía automáticamente el `max_completion_tokens`, añade instrucciones de respuesta mínima y reintenta antes de fallar. En `ai_columns` se divide el lote según el presupuesto estimado de tokens, se escalona hasta 1 ítem y, si aun así se trunca, se registra un `ko.json_truncated` sin detener el resto del job.
+- **`InvalidJSONError: La respuesta JSON está vacía` al refinar Desire**: el parser sanitiza fences, detecta vacíos y fuerza un reintento con una orden estricta de “solo JSON válido”. Si el segundo intento no aporta datos, se devuelve un JSON mínimo con `low_confidence` para que el job continúe.
+- **Ruido de handshakes TLS en el servidor HTTP**: el `QuietHandlerMixin` identifica paquetes que comienzan por `0x16 0x03 0x01` (ClientHello) y suprime el log de error, dejándolo como `DEBUG` opcional.
 
 ## Configuración nueva/modificada
-- `TOKENS_POR_ITEM_ESTIMADOS` (`PRAPP_AI_COLUMNS_TOKENS_PER_ITEM`, default 96): estimación del presupuesto de tokens por producto. Ajusta esta constante si el modelo devuelve respuestas más largas o cortas; se usa con un margen del 15 % (`TOKEN_BUDGET_MARGIN`) para calcular el tamaño máximo inicial del batch.
+- `product_research_app/gpt.py`
+  - `TOKENS_POR_ITEM_ESTIMADOS` (`PRAPP_GPT_TOKENS_POR_ITEM_ESTIMADOS`, fallback a `PRAPP_AI_COLUMNS_TOKENS_PER_ITEM`, default 220): estimación de salida por ítem usada para calcular el tamaño máximo seguro de lote.
+  - `MIN_COMPLETION_TOKENS_JSON` (`PRAPP_GPT_MIN_COMPLETION_TOKENS_JSON`, default 700) y `MAX_COMPLETION_TOKENS_JSON` (`PRAPP_GPT_MAX_COMPLETION_TOKENS_JSON`, default 1200): límites inferiores/superiores del `max_completion_tokens` cuando se exige JSON estricto. Ajusta estos valores si el modelo necesita más o menos presupuesto de salida.
+- `product_research_app/services/ai_columns.py`
+  - Usa los límites anteriores para decidir cuántos ítems caben en un batch (`⌊MAX * 0.9 / TOKENS_POR_ITEM_ESTIMADOS⌋`). Si personalizas las constantes en `gpt.py`, esta lógica se adapta automáticamente.
 
 ## Cómo ejecutar las pruebas
 ```bash
 pip install -r requirements.txt
-pytest product_research_app/tests/test_ai_columns_microbatch.py product_research_app/tests/test_http_quiet.py -q
+pytest product_research_app/tests/test_ai_columns_microbatch.py \
+       product_research_app/tests/test_ai_columns_refine.py \
+       product_research_app/tests/test_http_quiet.py \
+       product_research_app/tests/test_gpt_messages.py -q
 pytest -q
 ```
 
 ## Runbook de verificación manual
-1. Arrancar la aplicación como de costumbre (`python -m product_research_app.app` o script equivalente).
-2. Lanzar un llenado de columnas de IA con varios productos (>40) y comprobar en los logs que:
-   - No aparecen mensajes `Salida sin JSON (finish_reason=length …)`; si los hay, deben ir seguidos de reintentos con lotes más pequeños.
-   - Las entradas de error para truncados se etiquetan como `ko.json_truncated` en la telemetría.
-3. Ejecutar un escaneo de puertos/sondeo TLS contra el puerto HTTP y verificar que no se registran entradas `code 400, message Bad request version …`.
+1. Arranca la app y lanza un “AI fill” con suficientes productos para generar batches grandes.
+2. Comprueba en los logs que, ante cualquier `finish_reason=length`/`json_truncated`, se observan reintentos con batches más pequeños y sin degradar el resto del trabajo.
+3. Fuerza un refine manual (p. ej. con un borrador vacío) y confirma que, tras dos respuestas vacías, se guarda un JSON mínimo con `low_confidence`.
+4. Envía un ClientHello TLS al puerto HTTP (por ejemplo con `openssl s_client -connect localhost:PUERTO`) y verifica que no aparecen entradas `code 400` en los logs del servidor (solo un mensaje `DEBUG` opcional).

--- a/product_research_app/tests/test_ai_columns_refine.py
+++ b/product_research_app/tests/test_ai_columns_refine.py
@@ -1,0 +1,32 @@
+import asyncio
+
+from product_research_app import gpt
+from product_research_app.services import ai_columns
+
+
+def test_refine_desire_fallback_low_confidence(monkeypatch):
+    candidate = ai_columns.Candidate(
+        id=701,
+        sig_hash="hash701",
+        payload={"name": "Producto"},
+        extra={"title": "Producto"},
+    )
+
+    calls = []
+
+    async def fake_call_prompt(*args, **kwargs):
+        calls.append(kwargs.get("extra_user"))
+        if len(calls) == 1:
+            exc = gpt.InvalidJSONError("vacío")
+            setattr(exc, "sanitized_text", "")
+            raise exc
+        return {"content": {}}
+
+    monkeypatch.setattr(ai_columns.gpt, "call_prompt_task_async", fake_call_prompt)
+
+    result = asyncio.run(ai_columns._refine_desire_statement(candidate, ""))
+
+    assert result["low_confidence"] is True
+    assert result["desire_statement"] == ""
+    assert len(calls) == 2
+    assert "Responde exclusivamente" in (calls[1] or "")

--- a/product_research_app/tests/test_gpt_messages.py
+++ b/product_research_app/tests/test_gpt_messages.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from product_research_app import gpt
 from product_research_app.prompts import registry
 
@@ -77,3 +79,15 @@ def test_prepare_params_with_schema_json_mode():
         == "object"
     )
     assert "temperature" not in payload
+
+
+def test_parse_json_content_from_fence():
+    text = "```json\n{\"foo\": 1}\n```"
+    parsed = gpt._parse_json_content(text)
+    assert parsed == {"foo": 1}
+
+
+def test_parse_json_content_empty_sets_attribute():
+    with pytest.raises(gpt.InvalidJSONError) as excinfo:
+        gpt._parse_json_content("")
+    assert getattr(excinfo.value, "sanitized_text", None) == ""

--- a/product_research_app/tests/test_http_quiet.py
+++ b/product_research_app/tests/test_http_quiet.py
@@ -35,6 +35,13 @@ def test_tls_client_hello_is_silenced():
     assert handler._records == []
 
 
+def test_tls_client_hello_without_bad_request_is_silenced():
+    handler = DummyQuietHandler()
+    handler.raw_requestline = b"\x16\x03\x01\x00"
+    handler.log_error("code %d", 400)
+    assert handler._records == []
+
+
 def test_regular_error_is_logged():
     handler = DummyQuietHandler()
     handler.requestline = "GET / HTTP/1.1"


### PR DESCRIPTION
## Summary
- add JSON sanitisation, retry hints, and configurable token limits to the GPT client
- tighten ai_columns micro-batching, retry length truncations with higher token budgets, and add a low-confidence refine fallback
- suppress TLS ClientHello noise in the HTTP server and extend unit coverage for the new flows

## Testing
- `pytest product_research_app/tests/test_ai_columns_microbatch.py product_research_app/tests/test_ai_columns_refine.py product_research_app/tests/test_http_quiet.py product_research_app/tests/test_gpt_messages.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68dfe168a46483288a5381276a7a0d19