### PR TITLE
Add browser auto-open and health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,16 @@ PRAPP_AI_COLUMNS_MAX_TOKENS_PER_ITEM=256
 Adjust these numbers based on the access tier in your OpenAI account.
 
 Make sure the cost estimator is aligned with the active reasoning model. In `product_research_app/config.json`, set `aiCost.model` to `gpt-5-mini` (or update the persisted configuration through the UI) so that projected spend reflects the GPT-5 Mini rates.
+
+## Auto-open y variables de entorno
+
+El arranque por `python -m product_research_app` respeta varias variables útiles para entornos locales:
+
+| Variable | Default | Descripción |
+| --- | --- | --- |
+| `PRAPP_HOST` | `127.0.0.1` | Host donde se enlaza el servidor Flask. |
+| `PRAPP_PORT` | `8000` | Puerto TCP expuesto por la aplicación. |
+| `PRAPP_AUTO_OPEN` | `1` | Controla la apertura automática del navegador (usa `0`, `false` o `no` para desactivarlo). |
+| `PRAPP_BROWSER_URL` | `http://{host}:{port}/` | URL que se abrirá cuando el puerto esté listo. |
+
+Además de `/healthz`, el backend expone `/health` para comprobaciones rápidas de estado (`200` + `{"status": "ok"}`).

--- a/product_research_app/__main__.py
+++ b/product_research_app/__main__.py
@@ -1,7 +1,41 @@
+import logging
+import os
+
 from product_research_app.services.config import init_app_config
 from product_research_app.api import app
+from product_research_app.utils.auto_open import open_browser_when_ready
 
-init_app_config()
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    init_app_config()
+
+    host = os.getenv("PRAPP_HOST", "127.0.0.1")
+    port_value = os.getenv("PRAPP_PORT", "8000")
+    try:
+        port = int(port_value)
+    except (TypeError, ValueError):
+        port = 8000
+    browser_url = os.getenv("PRAPP_BROWSER_URL", f"http://{host}:{port}/")
+
+    open_browser_when_ready(browser_url, host=host, port=port, timeout_s=90)
+
+    message = f"Servidor iniciado en {browser_url.rstrip('/')}"
+
+    try:
+        logger.info(message)
+        print(message)
+        app.run(host=host, port=port, debug=False, threaded=True, use_reloader=False)
+    except Exception:
+        logger.exception("Fallo fatal al iniciar el servidor")
+        try:
+            if os.name == "nt":
+                input("\n[CRASH] Revisa logs y pulsa Enter para cerrar...")
+        except Exception:
+            pass
+        raise
+
 
 if __name__ == "__main__":
-    app.run(host="127.0.0.1", port=8000, debug=False, threaded=True, use_reloader=False)
+    main()

--- a/product_research_app/api/__init__.py
+++ b/product_research_app/api/__init__.py
@@ -18,6 +18,32 @@ def healthz():
     return {"ok": True}
 
 
+# Garantizar endpoint /health si no existe previamente
+try:
+    has_health = False
+    try:
+        for r in getattr(app, "routes", []):
+            if getattr(r, "path", None) == "/health":
+                has_health = True
+                break
+    except Exception:
+        pass
+
+    try:
+        if not has_health and hasattr(app, "view_functions"):
+            if "health._health" in app.view_functions or "health" in app.view_functions:
+                has_health = True
+    except Exception:
+        pass
+
+    if not has_health:
+        from product_research_app.utils.health import mount_health
+
+        mount_health(app)
+except Exception:
+    pass
+
+
 # Log registered routes for easier debugging in start-up logs.
 for r in app.url_map.iter_rules():
     app.logger.info("ROUTE %s %s", ",".join(sorted(r.methods)), r.rule)

--- a/product_research_app/utils/auto_open.py
+++ b/product_research_app/utils/auto_open.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+import atexit
+import os
+import socket
+import tempfile
+import threading
+import time
+import webbrowser
+
+
+def _can_connect(host: str, port: int, timeout: float = 0.5) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _is_truthy(val: str | None) -> bool:
+    return str(val).strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+def open_browser_when_ready(url: str, host: str = "127.0.0.1", port: int = 8000,
+                            timeout_s: int = 60, check_interval_s: float = 0.5,
+                            lock_name: str = "prapp_auto_open.lock") -> None:
+    """
+    Lanza un hilo que abre el navegador cuando (host,port) acepta conexiones.
+    Evita aperturas duplicadas usando un lock-file en temp y detecta recargadores comunes.
+    Respeta PRAPP_AUTO_OPEN (truthy por defecto).
+    """
+    if not _is_truthy(os.getenv("PRAPP_AUTO_OPEN", "1")):
+        return
+
+    # Evitar ejecuciones duplicadas por recargadores (heurísticas más comunes)
+    if os.getenv("WERKZEUG_RUN_MAIN") == "true":
+        return
+    if os.getenv("RUN_MAIN") == "true":
+        return
+
+    # Lock para "abrir solo una vez" por sesión
+    lock_path = os.path.join(tempfile.gettempdir(), lock_name)
+    try:
+        # Crear exclusión atómica
+        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        with os.fdopen(fd, "w") as f:
+            f.write(str(os.getpid()))
+    except FileExistsError:
+        return  # ya abierto/abriéndose en otro proceso
+
+    def _cleanup():
+        try:
+            os.remove(lock_path)
+        except FileNotFoundError:
+            pass
+    atexit.register(_cleanup)
+
+    def _worker():
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            if _can_connect(host, port, timeout=0.5):
+                try:
+                    webbrowser.open(url, new=1, autoraise=True)
+                finally:
+                    return
+            time.sleep(check_interval_s)
+        # Timeout → liberar lock para futuros intentos
+        _cleanup()
+
+    t = threading.Thread(target=_worker, name="AutoOpenBrowser", daemon=True)
+    t.start()

--- a/product_research_app/utils/health.py
+++ b/product_research_app/utils/health.py
@@ -1,0 +1,33 @@
+def mount_health(app):
+    """
+    Incluye /health en FastAPI o Flask. Devuelve True si se montó.
+    """
+    try:
+        # FastAPI
+        from fastapi import APIRouter
+        router = APIRouter()
+
+        @router.get("/health")
+        def _health():
+            return {"status": "ok"}
+
+        app.include_router(router)
+        return True
+    except Exception:
+        pass
+
+    try:
+        # Flask
+        from flask import Blueprint, jsonify
+        bp = Blueprint("health", __name__)
+
+        @bp.route("/health")
+        def _health():
+            return jsonify(status="ok")
+
+        app.register_blueprint(bp)
+        return True
+    except Exception:
+        pass
+
+    return False

--- a/run_app.bat
+++ b/run_app.bat
@@ -15,7 +15,10 @@ echo %DATE% %TIME% — Bootstrap run_app.bat >> "logs\session.log"
 :: ---------- Config ----------
 set "PY_EXPECTED_MIN=3.11"
 set "PY_SETUP_VER=3.12.6"
-set "APP_DEFAULT_PORT=8000"
+if not defined PRAPP_HOST set "PRAPP_HOST=127.0.0.1"
+if not defined PRAPP_PORT set "PRAPP_PORT=8000"
+if not defined PRAPP_AUTO_OPEN set "PRAPP_AUTO_OPEN=1"
+if not defined PRAPP_BROWSER_URL set "PRAPP_BROWSER_URL=http://%PRAPP_HOST%:%PRAPP_PORT%/"
 
 :: Detectar arquitectura
 set "ARCH=amd64"
@@ -195,14 +198,10 @@ if not exist "%ROOT%%PKG%\__init__.py" (
 )
 :pkg_ok
 
-:: ---------- Abrir navegador cuando esté listo (CMD + curl, sin PowerShell) ----------
-start "" cmd /c ^
-  "for /l %%i in (1,1,60) do (curl -I -s http://127.0.0.1:%APP_DEFAULT_PORT% >nul 2>&1 && start "" http://127.0.0.1:%APP_DEFAULT_PORT% & exit) & timeout /t 1 >nul"
-
 :: ---------- Lanzar servidor DIRECTO desde CMD (sin tuberías, sin relanzar) ----------
-echo [INFO] Lanzando: -m %PKG%.web_app  >> "logs\session.log"
+echo [INFO] Lanzando: -m %PKG%  >> "logs\session.log"
 echo Iniciando servidor de Ecom Testing App...
-"%PYEXE%" -m %PKG%.web_app
+"%PYEXE%" -m %PKG%
 set "RC=%ERRORLEVEL%"
 
 echo [INFO] Proceso terminado con código %RC% >> "logs\session.log"


### PR DESCRIPTION
## Summary
- add utilities to expose a shared /health endpoint and to open the browser when the server is ready
- wire the startup flow to read PRAPP_* environment variables, handle crashes, and avoid duplicate browser launches
- update Windows launch script and documentation with the new configuration knobs

## Testing
- PRAPP_AUTO_OPEN=0 python -m product_research_app
- curl -s -i http://127.0.0.1:8000/health

------
https://chatgpt.com/codex/tasks/task_e_68e27f0d8b1c832897a7ee0db0988b45