### PR TITLE
Improve AI column parsing with JSON response format

### DIFF
--- a/product_research_app/services/ai_client.py
+++ b/product_research_app/services/ai_client.py
@@ -1,0 +1,113 @@
+"""Wrapper del cliente OpenAI para respuestas JSON estrictas.
+
+Variables de entorno soportadas:
+- ``PRAPP_OPENAI_MAX_TOKENS`` (por defecto 2048)
+- ``PRAPP_OPENAI_TEMPERATURE`` (por defecto 0.2)
+- ``PRAPP_OPENAI_TOP_P`` (por defecto 1.0)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from openai import OpenAI
+
+from product_research_app.utils.json_extract import coerce_json, message_parts_to_text
+
+_client = OpenAI()
+_RAW_DIR = Path("./logs/ai_raw")
+_RAW_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _dump_raw(prefix: str, payload: Dict[str, Any], resp: Dict[str, Any]) -> str:
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    path = _RAW_DIR / f"{prefix}_{timestamp}.json"
+    try:
+        with path.open("w", encoding="utf-8") as handler:
+            json.dump({"request": payload, "response": resp}, handler, ensure_ascii=False, indent=2)
+    except Exception:
+        return ""
+    return str(path)
+
+
+def chat_json(
+    *,
+    model: str,
+    messages: List[Dict[str, Any]],
+    json_schema: Optional[Dict[str, Any]] = None,
+    max_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
+    top_p: Optional[float] = None,
+    seed: Optional[int] = 7,
+    req_id: Optional[str] = None,
+    timeout: float = 90.0,
+) -> Tuple[Any, Dict[str, Any]]:
+    """Llama a Chat Completions asegurando salida JSON y devolviendo el payload parseado y el raw."""
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": float(os.getenv("PRAPP_OPENAI_TEMPERATURE", temperature if temperature is not None else 0.2)),
+        "top_p": float(os.getenv("PRAPP_OPENAI_TOP_P", top_p if top_p is not None else 1.0)),
+    }
+
+    if seed is not None:
+        payload["seed"] = seed
+
+    if max_tokens is None:
+        max_tokens = int(os.getenv("PRAPP_OPENAI_MAX_TOKENS", 2048))
+    payload["max_tokens"] = max_tokens
+
+    if json_schema:
+        payload["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": json_schema.get("name", "ai_columns_payload"),
+                "schema": json_schema.get("schema", {"type": "object"}),
+                "strict": True,
+            },
+        }
+    else:
+        payload["response_format"] = {"type": "json_object"}
+
+    retries = [0.0, 0.5, 1.0, 2.0, 4.0]
+    last_error: Optional[Exception] = None
+    for delay in retries:
+        if delay:
+            time.sleep(delay)
+        try:
+            response = _client.chat.completions.create(**payload, timeout=timeout)
+            response_dict = json.loads(response.model_dump_json())
+            _dump_raw(f"chat_{req_id or 'noid'}", payload, response_dict)
+
+            choice = (response_dict.get("choices") or [{}])[0]
+            message = choice.get("message", {}) or {}
+
+            content_text = message_parts_to_text(message.get("content"))
+            if content_text:
+                return coerce_json(content_text), response_dict
+
+            for tool_call in message.get("tool_calls") or []:
+                fn = tool_call.get("function") or {}
+                arguments = fn.get("arguments")
+                if arguments:
+                    return coerce_json(arguments), response_dict
+
+            function_call = message.get("function_call") or {}
+            arguments = function_call.get("arguments")
+            if arguments:
+                return coerce_json(arguments), response_dict
+
+            raise ValueError("empty_or_nonjson")
+        except Exception as exc:  # pragma: no cover - rutas de error difíciles de forzar
+            last_error = exc
+            continue
+    raise last_error or ValueError("empty_or_nonjson")
+
+
+__all__ = ["chat_json"]
+

--- a/product_research_app/utils/json_extract.py
+++ b/product_research_app/utils/json_extract.py
@@ -1,0 +1,123 @@
+"""Utilidades para extraer y parsear contenido JSON de respuestas de IA."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Optional
+
+FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def _stack_find_json(s: str) -> Optional[str]:
+    """Busca el primer objeto o array JSON balanceado dentro de ``s``."""
+
+    if not s:
+        return None
+
+    start_idxs = [idx for idx, char in enumerate(s) if char in ("{", "[")]
+
+    for start in start_idxs:
+        stack: list[str] = []
+        in_string = False
+        escaped = False
+        for idx in range(start, len(s)):
+            char = s[idx]
+            if in_string:
+                if escaped:
+                    escaped = False
+                    continue
+                if char == "\\":
+                    escaped = True
+                    continue
+                if char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+                continue
+            if char in ("{", "["):
+                stack.append(char)
+            elif char in "]}":
+                if not stack:
+                    break
+                top = stack.pop()
+                if (top == "{" and char != "}") or (top == "[" and char != "]"):
+                    break
+                if not stack:
+                    candidate = s[start : idx + 1].strip()
+                    try:
+                        json.loads(candidate)
+                    except Exception:
+                        break
+                    return candidate
+    return None
+
+
+def message_parts_to_text(content: Any) -> str:
+    """Convierte los posibles formatos de ``content`` en texto plano."""
+
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if text:
+                    parts.append(str(text))
+        return "\n".join(parts)
+    return str(content)
+
+
+def extract_first_json_blob(text: str) -> Optional[str]:
+    """Intenta localizar el primer fragmento JSON válido dentro de ``text``."""
+
+    if not text:
+        return None
+
+    text = text.strip()
+    if text and text[0] in "{[":
+        try:
+            json.loads(text)
+        except Exception:
+            pass
+        else:
+            return text
+
+    match = FENCE_RE.search(text)
+    if match:
+        fenced = match.group(1).strip()
+        try:
+            json.loads(fenced)
+        except Exception:
+            pass
+        else:
+            return fenced
+
+    return _stack_find_json(text)
+
+
+def coerce_json(value: Any) -> Any:
+    """Convierte ``value`` a JSON si es necesario."""
+
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        blob = extract_first_json_blob(value)
+        if blob is None:
+            raise ValueError("empty_or_nonjson")
+        return json.loads(blob)
+    raise ValueError("unsupported_content_type")
+
+
+__all__ = [
+    "coerce_json",
+    "extract_first_json_blob",
+    "message_parts_to_text",
+]
+


### PR DESCRIPTION
## Summary
- add reusable JSON extraction helpers and an OpenAI chat_json wrapper that enforces response_format logging raw payloads
- harden GPT message parsing to support modern response shapes and default json_object enforcement
- update AI column generation to call the new wrapper, reclassifying empty responses as ko.empty_or_nonjson and improving retries

## Testing
- python -m compileall product_research_app/utils/json_extract.py product_research_app/services/ai_client.py product_research_app/gpt.py product_research_app/services/ai_columns.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ffa00120832895b822d83a6c0c50