### PR TITLE
Handle parsed responses from OpenAI

### DIFF
--- a/product_research_app/gpt.py
+++ b/product_research_app/gpt.py
@@ -169,6 +169,8 @@ def _parse_message_content(raw: Dict[str, Any]) -> Tuple[Optional[Any], str]:
     message = choices[0].get("message", {}) or {}
     content = message.get("content", "")
     parsed_json: Optional[Any] = None
+    if "parsed" in message:
+        parsed_json = message.get("parsed")
     text_parts: List[str] = []
     if isinstance(content, str):
         text_parts.append(content)
@@ -187,6 +189,11 @@ def _parse_message_content(raw: Dict[str, Any]) -> Tuple[Optional[Any], str]:
             parsed_json = content.get("json")
         if "text" in content:
             text_parts.append(str(content.get("text", "")))
+    if parsed_json is None and "json" in message:
+        parsed_json = message.get("json")
+    refusal = message.get("refusal")
+    if refusal:
+        text_parts.append(str(refusal))
     text = "\n".join(part for part in text_parts if part).strip()
     return parsed_json, text
 


### PR DESCRIPTION
## Summary
- capture the `parsed` and `json` fields returned by the OpenAI API when present
- fall back to refusal text so downstream JSON parsing does not see an empty payload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f87b36b08328a47cf054fd83372b