### PR TITLE
Improve OpenAI API key handling

### DIFF
--- a/product_research_app/.secrets/.gitignore
+++ b/product_research_app/.secrets/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- load the OpenAI API key from environment variables, optional secrets module, or persisted file
- persist API keys submitted via /api/auth/set-key to both the running environment and product_research_app/.secrets/openai.key
- ignore persisted secret files via repository-level .gitignore in the secrets directory

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10c00f99c83288342f6c9e688713b